### PR TITLE
fix(infra): Key Vault purge protection + OIDC federation setup

### DIFF
--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -35,7 +35,8 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
     }
     enableRbacAuthorization: true
     enableSoftDelete: true
-    enablePurgeProtection: enablePurgeProtection
+    // enablePurgeProtection cannot be set to false — omit when disabled
+    enablePurgeProtection: enablePurgeProtection ? true : null
     softDeleteRetentionInDays: softDeleteRetentionInDays
     networkAcls: {
       defaultAction: 'Allow' // Tighten in production


### PR DESCRIPTION
## Changes

- **Key Vault fix**: Azure rejects \nablePurgeProtection: false\ — property must be \	rue\ or omitted. Now uses conditional null (\nablePurgeProtection ? true : null\) to omit when disabled.

## OIDC Federation (out-of-band)

The following Azure/GitHub configuration was set up to enable CI/CD deployment:

- Created Azure AD App Registration: \github-actions-kmlsat\ (App ID: \16c3590e-87ca-451d-8404-83bd1566d946\)
- Added federated credentials for \nvironment:dev\ and \ef:refs/heads/main\
- Granted \Contributor\ + \User Access Administrator\ at subscription scope
- Configured GitHub \dev\ environment with \AZURE_CLIENT_ID\, \AZURE_TENANT_ID\, \AZURE_SUBSCRIPTION_ID\ secrets and \AZURE_LOCATION\ variable

## Testing

- 54 infrastructure tests passing
- All 16 pre-commit hooks passing
- Bicep lint clean