### PR TITLE
fix(infra): make Event Grid subscription conditional

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -48,6 +48,9 @@ param functionAppInstanceMemoryMB int = 2048
 @description('Enable Key Vault purge protection. Disable only for dev/test teardown.')
 param enableKeyVaultPurgeProtection bool = true
 
+@description('Enable Event Grid subscription. Requires function code to be deployed first.')
+param enableEventGridSubscription bool = false
+
 @description('Tags to apply to all resources.')
 param tags object = {}
 
@@ -86,6 +89,7 @@ module resources 'resources.bicep' = {
     functionAppMaxInstances: functionAppMaxInstances
     functionAppInstanceMemoryMB: functionAppInstanceMemoryMB
     enableKeyVaultPurgeProtection: enableKeyVaultPurgeProtection
+    enableEventGridSubscription: enableEventGridSubscription
     tags: defaultTags
   }
 }

--- a/infra/modules/event-grid.bicep
+++ b/infra/modules/event-grid.bicep
@@ -15,6 +15,9 @@ param storageAccountId string
 @description('Resource ID of the target Function App.')
 param functionAppId string
 
+@description('Enable the event subscription (requires function code to be deployed first).')
+param enableSubscription bool = false
+
 @description('Tags to apply to all resources.')
 param tags object = {}
 
@@ -35,7 +38,7 @@ resource systemTopic 'Microsoft.EventGrid/systemTopics@2024-06-01-preview' = {
 // Event Subscription — filters for .kml files in kml-input container
 // Delivers to the Function App's Event Grid trigger endpoint.
 // ---------------------------------------------------------------------------
-resource eventSubscription 'Microsoft.EventGrid/systemTopics/eventSubscriptions@2024-06-01-preview' = {
+resource eventSubscription 'Microsoft.EventGrid/systemTopics/eventSubscriptions@2024-06-01-preview' = if (enableSubscription) {
   parent: systemTopic
   name: 'evgs-kml-upload'
   properties: {

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -37,6 +37,9 @@ param functionAppInstanceMemoryMB int
 @description('Enable Key Vault purge protection.')
 param enableKeyVaultPurgeProtection bool
 
+@description('Enable Event Grid subscription (requires function code deployed).')
+param enableEventGridSubscription bool = false
+
 @description('Tags to apply to all resources.')
 param tags object
 
@@ -97,6 +100,7 @@ module eventGrid 'modules/event-grid.bicep' = {
     baseName: baseName
     storageAccountId: storage.outputs.id
     functionAppId: functionApp.outputs.id
+    enableSubscription: enableEventGridSubscription
     tags: tags
   }
 }


### PR DESCRIPTION
## Problem

Event Grid subscription requires the target function (\kml_blob_trigger\) to exist before the subscription can be created. Initial infrastructure deployment fails because no function code has been deployed yet.

## Solution

- Added \nableEventGridSubscription\ parameter (defaults to \alse\) to event-grid module, resources.bicep, and main.bicep
- System topic is always created (harmless — just watches storage account)
- Event subscription is gated behind the flag, only created when a deployed function exists
- Once function code is deployed, flip \nableEventGridSubscription: true\ in the bicepparam files

## Testing

- 54 infrastructure tests passing (conditional resource still present in ARM with \condition\ property)
- All 16 pre-commit hooks passing
- Bicep build + lint clean