### PR TITLE
fix(deploy): remove invalid --build-remote flag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,8 +66,7 @@ jobs:
             --name ${{ env.FUNCTION_APP_NAME }} \
             --resource-group ${{ env.RESOURCE_GROUP }} \
             --src-path deploy.zip \
-            --type zip \
-            --build-remote true
+            --type zip
 
       - name: Enable Event Grid subscription
         run: |


### PR DESCRIPTION
Fixes the deploy workflow failure — `--build-remote` is not a valid flag for `az functionapp deploy`. Flex Consumption handles remote build automatically with zip deploy.