### PR TITLE
fix(deploy): use azure/functions-action for Flex Consumption

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,12 +61,10 @@ jobs:
           zip -r ../deploy.zip .
 
       - name: Deploy to Azure Functions
-        run: |
-          az functionapp deploy \
-            --name ${{ env.FUNCTION_APP_NAME }} \
-            --resource-group ${{ env.RESOURCE_GROUP }} \
-            --src-path deploy.zip \
-            --type zip
+        uses: azure/functions-action@v2
+        with:
+          app-name: ${{ env.FUNCTION_APP_NAME }}
+          package: deploy.zip
 
       - name: Enable Event Grid subscription
         run: |


### PR DESCRIPTION
Fixes deployment failure (HTTP 415) — Flex Consumption plan uses blob-based deployment, not Kudu/SCM. `az functionapp deploy` doesn't work with Flex Consumption. Switched to `azure/functions-action@v2` which auto-detects the plan type and uses the correct deployment method.