### PR TITLE
fix(deploy): use azure/functions-action@v1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
           zip -r ../deploy.zip .
 
       - name: Deploy to Azure Functions
-        uses: azure/functions-action@v2
+        uses: azure/functions-action@v1
         with:
           app-name: ${{ env.FUNCTION_APP_NAME }}
           package: deploy.zip


### PR DESCRIPTION
v2 of `azure/functions-action` doesn't exist. Pinning to `v1` which is the latest available version.