### PR TITLE
fix(infra): add deployments blob container for Flex Consumption

### DIFF
--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -59,6 +59,14 @@ resource kmlOutputContainer 'Microsoft.Storage/storageAccounts/blobServices/cont
   }
 }
 
+resource deploymentsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobServices
+  name: 'deployments'
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
 // Lifecycle management — archive old imagery, delete old logs
 resource lifecyclePolicy 'Microsoft.Storage/storageAccounts/managementPolicies@2023-05-01' = {
   parent: storageAccount


### PR DESCRIPTION
Flex Consumption function apps store deployment packages in a blob container called `deployments`. The `function-app.bicep` module references it in the deployment config, but the `storage.bicep` module never created it — causing deployment to fail with "The specified container does not exist".\n\nAdds the `deployments` container to the storage module.\n\nNote: This PR touches `infra/`, so the infra workflow will also run (validate + deploy on merge).