### PR TITLE
fix: remove reserved Flex Consumption app settings from Bicep

### DIFF
--- a/infra/modules/function-app.bicep
+++ b/infra/modules/function-app.bicep
@@ -102,14 +102,6 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
           value: keyVaultUri
         }
         {
-          name: 'FUNCTIONS_WORKER_RUNTIME'
-          value: 'python'
-        }
-        {
-          name: 'FUNCTIONS_EXTENSION_VERSION'
-          value: '~4'
-        }
-        {
           name: 'KML_INPUT_CONTAINER'
           value: 'kml-input'
         }


### PR DESCRIPTION
## Problem

Two workflow failures on `main` after merging PRs #32 and #33:

### 1. Infrastructure workflow — `FUNCTIONS_WORKER_RUNTIME` rejected
```
BadRequest: The following app setting (Site.SiteConfig.AppSettings.FUNCTIONS_WORKER_RUNTIME)
for Flex Consumption sites is invalid. Please remove or rename it before retrying.
```

### 2. Deploy workflow — 0 functions detected after 5 minutes
The function app is left in a broken state by the infra failure, so deployed code never becomes discoverable.

## Root Cause

The Bicep template (`infra/modules/function-app.bicep`) declares runtime configuration **twice**:
- ✅ `functionAppConfig.runtime` — the correct Flex Consumption mechanism
- ❌ `FUNCTIONS_WORKER_RUNTIME` and `FUNCTIONS_EXTENSION_VERSION` in `siteConfig.appSettings` — reserved by Azure for Flex Consumption and rejected at deploy time

## Fix

- **Remove** `FUNCTIONS_WORKER_RUNTIME` and `FUNCTIONS_EXTENSION_VERSION` from `appSettings` (the `functionAppConfig.runtime` block already handles this correctly)
- **Add** `test_flex_consumption_runtime_config` — verifies runtime is declared via `functionAppConfig`
- **Add** `test_no_reserved_app_settings` — regression test ensuring reserved settings never creep back into `appSettings`
- **Update** `test_has_required_app_settings` — removes the two reserved settings from expected set

## Validation

- 152 tests pass (including 2 new regression tests)
- 16 pre-commit hooks pass
- Bicep lint passes