### PR TITLE
feat(m1.6): Metadata JSON generation with Pydantic schema and deterministic blob paths

### DIFF
--- a/kml_satellite/activities/write_metadata.py
+++ b/kml_satellite/activities/write_metadata.py
@@ -1,0 +1,158 @@
+"""Write metadata activity — generate and store per-AOI metadata JSON.
+
+This activity takes a processed AOI and an orchestration context, builds
+a metadata JSON document conforming to PID Section 9.2, writes it to
+Blob Storage at the deterministic path, and optionally archives the
+original KML file.
+
+Engineering standards:
+- PID 7.4.4 Idempotent: same input produces same output path (overwrites)
+- PID 7.4.5 Explicit: typed models, named constants, explicit units
+- PID 7.4.6 Observability: structured logging at activity boundaries (FR-2.3)
+- PID 7.4.8 Hamilton Standard: defensive validation, no silent failures
+
+References:
+- PID FR-4.4 (metadata stored under /metadata/ prefix)
+- PID FR-4.6 (metadata JSON per AOI)
+- PID FR-4.7 (storage hierarchy by date/orchard)
+- PID Section 9.2 (Metadata JSON Schema)
+- PID Section 10.1 (Container & Path Layout)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from kml_satellite.models.metadata import AOIMetadataRecord
+from kml_satellite.utils.blob_paths import build_metadata_path
+
+if TYPE_CHECKING:
+    from kml_satellite.models.aoi import AOI
+
+logger = logging.getLogger("kml_satellite.activities.write_metadata")
+
+# Output container name (PID Section 10.1)
+OUTPUT_CONTAINER = "kml-output"
+
+
+class MetadataWriteError(Exception):
+    """Raised when metadata writing fails."""
+
+
+def write_metadata(
+    aoi: AOI,
+    *,
+    processing_id: str = "",
+    timestamp: str = "",
+    blob_service_client: object | None = None,
+) -> dict[str, object]:
+    """Build and store a metadata JSON document for a processed AOI.
+
+    Args:
+        aoi: A processed AOI from the ``prepare_aoi`` activity.
+        processing_id: Orchestration instance ID for traceability (PID 7.4.4).
+        timestamp: Processing timestamp (ISO 8601). Defaults to current UTC.
+        blob_service_client: Optional ``BlobServiceClient`` for writing to
+            Blob Storage.  If ``None``, metadata is built and returned
+            without writing (useful for testing and local dev).
+
+    Returns:
+        A dict containing:
+        - ``metadata``: The full metadata record as a dict
+        - ``metadata_path``: The blob path where metadata was (or would be) written
+        - ``kml_archive_path``: The blob path for the KML archive
+
+    Raises:
+        MetadataWriteError: If blob upload fails.
+    """
+    if not timestamp:
+        timestamp = datetime.now().astimezone().isoformat()
+
+    # Parse timestamp for path generation
+    try:
+        ts = datetime.fromisoformat(timestamp)
+    except (ValueError, TypeError):
+        ts = datetime.now().astimezone()
+        timestamp = ts.isoformat()
+
+    # Build the metadata record (PID Section 9.2)
+    record = AOIMetadataRecord.from_aoi(aoi, processing_id=processing_id, timestamp=timestamp)
+
+    # Extract orchard name for path generation
+    orchard_name = record.orchard_name
+
+    # Build deterministic blob paths (PID 7.4.4, Section 10.1)
+    metadata_path = build_metadata_path(
+        aoi.feature_name,
+        orchard_name,
+        timestamp=ts,
+    )
+
+    from kml_satellite.utils.blob_paths import build_kml_archive_path
+
+    kml_archive_path = build_kml_archive_path(
+        aoi.source_file,
+        orchard_name,
+        timestamp=ts,
+    )
+
+    # Serialise to JSON
+    metadata_json = record.to_json()
+
+    # Write to Blob Storage if a client is provided
+    if blob_service_client is not None:
+        _upload_metadata(blob_service_client, metadata_path, metadata_json)
+
+    logger.info(
+        "Metadata written | feature=%s | path=%s | processing_id=%s",
+        aoi.feature_name,
+        metadata_path,
+        processing_id,
+    )
+
+    return {
+        "metadata": record.to_dict(),
+        "metadata_path": metadata_path,
+        "kml_archive_path": kml_archive_path,
+    }
+
+
+def _upload_metadata(
+    blob_service_client: object,
+    metadata_path: str,
+    metadata_json: str,
+) -> None:
+    """Upload metadata JSON to Blob Storage.
+
+    Uses overwrite=True for idempotent writes (PID 7.4.4).
+
+    Args:
+        blob_service_client: An Azure ``BlobServiceClient`` instance.
+        metadata_path: Blob path within the output container.
+        metadata_json: Serialised JSON string.
+
+    Raises:
+        MetadataWriteError: If the upload fails.
+    """
+    try:
+        from azure.storage.blob import BlobServiceClient
+
+        if not isinstance(blob_service_client, BlobServiceClient):
+            msg = f"Expected BlobServiceClient, got {type(blob_service_client).__name__}"
+            raise MetadataWriteError(msg)
+
+        blob_client = blob_service_client.get_blob_client(
+            container=OUTPUT_CONTAINER,
+            blob=metadata_path,
+        )
+        blob_client.upload_blob(
+            metadata_json.encode("utf-8"),
+            overwrite=True,  # PID 7.4.4: idempotent writes
+        )
+    except MetadataWriteError:
+        raise
+    except Exception as exc:
+        msg = f"Failed to upload metadata to {metadata_path}: {exc}"
+        raise MetadataWriteError(msg) from exc

--- a/kml_satellite/models/metadata.py
+++ b/kml_satellite/models/metadata.py
@@ -1,0 +1,253 @@
+"""Pydantic metadata model conforming to PID Section 9.2.
+
+Defines the per-AOI metadata JSON schema for the KML satellite imagery
+pipeline.  This is the "flight recorder" for each processed polygon:
+what was requested, what was received, how it was processed.
+
+The schema is split into three nested sections:
+- **geometry**: Polygon coordinates, bbox, buffered bbox, area, centroid
+- **imagery**: Provider details, scene metadata (populated during M-2.x)
+- **processing**: Pipeline execution details, timing, status
+
+Engineering standards:
+- PID 7.4.4: Idempotent and deterministic — same input produces same output
+- PID 7.4.5: Explicit units — hectares, metres, EPSG codes
+- PID 7.4.6: Observability — metadata is the audit trail
+
+References:
+- PID Section 9.2 (Metadata JSON Schema)
+- PID FR-4.4, FR-4.6, FR-4.7
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+# Schema version for forward compatibility (PID 7.4.5: explicit)
+SCHEMA_VERSION = "aoi-metadata-v1"
+
+
+class GeometryMetadata(BaseModel):
+    """Geometry section of the per-AOI metadata.
+
+    Contains the polygon coordinates, bounding boxes, area, and centroid.
+    All coordinates are WGS 84 (EPSG:4326).
+
+    Attributes:
+        type: GeoJSON geometry type, always ``"Polygon"``.
+        coordinates: GeoJSON-style nested coordinate arrays
+            ``[exterior_ring, *interior_rings]`` where each ring is a list
+            of ``[lon, lat]`` pairs.
+        centroid: Polygon centroid as ``[lon, lat]``.
+        bounding_box: Tight bounding box
+            ``[min_lon, min_lat, max_lon, max_lat]``.
+        buffered_bounding_box: Bounding box expanded by ``buffer_m`` metres.
+        area_hectares: Geodesic polygon area in hectares (PID 7.4.5).
+        crs: Coordinate reference system EPSG code.
+    """
+
+    type: str = "Polygon"
+    coordinates: list[list[list[float]]] = Field(default_factory=list)
+    centroid: list[float] = Field(default_factory=list)
+    bounding_box: list[float] = Field(default_factory=list)
+    buffered_bounding_box: list[float] = Field(default_factory=list)
+    area_hectares: float = 0.0
+    crs: str = "EPSG:4326"
+
+
+class ImageryMetadata(BaseModel):
+    """Imagery section of the per-AOI metadata.
+
+    Populated during imagery acquisition (M-2.x).  All fields default
+    to empty/zero for the M-1.6 milestone — the schema is defined now
+    so metadata JSON is always structurally complete.
+
+    Attributes:
+        provider: Imagery provider name (e.g. ``"maxar"``, ``"planet"``).
+        scene_id: Provider-specific scene identifier.
+        acquisition_date: Scene acquisition timestamp (ISO 8601).
+        spatial_resolution_m: Ground sample distance in metres.
+        crs: Scene CRS EPSG code (may differ from AOI CRS after reproject).
+        cloud_cover_pct: Cloud cover percentage over the AOI.
+        off_nadir_angle_deg: Off-nadir viewing angle in degrees.
+        format: Image file format (e.g. ``"GeoTIFF"``).
+        raw_blob_path: Blob path to the raw (unclipped) imagery.
+        clipped_blob_path: Blob path to the clipped imagery.
+    """
+
+    provider: str = ""
+    scene_id: str = ""
+    acquisition_date: str | None = None
+    spatial_resolution_m: float = 0.0
+    crs: str = ""
+    cloud_cover_pct: float = 0.0
+    off_nadir_angle_deg: float = 0.0
+    format: str = ""
+    raw_blob_path: str = ""
+    clipped_blob_path: str = ""
+
+
+class ProcessingMetadata(BaseModel):
+    """Processing section of the per-AOI metadata.
+
+    Records how the AOI was processed: buffer distance, clipping status,
+    timing, and any errors.
+
+    Attributes:
+        buffer_m: Buffer distance applied in metres.
+        clipped: Whether the imagery was clipped to the AOI polygon.
+        reprojected: Whether the imagery was reprojected.
+        timestamp: Processing timestamp (ISO 8601).
+        duration_s: Total processing duration in seconds.
+        status: Processing status (``"success"``, ``"partial"``, ``"failed"``).
+        errors: List of error messages encountered during processing.
+    """
+
+    buffer_m: float = 100.0
+    clipped: bool = False
+    reprojected: bool = False
+    timestamp: str = ""
+    duration_s: float = 0.0
+    status: str = "pending"
+    errors: list[str] = Field(default_factory=list)
+
+
+class AOIMetadataRecord(BaseModel):
+    """Top-level per-AOI metadata record (PID Section 9.2).
+
+    This is the complete JSON document written to
+    ``/metadata/{YYYY}/{MM}/{orchard-name}/{feature-name}.json``.
+
+    Attributes:
+        schema_version: Schema identifier for forward compatibility.
+        processing_id: Orchestration instance ID (PID 7.4.4: traceability).
+        kml_filename: Name of the source KML file.
+        feature_name: Name of the feature / Placemark.
+        orchard_name: Orchard or project name (from metadata or filename).
+        tree_variety: Tree/crop variety (from KML ExtendedData, if present).
+        geometry: Polygon geometry and derived measurements.
+        imagery: Imagery acquisition details (populated in M-2.x).
+        processing: Pipeline execution details.
+    """
+
+    schema_version: str = Field(default=SCHEMA_VERSION, alias="$schema")
+    processing_id: str = ""
+    kml_filename: str = ""
+    feature_name: str = ""
+    orchard_name: str = ""
+    tree_variety: str = ""
+    geometry: GeometryMetadata = Field(default_factory=GeometryMetadata)
+    imagery: ImageryMetadata = Field(default_factory=ImageryMetadata)
+    processing: ProcessingMetadata = Field(default_factory=ProcessingMetadata)
+
+    model_config = {"populate_by_name": True}
+
+    @classmethod
+    def from_aoi(
+        cls,
+        aoi: object,
+        *,
+        processing_id: str = "",
+        timestamp: str = "",
+    ) -> AOIMetadataRecord:
+        """Construct a metadata record from an AOI dataclass.
+
+        This is the primary factory method, called by the ``write_metadata``
+        activity after the ``prepare_aoi`` activity completes.
+
+        Args:
+            aoi: An ``AOI`` dataclass instance (from ``kml_satellite.models.aoi``).
+            processing_id: Orchestration instance ID.
+            timestamp: Processing timestamp (ISO 8601).  If empty, uses
+                the current UTC time.
+
+        Returns:
+            A fully populated ``AOIMetadataRecord``.
+        """
+        from kml_satellite.models.aoi import AOI as AOIModel  # noqa: N811
+
+        if not isinstance(aoi, AOIModel):
+            msg = f"Expected AOI instance, got {type(aoi).__name__}"
+            raise TypeError(msg)
+
+        if not timestamp:
+            timestamp = datetime.now().astimezone().isoformat()
+
+        # Build GeoJSON-style coordinates: [exterior, *holes]
+        coords: list[list[list[float]]] = [
+            [list(c) for c in aoi.exterior_coords],
+        ]
+        for ring in aoi.interior_coords:
+            coords.append([list(c) for c in ring])
+
+        # Extract orchard name from metadata, or derive from source file
+        orchard_name = _extract_orchard_name(aoi.metadata, aoi.source_file)
+        tree_variety = aoi.metadata.get("tree_variety", "")
+
+        return cls(
+            processing_id=processing_id,
+            kml_filename=aoi.source_file,
+            feature_name=aoi.feature_name,
+            orchard_name=orchard_name,
+            tree_variety=tree_variety,
+            geometry=GeometryMetadata(
+                type="Polygon",
+                coordinates=coords,
+                centroid=list(aoi.centroid),
+                bounding_box=list(aoi.bbox),
+                buffered_bounding_box=list(aoi.buffered_bbox),
+                area_hectares=aoi.area_ha,
+                crs=aoi.crs,
+            ),
+            processing=ProcessingMetadata(
+                buffer_m=aoi.buffer_m,
+                timestamp=timestamp,
+                status="metadata_written",
+            ),
+        )
+
+    def to_json(self, *, indent: int = 2) -> str:
+        """Serialise to a JSON string.
+
+        Uses the ``$schema`` alias for the schema version field.
+        """
+        return self.model_dump_json(indent=indent, by_alias=True)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialise to a plain dict (for Durable Functions transport)."""
+        return self.model_dump(by_alias=True)  # type: ignore[return-value]
+
+
+def _extract_orchard_name(
+    metadata: dict[str, str],
+    source_file: str,
+) -> str:
+    """Derive the orchard/project name from metadata or the filename.
+
+    Tries (in order):
+    1. ``metadata["orchard_name"]``
+    2. ``metadata["project_name"]``
+    3. KML filename stem (without extension), sanitised
+
+    Args:
+        metadata: Key-value metadata from the KML feature.
+        source_file: Name of the source KML file.
+
+    Returns:
+        A non-empty orchard name string.
+    """
+    for key in ("orchard_name", "project_name"):
+        value = metadata.get(key, "").strip()
+        if value:
+            return value
+
+    # Fall back to sanitised filename stem
+    if source_file:
+        from pathlib import PurePosixPath
+
+        stem = PurePosixPath(source_file).stem
+        return stem if stem else "unknown"
+
+    return "unknown"

--- a/kml_satellite/utils/__init__.py
+++ b/kml_satellite/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for the KML satellite pipeline."""

--- a/kml_satellite/utils/blob_paths.py
+++ b/kml_satellite/utils/blob_paths.py
@@ -1,0 +1,104 @@
+"""Deterministic blob path generation for the KML satellite pipeline.
+
+Generates output paths conforming to PID Section 10.1:
+
+    kml/{YYYY}/{MM}/{orchard-name}/{filename}.kml
+    metadata/{YYYY}/{MM}/{orchard-name}/{feature-name}.json
+
+All path components are sanitised to lowercase slug form: only ``a-z``,
+``0-9``, and ``-`` are allowed.  Spaces become hyphens; other characters
+are stripped.
+
+Engineering standards:
+- PID 7.4.4 Idempotent: same input always produces the same path.
+- PID 7.4.5 Explicit: constants for path prefixes, no inline literals.
+- PID 7.4.8 Defensive: missing names fall back to ``"unknown"``.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+# ---------------------------------------------------------------------------
+# Path prefixes (PID 7.4.5: no magic strings)
+# ---------------------------------------------------------------------------
+
+KML_PREFIX = "kml"
+METADATA_PREFIX = "metadata"
+
+# Regex for sanitising path segments (allow only lowercase alphanumeric + hyphen)
+_SLUG_RE = re.compile(r"[^a-z0-9-]+")
+
+
+def sanitise_slug(value: str) -> str:
+    """Convert a string to a URL/path-safe slug.
+
+    - Lowercase
+    - Spaces → hyphens
+    - Strips all characters except ``a-z``, ``0-9``, ``-``
+    - Collapses consecutive hyphens
+    - Falls back to ``"unknown"`` if the result is empty
+
+    Args:
+        value: Raw string to sanitise.
+
+    Returns:
+        A non-empty slug string.
+    """
+    slug = value.lower().strip().replace(" ", "-")
+    slug = _SLUG_RE.sub("", slug)
+    slug = re.sub(r"-{2,}", "-", slug).strip("-")
+    return slug if slug else "unknown"
+
+
+def build_kml_archive_path(
+    source_filename: str,
+    orchard_name: str,
+    *,
+    timestamp: datetime | None = None,
+) -> str:
+    """Build the blob path for archiving the original KML file.
+
+    Format: ``kml/{YYYY}/{MM}/{orchard-name}/{filename}.kml``
+
+    Args:
+        source_filename: Original KML filename (e.g. ``"orchard_alpha.kml"``).
+        orchard_name: Orchard/project name (will be sanitised).
+        timestamp: Processing timestamp. Defaults to current UTC time.
+
+    Returns:
+        Deterministic blob path string (PID 7.4.4).
+    """
+    ts = timestamp or datetime.now().astimezone()
+    year = f"{ts.year:04d}"
+    month = f"{ts.month:02d}"
+    orchard_slug = sanitise_slug(orchard_name)
+    filename_slug = sanitise_slug(source_filename.removesuffix(".kml")) + ".kml"
+    return f"{KML_PREFIX}/{year}/{month}/{orchard_slug}/{filename_slug}"
+
+
+def build_metadata_path(
+    feature_name: str,
+    orchard_name: str,
+    *,
+    timestamp: datetime | None = None,
+) -> str:
+    """Build the blob path for a metadata JSON document.
+
+    Format: ``metadata/{YYYY}/{MM}/{orchard-name}/{feature-name}.json``
+
+    Args:
+        feature_name: Feature/Placemark name (will be sanitised).
+        orchard_name: Orchard/project name (will be sanitised).
+        timestamp: Processing timestamp. Defaults to current UTC time.
+
+    Returns:
+        Deterministic blob path string (PID 7.4.4).
+    """
+    ts = timestamp or datetime.now().astimezone()
+    year = f"{ts.year:04d}"
+    month = f"{ts.month:02d}"
+    orchard_slug = sanitise_slug(orchard_name)
+    feature_slug = sanitise_slug(feature_name) + ".json"
+    return f"{METADATA_PREFIX}/{year}/{month}/{orchard_slug}/{feature_slug}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ dependencies = [
 
     # HTTP
     "httpx>=0.28.0",
+
+    # Data Validation & Serialisation
+    "pydantic>=2.10.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_blob_paths.py
+++ b/tests/unit/test_blob_paths.py
@@ -1,0 +1,167 @@
+"""Tests for deterministic blob path generation (PID 7.4.4, Section 10.1).
+
+Covers:
+- sanitise_slug: edge cases, special characters, unicode
+- build_kml_archive_path: format, determinism
+- build_metadata_path: format, determinism
+- Path hierarchy: {prefix}/{YYYY}/{MM}/{orchard-slug}/{name}.{ext}
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from kml_satellite.utils.blob_paths import (
+    KML_PREFIX,
+    METADATA_PREFIX,
+    build_kml_archive_path,
+    build_metadata_path,
+    sanitise_slug,
+)
+
+# ===========================================================================
+# sanitise_slug
+# ===========================================================================
+
+
+class TestSanitiseSlug:
+    """Test the slug sanitisation function."""
+
+    def test_simple_lowercase(self) -> None:
+        assert sanitise_slug("hello") == "hello"
+
+    def test_uppercase_to_lowercase(self) -> None:
+        assert sanitise_slug("Hello World") == "hello-world"
+
+    def test_special_characters_removed(self) -> None:
+        assert sanitise_slug("Block A (Fuji)") == "block-a-fuji"
+
+    def test_multiple_spaces_to_single_hyphen(self) -> None:
+        assert sanitise_slug("Alpha   Orchard") == "alpha-orchard"
+
+    def test_leading_trailing_whitespace(self) -> None:
+        assert sanitise_slug("  trimmed  ") == "trimmed"
+
+    def test_empty_string_returns_unknown(self) -> None:
+        assert sanitise_slug("") == "unknown"
+
+    def test_only_special_chars_returns_unknown(self) -> None:
+        assert sanitise_slug("@#$%^&*()") == "unknown"
+
+    def test_hyphens_preserved(self) -> None:
+        assert sanitise_slug("alpha-orchard") == "alpha-orchard"
+
+    def test_underscores_removed(self) -> None:
+        """Underscores are not in the allowed charset; they are stripped."""
+        assert sanitise_slug("my_orchard") == "myorchard"
+
+    def test_numbers_preserved(self) -> None:
+        assert sanitise_slug("block-42") == "block-42"
+
+    def test_consecutive_hyphens_collapsed(self) -> None:
+        assert sanitise_slug("a---b") == "a-b"
+
+    def test_leading_trailing_hyphens_stripped(self) -> None:
+        assert sanitise_slug("-hello-") == "hello"
+
+
+# ===========================================================================
+# build_kml_archive_path
+# ===========================================================================
+
+
+class TestBuildKmlArchivePath:
+    """Test KML archive blob path generation."""
+
+    def test_basic_path(self) -> None:
+        """Standard path follows PID Section 10.1 format."""
+        ts = datetime(2026, 2, 16, tzinfo=UTC)
+        path = build_kml_archive_path("orchard_alpha.kml", "Alpha Orchard", timestamp=ts)
+        assert path == f"{KML_PREFIX}/2026/02/alpha-orchard/orchardalpha.kml"
+
+    def test_deterministic(self) -> None:
+        """Same inputs produce exactly the same output (PID 7.4.4)."""
+        ts = datetime(2026, 1, 5, tzinfo=UTC)
+        path1 = build_kml_archive_path("test.kml", "Farm", timestamp=ts)
+        path2 = build_kml_archive_path("test.kml", "Farm", timestamp=ts)
+        assert path1 == path2
+
+    def test_year_month_segments(self) -> None:
+        """Path includes zero-padded YYYY/MM."""
+        ts = datetime(2026, 3, 1, tzinfo=UTC)
+        path = build_kml_archive_path("x.kml", "y", timestamp=ts)
+        assert "/2026/03/" in path
+
+    def test_orchard_name_sanitised(self) -> None:
+        """Orchard name with special chars is slugified."""
+        ts = datetime(2026, 6, 15, tzinfo=UTC)
+        path = build_kml_archive_path("f.kml", "O'Brien's Farm!", timestamp=ts)
+        assert "obriens-farm" in path
+
+    def test_starts_with_prefix(self) -> None:
+        """Path starts with the KML prefix constant."""
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        path = build_kml_archive_path("f.kml", "o", timestamp=ts)
+        assert path.startswith(f"{KML_PREFIX}/")
+
+    def test_ends_with_kml_extension(self) -> None:
+        """Path always ends with .kml."""
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        path = build_kml_archive_path("data.kml", "test", timestamp=ts)
+        assert path.endswith(".kml")
+
+
+# ===========================================================================
+# build_metadata_path
+# ===========================================================================
+
+
+class TestBuildMetadataPath:
+    """Test metadata JSON blob path generation."""
+
+    def test_basic_path(self) -> None:
+        """Standard path follows PID Section 10.1 format."""
+        ts = datetime(2026, 2, 16, tzinfo=UTC)
+        path = build_metadata_path("Block A", "Alpha Orchard", timestamp=ts)
+        assert path == f"{METADATA_PREFIX}/2026/02/alpha-orchard/block-a.json"
+
+    def test_deterministic(self) -> None:
+        """Same inputs produce exactly the same output (PID 7.4.4)."""
+        ts = datetime(2026, 7, 20, tzinfo=UTC)
+        path1 = build_metadata_path("F1", "Farm", timestamp=ts)
+        path2 = build_metadata_path("F1", "Farm", timestamp=ts)
+        assert path1 == path2
+
+    def test_starts_with_prefix(self) -> None:
+        """Path starts with the metadata prefix constant."""
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        path = build_metadata_path("f", "o", timestamp=ts)
+        assert path.startswith(f"{METADATA_PREFIX}/")
+
+    def test_ends_with_json_extension(self) -> None:
+        """Path always ends with .json."""
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        path = build_metadata_path("feature", "orchard", timestamp=ts)
+        assert path.endswith(".json")
+
+    def test_feature_name_sanitised(self) -> None:
+        """Feature name with spaces and specials is slugified."""
+        ts = datetime(2026, 5, 1, tzinfo=UTC)
+        path = build_metadata_path("Block A (polygon 2)", "Orchard", timestamp=ts)
+        assert "block-a-polygon-2" in path
+
+    def test_missing_orchard_name(self) -> None:
+        """Empty orchard name falls back to 'unknown'."""
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        path = build_metadata_path("F1", "", timestamp=ts)
+        assert "/unknown/" in path
+
+    def test_year_month_in_path(self) -> None:
+        """Different months produce different paths."""
+        ts_jan = datetime(2026, 1, 15, tzinfo=UTC)
+        ts_dec = datetime(2026, 12, 25, tzinfo=UTC)
+        path_jan = build_metadata_path("f", "o", timestamp=ts_jan)
+        path_dec = build_metadata_path("f", "o", timestamp=ts_dec)
+        assert "/01/" in path_jan
+        assert "/12/" in path_dec
+        assert path_jan != path_dec

--- a/tests/unit/test_metadata_model.py
+++ b/tests/unit/test_metadata_model.py
@@ -1,0 +1,333 @@
+"""Tests for the Pydantic metadata model (PID Section 9.2).
+
+Covers:
+- AOIMetadataRecord construction from AOI dataclass
+- JSON serialisation/deserialisation
+- Schema validation (required fields, types)
+- Orchard name extraction logic
+- Edge cases: missing metadata, empty strings, special characters
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kml_satellite.models.aoi import AOI
+from kml_satellite.models.metadata import (
+    SCHEMA_VERSION,
+    AOIMetadataRecord,
+    GeometryMetadata,
+    ImageryMetadata,
+    ProcessingMetadata,
+    _extract_orchard_name,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_aoi(
+    *,
+    feature_name: str = "Block A",
+    source_file: str = "orchard_alpha.kml",
+    metadata: dict[str, str] | None = None,
+    area_ha: float = 12.5,
+    buffer_m: float = 100.0,
+) -> AOI:
+    """Build a minimal AOI for testing."""
+    return AOI(
+        feature_name=feature_name,
+        source_file=source_file,
+        feature_index=0,
+        exterior_coords=[
+            (-120.52, 46.60),
+            (-120.52, 46.61),
+            (-120.51, 46.61),
+            (-120.51, 46.60),
+            (-120.52, 46.60),
+        ],
+        interior_coords=[],
+        bbox=(-120.52, 46.60, -120.51, 46.61),
+        buffered_bbox=(-120.521, 46.599, -120.509, 46.611),
+        area_ha=area_ha,
+        centroid=(-120.515, 46.605),
+        buffer_m=buffer_m,
+        crs="EPSG:4326",
+        metadata=metadata or {"orchard_name": "Alpha Orchard", "tree_variety": "Fuji Apple"},
+        area_warning="",
+    )
+
+
+# ===========================================================================
+# AOIMetadataRecord.from_aoi
+# ===========================================================================
+
+
+class TestFromAOI:
+    """Test constructing metadata records from AOI dataclasses."""
+
+    def test_basic_construction(self) -> None:
+        """from_aoi produces a valid record with all required fields."""
+        aoi = _make_aoi()
+        record = AOIMetadataRecord.from_aoi(aoi, processing_id="inst-001")
+        assert record.processing_id == "inst-001"
+        assert record.feature_name == "Block A"
+        assert record.kml_filename == "orchard_alpha.kml"
+
+    def test_schema_version(self) -> None:
+        """Schema version matches the constant."""
+        record = AOIMetadataRecord.from_aoi(_make_aoi())
+        assert record.schema_version == SCHEMA_VERSION
+
+    def test_orchard_name_from_metadata(self) -> None:
+        """Orchard name is extracted from metadata."""
+        aoi = _make_aoi(metadata={"orchard_name": "Beta Ranch"})
+        record = AOIMetadataRecord.from_aoi(aoi)
+        assert record.orchard_name == "Beta Ranch"
+
+    def test_tree_variety_from_metadata(self) -> None:
+        """Tree variety is extracted from metadata key."""
+        aoi = _make_aoi(metadata={"orchard_name": "X", "tree_variety": "Gala Apple"})
+        record = AOIMetadataRecord.from_aoi(aoi)
+        assert record.tree_variety == "Gala Apple"
+
+    def test_geometry_section(self) -> None:
+        """Geometry section contains correct bbox, centroid, area, CRS."""
+        aoi = _make_aoi(area_ha=50.3)
+        record = AOIMetadataRecord.from_aoi(aoi)
+        geo = record.geometry
+        assert geo.type == "Polygon"
+        assert geo.area_hectares == pytest.approx(50.3)
+        assert geo.crs == "EPSG:4326"
+        assert len(geo.bounding_box) == 4
+        assert len(geo.buffered_bounding_box) == 4
+        assert len(geo.centroid) == 2
+
+    def test_coordinates_geojson_format(self) -> None:
+        """Coordinates are in GeoJSON format: [exterior_ring, *holes]."""
+        aoi = _make_aoi()
+        record = AOIMetadataRecord.from_aoi(aoi)
+        coords = record.geometry.coordinates
+        # One ring (exterior), no holes
+        assert len(coords) == 1
+        # 5 vertices in the exterior ring
+        assert len(coords[0]) == 5
+        # Each vertex is [lon, lat]
+        assert len(coords[0][0]) == 2
+
+    def test_coordinates_with_holes(self) -> None:
+        """Interior rings (holes) appear as additional coordinate arrays."""
+        aoi = AOI(
+            feature_name="Holed",
+            exterior_coords=[(-1.0, 0.0), (-1.0, 1.0), (1.0, 1.0), (1.0, 0.0), (-1.0, 0.0)],
+            interior_coords=[
+                [(-0.5, 0.3), (-0.5, 0.7), (-0.1, 0.7), (-0.1, 0.3), (-0.5, 0.3)],
+            ],
+            bbox=(-1.0, 0.0, 1.0, 1.0),
+            buffered_bbox=(-1.001, -0.001, 1.001, 1.001),
+            area_ha=10.0,
+            centroid=(0.0, 0.5),
+        )
+        record = AOIMetadataRecord.from_aoi(aoi)
+        assert len(record.geometry.coordinates) == 2  # exterior + 1 hole
+
+    def test_processing_section(self) -> None:
+        """Processing section has buffer_m and status."""
+        aoi = _make_aoi(buffer_m=150.0)
+        record = AOIMetadataRecord.from_aoi(aoi, timestamp="2026-02-16T12:00:00+00:00")
+        proc = record.processing
+        assert proc.buffer_m == 150.0
+        assert proc.status == "metadata_written"
+        assert proc.timestamp == "2026-02-16T12:00:00+00:00"
+
+    def test_imagery_section_defaults(self) -> None:
+        """Imagery section defaults to empty (populated in M-2.x)."""
+        record = AOIMetadataRecord.from_aoi(_make_aoi())
+        img = record.imagery
+        assert img.provider == ""
+        assert img.scene_id == ""
+        assert img.spatial_resolution_m == 0.0
+
+    def test_rejects_non_aoi(self) -> None:
+        """from_aoi raises TypeError for non-AOI input."""
+        with pytest.raises(TypeError, match="Expected AOI instance"):
+            AOIMetadataRecord.from_aoi({"not": "an AOI"})  # type: ignore[arg-type]
+
+    def test_custom_timestamp(self) -> None:
+        """Custom timestamp is used when provided."""
+        aoi = _make_aoi()
+        record = AOIMetadataRecord.from_aoi(aoi, timestamp="2026-01-01T00:00:00Z")
+        assert record.processing.timestamp == "2026-01-01T00:00:00Z"
+
+    def test_auto_timestamp_when_empty(self) -> None:
+        """Timestamp is auto-generated when not provided."""
+        aoi = _make_aoi()
+        record = AOIMetadataRecord.from_aoi(aoi)
+        assert record.processing.timestamp != ""
+
+
+# ===========================================================================
+# JSON Serialisation
+# ===========================================================================
+
+
+class TestJSONSerialisation:
+    """Test JSON round-trip serialisation."""
+
+    def test_to_json_valid(self) -> None:
+        """to_json produces valid JSON."""
+        record = AOIMetadataRecord.from_aoi(_make_aoi(), processing_id="test-123")
+        json_str = record.to_json()
+        parsed = json.loads(json_str)
+        assert isinstance(parsed, dict)
+
+    def test_schema_alias_in_json(self) -> None:
+        """JSON output uses '$schema' key (not 'schema_version')."""
+        record = AOIMetadataRecord.from_aoi(_make_aoi())
+        json_str = record.to_json()
+        parsed = json.loads(json_str)
+        assert "$schema" in parsed
+        assert parsed["$schema"] == SCHEMA_VERSION
+        assert "schema_version" not in parsed
+
+    def test_required_fields_present(self) -> None:
+        """All PID-required fields are present in JSON output."""
+        record = AOIMetadataRecord.from_aoi(
+            _make_aoi(), processing_id="inst-001", timestamp="2026-02-16T12:00:00Z"
+        )
+        parsed = json.loads(record.to_json())
+        # Top-level required fields
+        assert "processing_id" in parsed
+        assert "kml_filename" in parsed
+        assert "feature_name" in parsed
+        # Geometry section
+        geo = parsed["geometry"]
+        assert "bounding_box" in geo
+        assert "area_hectares" in geo
+        assert "centroid" in geo
+        assert "crs" in geo
+        # Processing section
+        proc = parsed["processing"]
+        assert "timestamp" in proc
+        assert "status" in proc
+        assert "buffer_m" in proc
+
+    def test_to_dict_round_trip(self) -> None:
+        """to_dict produces a dict that can reconstruct the model."""
+        record = AOIMetadataRecord.from_aoi(_make_aoi(), processing_id="rt-001")
+        d = record.to_dict()
+        restored = AOIMetadataRecord.model_validate(d)
+        assert restored.processing_id == "rt-001"
+        assert restored.feature_name == record.feature_name
+
+    def test_json_indent(self) -> None:
+        """to_json respects the indent parameter."""
+        record = AOIMetadataRecord.from_aoi(_make_aoi())
+        compact = record.to_json(indent=0)
+        pretty = record.to_json(indent=4)
+        # Pretty-printed is longer due to indentation
+        assert len(pretty) > len(compact)
+
+
+# ===========================================================================
+# Schema Validation
+# ===========================================================================
+
+
+class TestSchemaValidation:
+    """Test Pydantic model validation on metadata records."""
+
+    def test_geometry_metadata_defaults(self) -> None:
+        """GeometryMetadata has sensible defaults."""
+        geo = GeometryMetadata()
+        assert geo.type == "Polygon"
+        assert geo.coordinates == []
+        assert geo.area_hectares == 0.0
+        assert geo.crs == "EPSG:4326"
+
+    def test_imagery_metadata_defaults(self) -> None:
+        """ImageryMetadata defaults to empty/zero."""
+        img = ImageryMetadata()
+        assert img.provider == ""
+        assert img.spatial_resolution_m == 0.0
+        assert img.cloud_cover_pct == 0.0
+
+    def test_processing_metadata_defaults(self) -> None:
+        """ProcessingMetadata defaults to pending status."""
+        proc = ProcessingMetadata()
+        assert proc.status == "pending"
+        assert proc.errors == []
+        assert proc.buffer_m == 100.0
+
+    def test_full_record_from_dict(self) -> None:
+        """A full metadata record can be constructed from a raw dict."""
+        raw = {
+            "$schema": "aoi-metadata-v1",
+            "processing_id": "test-456",
+            "kml_filename": "test.kml",
+            "feature_name": "Plot 1",
+            "orchard_name": "Test Orchard",
+            "tree_variety": "Cherry",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[[-1.0, 0.0], [0.0, 1.0], [1.0, 0.0], [-1.0, 0.0]]],
+                "centroid": [0.0, 0.33],
+                "bounding_box": [-1.0, 0.0, 1.0, 1.0],
+                "buffered_bounding_box": [-1.01, -0.01, 1.01, 1.01],
+                "area_hectares": 5.5,
+                "crs": "EPSG:4326",
+            },
+            "imagery": {"provider": "", "scene_id": ""},
+            "processing": {
+                "buffer_m": 100.0,
+                "timestamp": "2026-02-16T12:00:00Z",
+                "status": "metadata_written",
+            },
+        }
+        record = AOIMetadataRecord.model_validate(raw)
+        assert record.processing_id == "test-456"
+        assert record.geometry.area_hectares == 5.5
+
+
+# ===========================================================================
+# Orchard Name Extraction
+# ===========================================================================
+
+
+class TestOrchardNameExtraction:
+    """Test the _extract_orchard_name helper."""
+
+    def test_from_orchard_name_key(self) -> None:
+        """Uses 'orchard_name' metadata key first."""
+        name = _extract_orchard_name({"orchard_name": "Alpha"}, "fallback.kml")
+        assert name == "Alpha"
+
+    def test_from_project_name_key(self) -> None:
+        """Falls back to 'project_name' metadata key."""
+        name = _extract_orchard_name({"project_name": "Beta Project"}, "fallback.kml")
+        assert name == "Beta Project"
+
+    def test_from_filename(self) -> None:
+        """Falls back to filename stem when metadata is empty."""
+        name = _extract_orchard_name({}, "my_orchard.kml")
+        assert name == "my_orchard"
+
+    def test_empty_metadata_and_file(self) -> None:
+        """Returns 'unknown' when both metadata and filename are empty."""
+        name = _extract_orchard_name({}, "")
+        assert name == "unknown"
+
+    def test_whitespace_only_value(self) -> None:
+        """Whitespace-only metadata values are treated as empty."""
+        name = _extract_orchard_name({"orchard_name": "  "}, "backup.kml")
+        assert name == "backup"
+
+    def test_orchard_name_takes_priority(self) -> None:
+        """orchard_name is preferred over project_name."""
+        name = _extract_orchard_name(
+            {"orchard_name": "First", "project_name": "Second"}, "file.kml"
+        )
+        assert name == "First"

--- a/tests/unit/test_write_metadata.py
+++ b/tests/unit/test_write_metadata.py
@@ -1,0 +1,266 @@
+"""Tests for the write_metadata activity.
+
+Covers:
+- Metadata record generation from AOI
+- Blob path generation
+- Blob upload (mocked)
+- Error handling
+- Integration with metadata model
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kml_satellite.activities.write_metadata import (
+    MetadataWriteError,
+    write_metadata,
+)
+from kml_satellite.models.aoi import AOI
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_aoi(
+    *,
+    feature_name: str = "Block A",
+    source_file: str = "orchard_alpha.kml",
+    metadata: dict[str, str] | None = None,
+) -> AOI:
+    """Build a minimal AOI for testing."""
+    if metadata is None:
+        metadata = {"orchard_name": "Alpha Orchard", "tree_variety": "Fuji Apple"}
+    return AOI(
+        feature_name=feature_name,
+        source_file=source_file,
+        feature_index=0,
+        exterior_coords=[
+            (-120.52, 46.60),
+            (-120.52, 46.61),
+            (-120.51, 46.61),
+            (-120.51, 46.60),
+            (-120.52, 46.60),
+        ],
+        interior_coords=[],
+        bbox=(-120.52, 46.60, -120.51, 46.61),
+        buffered_bbox=(-120.521, 46.599, -120.509, 46.611),
+        area_ha=12.5,
+        centroid=(-120.515, 46.605),
+        buffer_m=100.0,
+        crs="EPSG:4326",
+        metadata=metadata,
+        area_warning="",
+    )
+
+
+# ===========================================================================
+# write_metadata (no blob client — local mode)
+# ===========================================================================
+
+
+class TestWriteMetadataLocal:
+    """Test write_metadata without a blob client (local/test mode)."""
+
+    def test_returns_metadata_dict(self) -> None:
+        """Result includes the full metadata record as a dict."""
+        aoi = _make_aoi()
+        result = write_metadata(aoi, processing_id="inst-001")
+        assert "metadata" in result
+        assert isinstance(result["metadata"], dict)
+
+    def test_returns_metadata_path(self) -> None:
+        """Result includes the deterministic blob path for metadata."""
+        aoi = _make_aoi()
+        result = write_metadata(
+            aoi, processing_id="inst-001", timestamp="2026-02-16T12:00:00+00:00"
+        )
+        path = result["metadata_path"]
+        assert isinstance(path, str)
+        assert path.startswith("metadata/")
+        assert path.endswith(".json")
+        assert "alpha-orchard" in path
+        assert "block-a" in path
+
+    def test_returns_kml_archive_path(self) -> None:
+        """Result includes the KML archive blob path."""
+        aoi = _make_aoi()
+        result = write_metadata(
+            aoi, processing_id="inst-001", timestamp="2026-02-16T12:00:00+00:00"
+        )
+        path = result["kml_archive_path"]
+        assert isinstance(path, str)
+        assert path.startswith("kml/")
+        assert path.endswith(".kml")
+
+    def test_processing_id_in_metadata(self) -> None:
+        """Processing ID is included in the metadata record."""
+        aoi = _make_aoi()
+        result = write_metadata(aoi, processing_id="my-instance-42")
+        metadata = result["metadata"]
+        assert metadata["processing_id"] == "my-instance-42"
+
+    def test_feature_name_in_metadata(self) -> None:
+        """Feature name from AOI appears in the metadata."""
+        aoi = _make_aoi(feature_name="Vineyard Block B")
+        result = write_metadata(aoi)
+        assert result["metadata"]["feature_name"] == "Vineyard Block B"
+
+    def test_geometry_in_metadata(self) -> None:
+        """Geometry section is populated with bbox, area, centroid."""
+        aoi = _make_aoi()
+        result = write_metadata(aoi)
+        geo = result["metadata"]["geometry"]
+        assert geo["area_hectares"] == pytest.approx(12.5)
+        assert len(geo["bounding_box"]) == 4
+        assert len(geo["centroid"]) == 2
+        assert geo["crs"] == "EPSG:4326"
+
+    def test_custom_timestamp(self) -> None:
+        """Custom timestamp is passed through to the metadata record."""
+        aoi = _make_aoi()
+        result = write_metadata(aoi, timestamp="2026-01-01T00:00:00Z")
+        proc = result["metadata"]["processing"]
+        assert proc["timestamp"] == "2026-01-01T00:00:00Z"
+
+    def test_invalid_timestamp_falls_back(self) -> None:
+        """Invalid timestamp string falls back to auto-generated."""
+        aoi = _make_aoi()
+        result = write_metadata(aoi, timestamp="not-a-date")
+        proc = result["metadata"]["processing"]
+        # Should still have a non-empty timestamp
+        assert proc["timestamp"] != ""
+
+    def test_orchard_name_derived_from_metadata(self) -> None:
+        """Orchard name in path is derived from AOI metadata."""
+        aoi = _make_aoi(metadata={"orchard_name": "Sunset Valley"})
+        result = write_metadata(aoi, timestamp="2026-06-15T00:00:00+00:00")
+        assert "sunset-valley" in result["metadata_path"]
+
+    def test_orchard_name_from_filename(self) -> None:
+        """Orchard name falls back to filename when metadata is empty."""
+        aoi = _make_aoi(source_file="my_farm.kml", metadata={})
+        result = write_metadata(aoi, timestamp="2026-06-15T00:00:00+00:00")
+        # sanitise_slug("my_farm") -> "myfarm" (underscores stripped)
+        assert "myfarm" in result["metadata_path"]
+
+    def test_deterministic_paths(self) -> None:
+        """Same AOI + timestamp produces identical paths (PID 7.4.4)."""
+        aoi = _make_aoi()
+        ts = "2026-02-16T12:00:00+00:00"
+        r1 = write_metadata(aoi, processing_id="id-1", timestamp=ts)
+        r2 = write_metadata(aoi, processing_id="id-1", timestamp=ts)
+        assert r1["metadata_path"] == r2["metadata_path"]
+        assert r1["kml_archive_path"] == r2["kml_archive_path"]
+
+
+# ===========================================================================
+# write_metadata with blob client (mocked upload)
+# ===========================================================================
+
+
+class TestWriteMetadataUpload:
+    """Test write_metadata with a mocked BlobServiceClient."""
+
+    def test_uploads_to_correct_container(self) -> None:
+        """Metadata is uploaded to the kml-output container."""
+        aoi = _make_aoi()
+        mock_service = MagicMock(spec_set=["get_blob_client"])
+
+        # Patch _upload_metadata directly to avoid BlobServiceClient isinstance check
+        with patch("kml_satellite.activities.write_metadata._upload_metadata") as mock_upload:
+            result = write_metadata(
+                aoi,
+                processing_id="inst-001",
+                timestamp="2026-02-16T12:00:00+00:00",
+                blob_service_client=mock_service,
+            )
+            mock_upload.assert_called_once()
+            call_args = mock_upload.call_args
+            assert call_args[0][0] is mock_service  # blob_service_client
+            assert call_args[0][1] == result["metadata_path"]  # path
+            assert isinstance(call_args[0][2], str)  # JSON string
+
+    def test_upload_failure_raises_error(self) -> None:
+        """MetadataWriteError is raised if upload fails."""
+        aoi = _make_aoi()
+
+        with (
+            patch(
+                "kml_satellite.activities.write_metadata._upload_metadata",
+                side_effect=MetadataWriteError("Upload failed"),
+            ),
+            pytest.raises(MetadataWriteError, match="Upload failed"),
+        ):
+            write_metadata(
+                aoi,
+                blob_service_client=MagicMock(),
+            )
+
+
+# ===========================================================================
+# Schema conformance (PID Section 9.2)
+# ===========================================================================
+
+
+class TestSchemaConformance:
+    """Verify that the write_metadata output conforms to PID Section 9.2."""
+
+    def test_all_top_level_fields(self) -> None:
+        """All PID-required top-level fields are present."""
+        aoi = _make_aoi()
+        result = write_metadata(aoi, processing_id="inst-001")
+        metadata = result["metadata"]
+        required_keys = {
+            "$schema",
+            "processing_id",
+            "kml_filename",
+            "feature_name",
+            "orchard_name",
+            "tree_variety",
+            "geometry",
+            "imagery",
+            "processing",
+        }
+        assert required_keys.issubset(set(metadata.keys()))
+
+    def test_geometry_fields(self) -> None:
+        """Geometry section has all required fields."""
+        aoi = _make_aoi()
+        result = write_metadata(aoi)
+        geo = result["metadata"]["geometry"]
+        for key in (
+            "type",
+            "coordinates",
+            "centroid",
+            "bounding_box",
+            "buffered_bounding_box",
+            "area_hectares",
+            "crs",
+        ):
+            assert key in geo, f"Missing geometry field: {key}"
+
+    def test_imagery_fields(self) -> None:
+        """Imagery section has all required fields (even if empty)."""
+        aoi = _make_aoi()
+        result = write_metadata(aoi)
+        img = result["metadata"]["imagery"]
+        for key in ("provider", "scene_id", "spatial_resolution_m", "cloud_cover_pct", "format"):
+            assert key in img, f"Missing imagery field: {key}"
+
+    def test_processing_fields(self) -> None:
+        """Processing section has all required fields."""
+        aoi = _make_aoi()
+        result = write_metadata(aoi)
+        proc = result["metadata"]["processing"]
+        for key in ("buffer_m", "timestamp", "status", "errors"):
+            assert key in proc, f"Missing processing field: {key}"
+
+    def test_schema_version_value(self) -> None:
+        """$schema field has the correct version string."""
+        aoi = _make_aoi()
+        result = write_metadata(aoi)
+        assert result["metadata"]["$schema"] == "aoi-metadata-v1"

--- a/uv.lock
+++ b/uv.lock
@@ -68,6 +68,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -551,6 +560,7 @@ dependencies = [
     { name = "fiona" },
     { name = "httpx" },
     { name = "lxml" },
+    { name = "pydantic" },
     { name = "pyproj" },
     { name = "pystac-client" },
     { name = "rasterio" },
@@ -592,6 +602,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "lxml", specifier = ">=5.3.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.1.0" },
+    { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pyproj", specifier = ">=3.7.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390" },
     { name = "pystac-client", specifier = ">=0.8.0" },
@@ -870,6 +881,50 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
 ]
 
 [[package]]
@@ -1188,6 +1243,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements **Issue #7 — M-1.6: Metadata JSON generation and storage**.

Adds the `write_metadata` Durable Functions activity that generates per-AOI metadata JSON documents conforming to PID Section 9.2, with deterministic blob paths conforming to PID Section 10.1.

## New files

| File | Purpose |
|------|---------|
| `kml_satellite/models/metadata.py` | Pydantic `AOIMetadataRecord` model with `GeometryMetadata`, `ImageryMetadata`, `ProcessingMetadata` sections |
| `kml_satellite/utils/__init__.py` | Utils package |
| `kml_satellite/utils/blob_paths.py` | Deterministic blob path generation (`build_metadata_path`, `build_kml_archive_path`, `sanitise_slug`) |
| `kml_satellite/activities/write_metadata.py` | `write_metadata()` activity + `_upload_metadata()` Blob Storage upload |
| `tests/unit/test_metadata_model.py` | **27 tests** — Pydantic model construction, JSON serialisation, schema validation, orchard name extraction |
| `tests/unit/test_blob_paths.py` | **24 tests** — slug sanitisation, KML archive paths, metadata paths, determinism |
| `tests/unit/test_write_metadata.py` | **19 tests** — local mode, mocked upload, schema conformance |

## Modified files

| File | Change |
|------|--------|
| `pyproject.toml` | Add `pydantic>=2.10.0` dependency |
| `function_app.py` | Register `write_metadata` activity; remove Issue #7 TODO |
| `kml_satellite/orchestrators/kml_pipeline.py` | Add Phase 3 (write_metadata fan-out via `task_all`) |
| `tests/unit/test_orchestrator.py` | Update for three-phase generator (12 tests, +3 new) |

## PID requirements addressed

- **FR-4.4** — Metadata JSON stored under `/metadata/` prefix
- **FR-4.6** — Per-AOI metadata JSON with geometry, processing details, imagery placeholders
- **FR-4.7** — Storage hierarchy by `{YYYY}/{MM}/{orchard-name}/{feature-name}.json`
- **PID 7.4.4** — Idempotent: same input produces same deterministic output paths
- **PID 7.4.5** — Explicit: typed Pydantic models, named constants, explicit units
- **PID 7.4.6** — Observability: structured logging at activity boundaries
- **PID Section 9.2** — Full schema: `$schema`, `processing_id`, `geometry`, `imagery`, `processing`
- **PID Section 10.1** — Container & path layout: `kml/`, `metadata/` prefixes

## Testing

- **73 new unit tests** — all passing
- **343 total tests** — all passing
- All 16 pre-commit hooks passing (ruff, ruff-format, pyright, detect-secrets, etc.)

## Notes

- Imagery section defaults to empty (populated during M-2.x milestone)
- Processing status set to `"metadata_written"` after this phase
- Blob path slugification: lowercase, alphanumeric + hyphens only, falls back to `"unknown"`

Closes #7