### PR TITLE
refactor: rename orchard_name → project_name across codebase (#67)

### DIFF
--- a/DEFENSIVE_CODE_REVIEW.md
+++ b/DEFENSIVE_CODE_REVIEW.md
@@ -105,7 +105,7 @@ Status: **Strong**
 
 ### Functions reviewed
 
-- `AOIMetadataRecord.from_aoi`, `to_json`, `to_dict`, `_extract_orchard_name`
+- `AOIMetadataRecord.from_aoi`, `to_json`, `to_dict`, `_extract_project_name`
 
 ### Findings
 

--- a/function_app.py
+++ b/function_app.py
@@ -481,7 +481,7 @@ def download_imagery_activity(activityInput: str) -> dict[str, object]:  # noqa:
           ``order_id``, ``scene_id``, ``provider``, ``aoi_feature_name``.
         - ``provider_name``: Imagery provider name (default ``"planetary_computer"``).
         - ``provider_config``: Optional provider configuration overrides.
-        - ``orchard_name``: Orchard/project name for blob path generation.
+        - ``project_name``: Project name for blob path generation.
         - ``timestamp``: Processing timestamp (ISO 8601).
 
     Returns:
@@ -503,7 +503,7 @@ def download_imagery_activity(activityInput: str) -> dict[str, object]:  # noqa:
 
     provider_name = str(payload.get("provider_name", "planetary_computer"))
     provider_config = payload.get("provider_config")
-    orchard_name = str(payload.get("orchard_name", ""))
+    project_name = str(payload.get("project_name", ""))
     timestamp = str(payload.get("timestamp", ""))
 
     logger.info(
@@ -516,7 +516,7 @@ def download_imagery_activity(activityInput: str) -> dict[str, object]:  # noqa:
         imagery_outcome,
         provider_name=provider_name,
         provider_config=provider_config,  # type: ignore[arg-type]
-        orchard_name=orchard_name,
+        project_name=project_name,
         timestamp=timestamp,
     )
 
@@ -540,7 +540,7 @@ def post_process_imagery_activity(activityInput: str) -> dict[str, object]:  # n
         - ``download_result``: Dict from download_imagery with
           ``order_id``, ``blob_path``, ``size_bytes``, etc.
         - ``aoi``: Serialised AOI dict with polygon geometry.
-        - ``orchard_name``: Orchard/project name for output path.
+        - ``project_name``: Project name for output path.
         - ``timestamp``: Processing timestamp (ISO 8601).
         - ``target_crs``: Target CRS for reprojection (default EPSG:4326).
         - ``enable_clipping``: Whether to clip (default True).
@@ -568,7 +568,7 @@ def post_process_imagery_activity(activityInput: str) -> dict[str, object]:  # n
         msg = "post_process_imagery activity: aoi must be a dict"
         raise TypeError(msg)
 
-    orchard_name = str(payload.get("orchard_name", ""))
+    project_name = str(payload.get("project_name", ""))
     timestamp = str(payload.get("timestamp", ""))
     target_crs = str(payload.get("target_crs", "EPSG:4326"))
     enable_clipping = bool(payload.get("enable_clipping", True))
@@ -583,7 +583,7 @@ def post_process_imagery_activity(activityInput: str) -> dict[str, object]:  # n
     result = post_process_imagery(
         download_result,
         aoi_data,
-        orchard_name=orchard_name,
+        project_name=project_name,
         timestamp=timestamp,
         target_crs=target_crs,
         enable_clipping=enable_clipping,

--- a/kml_satellite/activities/download_imagery.py
+++ b/kml_satellite/activities/download_imagery.py
@@ -68,7 +68,7 @@ def download_imagery(
     *,
     provider_name: str = "planetary_computer",
     provider_config: dict[str, Any] | None = None,
-    orchard_name: str = "",
+    project_name: str = "",
     timestamp: str = "",
     max_retries: int = DEFAULT_MAX_DOWNLOAD_RETRIES,
 ) -> dict[str, Any]:
@@ -79,7 +79,7 @@ def download_imagery(
             ``order_id``, ``scene_id``, ``provider``, ``aoi_feature_name``.
         provider_name: Name of the imagery provider to use.
         provider_config: Optional provider configuration overrides.
-        orchard_name: Orchard/project name for blob path generation.
+        project_name: Project name for blob path generation.
         timestamp: Processing timestamp (ISO 8601) for blob path.
             Defaults to current UTC time.
         max_retries: Maximum download retry attempts (default 3, FR-6.5).
@@ -146,7 +146,7 @@ def download_imagery(
     ts = parse_timestamp(timestamp)
     blob_path = build_imagery_path(
         feature_name or scene_id,
-        orchard_name or "unknown",
+        project_name or "unknown",
         timestamp=ts,
     )
 

--- a/kml_satellite/activities/post_process_imagery.py
+++ b/kml_satellite/activities/post_process_imagery.py
@@ -62,7 +62,7 @@ def post_process_imagery(
     download_result: dict[str, Any],
     aoi: dict[str, Any],
     *,
-    orchard_name: str = "",
+    project_name: str = "",
     timestamp: str = "",
     target_crs: str = DEFAULT_TARGET_CRS,
     enable_clipping: bool = True,
@@ -75,7 +75,7 @@ def post_process_imagery(
             ``order_id``, ``blob_path``, ``size_bytes``, etc.
         aoi: Serialised AOI dict with ``exterior_coords``,
             ``feature_name``, and optionally ``interior_coords``.
-        orchard_name: Orchard/project name for output path generation.
+        project_name: Project name for output path generation.
         timestamp: Processing timestamp (ISO 8601). Defaults to now.
         target_crs: Target CRS for reprojection (default EPSG:4326).
         enable_clipping: Whether to clip to AOI polygon (default True).
@@ -149,7 +149,7 @@ def post_process_imagery(
     name_for_path = feature_name or scene_id or "unknown"
     clipped_blob_path = build_clipped_imagery_path(
         name_for_path,
-        orchard_name or "unknown",
+        project_name or "unknown",
         timestamp=ts,
     )
 

--- a/kml_satellite/activities/write_metadata.py
+++ b/kml_satellite/activities/write_metadata.py
@@ -83,13 +83,13 @@ def write_metadata(
     # Build the metadata record (PID Section 9.2)
     record = AOIMetadataRecord.from_aoi(aoi, processing_id=processing_id, timestamp=timestamp)
 
-    # Extract orchard name for path generation
-    orchard_name = record.orchard_name
+    # Extract project name for path generation
+    project_name = record.project_name
 
     # Build deterministic blob paths (PID 7.4.4, Section 10.1)
     metadata_path = build_metadata_path(
         aoi.feature_name,
-        orchard_name,
+        project_name,
         timestamp=ts,
     )
 
@@ -97,7 +97,7 @@ def write_metadata(
 
     kml_archive_path = build_kml_archive_path(
         aoi.source_file,
-        orchard_name,
+        project_name,
         timestamp=ts,
     )
 

--- a/kml_satellite/models/contracts.py
+++ b/kml_satellite/models/contracts.py
@@ -171,7 +171,7 @@ class DownloadImageryInput(TypedDict):
     imagery_outcome: ImageryOutcome
     provider_name: str
     provider_config: dict[str, str] | None
-    orchard_name: str
+    project_name: str
     timestamp: str
 
 
@@ -201,7 +201,7 @@ class PostProcessInput(TypedDict):
 
     download_result: DownloadResult
     aoi: AOIPayload
-    orchard_name: str
+    project_name: str
     timestamp: str
     target_crs: str
     enable_clipping: bool

--- a/kml_satellite/models/metadata.py
+++ b/kml_satellite/models/metadata.py
@@ -125,7 +125,7 @@ class AOIMetadataRecord(BaseModel):
         processing_id: Orchestration instance ID (PID 7.4.4: traceability).
         kml_filename: Name of the source KML file.
         feature_name: Name of the feature / Placemark.
-        orchard_name: Orchard or project name (from metadata or filename).
+        project_name: Project name (from metadata or filename).
         tree_variety: Tree/crop variety (from KML ExtendedData, if present).
         geometry: Polygon geometry and derived measurements.
         imagery: Imagery acquisition details (populated in M-2.x).
@@ -136,7 +136,7 @@ class AOIMetadataRecord(BaseModel):
     processing_id: str = ""
     kml_filename: str = ""
     feature_name: str = ""
-    orchard_name: str = ""
+    project_name: str = ""
     tree_variety: str = ""
     geometry: GeometryMetadata = Field(default_factory=GeometryMetadata)
     imagery: ImageryMetadata = Field(default_factory=ImageryMetadata)
@@ -182,15 +182,15 @@ class AOIMetadataRecord(BaseModel):
         for ring in aoi.interior_coords:
             coords.append([list(c) for c in ring])
 
-        # Extract orchard name from metadata, or derive from source file
-        orchard_name = _extract_orchard_name(aoi.metadata, aoi.source_file)
+        # Extract project name from metadata, or derive from source file
+        project_name = _extract_project_name(aoi.metadata, aoi.source_file)
         tree_variety = aoi.metadata.get("tree_variety", "")
 
         return cls(
             processing_id=processing_id,
             kml_filename=aoi.source_file,
             feature_name=aoi.feature_name,
-            orchard_name=orchard_name,
+            project_name=project_name,
             tree_variety=tree_variety,
             geometry=GeometryMetadata(
                 type="Polygon",
@@ -220,15 +220,15 @@ class AOIMetadataRecord(BaseModel):
         return self.model_dump(by_alias=True)  # type: ignore[return-value]
 
 
-def _extract_orchard_name(
+def _extract_project_name(
     metadata: dict[str, str],
     source_file: str,
 ) -> str:
-    """Derive the orchard/project name from metadata or the filename.
+    """Derive the project name from metadata or the filename.
 
     Tries (in order):
-    1. ``metadata["orchard_name"]``
-    2. ``metadata["project_name"]``
+    1. ``metadata["project_name"]``
+    2. ``metadata["orchard_name"]`` (backward compatibility)
     3. KML filename stem (without extension), sanitised
 
     Args:
@@ -236,9 +236,9 @@ def _extract_orchard_name(
         source_file: Name of the source KML file.
 
     Returns:
-        A non-empty orchard name string.
+        A non-empty project name string.
     """
-    for key in ("orchard_name", "project_name"):
+    for key in ("project_name", "orchard_name"):
         value = metadata.get(key, "").strip()
         if value:
             return value

--- a/kml_satellite/models/payloads.py
+++ b/kml_satellite/models/payloads.py
@@ -123,7 +123,7 @@ class DownloadImageryInput(TypedDict):
     imagery_outcome: dict[str, Any]
     provider_name: NotRequired[str]
     provider_config: NotRequired[dict[str, Any] | None]
-    orchard_name: NotRequired[str]
+    project_name: NotRequired[str]
     timestamp: NotRequired[str]
 
 
@@ -153,7 +153,7 @@ class PostProcessImageryInput(TypedDict):
 
     download_result: dict[str, Any]
     aoi: dict[str, Any]
-    orchard_name: NotRequired[str]
+    project_name: NotRequired[str]
     timestamp: NotRequired[str]
     target_crs: NotRequired[str]
     enable_clipping: NotRequired[bool]

--- a/kml_satellite/orchestrators/kml_pipeline.py
+++ b/kml_satellite/orchestrators/kml_pipeline.py
@@ -117,9 +117,9 @@ def orchestrator_function(
     # -----------------------------------------------------------------------
     ready_outcomes = [o for o in acquisition["imagery_outcomes"] if o.get("state") == "ready"]
 
-    # Derive orchard_name from the source KML filename stem.
+    # Derive project_name from the source KML filename stem.
     _stem = PurePosixPath(blob_name).stem if blob_name else ""
-    orchard_name = _stem if _stem and _stem != "<unknown>" else "unknown"
+    project_name = _stem if _stem and _stem != "<unknown>" else "unknown"
 
     provider_name = str(blob_event.get("provider_name", "planetary_computer"))
 
@@ -138,7 +138,7 @@ def orchestrator_function(
         ingestion["aois"],
         provider_name=provider_name,
         provider_config=blob_event.get("provider_config"),
-        orchard_name=orchard_name,
+        project_name=project_name,
         timestamp=timestamp,
         enable_clipping=bool(blob_event.get("enable_clipping", True)),
         enable_reprojection=bool(blob_event.get("enable_reprojection", True)),

--- a/kml_satellite/orchestrators/phases.py
+++ b/kml_satellite/orchestrators/phases.py
@@ -347,7 +347,7 @@ def run_fulfillment_phase(
     *,
     provider_name: str,
     provider_config: object | None,
-    orchard_name: str,
+    project_name: str,
     timestamp: str,
     enable_clipping: bool = True,
     enable_reprojection: bool = True,
@@ -372,7 +372,7 @@ def run_fulfillment_phase(
         aois: Full AOI list for geometry lookup.
         provider_name: Imagery provider name.
         provider_config: Optional provider configuration overrides.
-        orchard_name: Orchard/project name for blob path generation.
+        project_name: Project name for blob path generation.
         timestamp: Shared processing timestamp (ISO 8601).
         enable_clipping: Whether to clip to AOI polygon.
         enable_reprojection: Whether to reproject if CRS differs.
@@ -404,7 +404,7 @@ def run_fulfillment_phase(
                     "imagery_outcome": outcome,
                     "provider_name": provider_name,
                     "provider_config": provider_config,
-                    "orchard_name": orchard_name,
+                    "project_name": project_name,
                     "timestamp": timestamp,
                 },
             )
@@ -476,7 +476,7 @@ def run_fulfillment_phase(
                 {
                     "download_result": dl_result,
                     "aoi": aoi_by_feature.get(str(dl_result.get("aoi_feature_name", "")), {}),
-                    "orchard_name": orchard_name,
+                    "project_name": project_name,
                     "timestamp": timestamp,
                     "target_crs": target_crs,
                     "enable_clipping": enable_clipping,

--- a/kml_satellite/utils/blob_paths.py
+++ b/kml_satellite/utils/blob_paths.py
@@ -2,8 +2,8 @@
 
 Generates output paths conforming to PID Section 10.1:
 
-    kml/{YYYY}/{MM}/{orchard-name}/{filename}.kml
-    metadata/{YYYY}/{MM}/{orchard-name}/{feature-name}.json
+    kml/{YYYY}/{MM}/{project-name}/{filename}.kml
+    metadata/{YYYY}/{MM}/{project-name}/{feature-name}.json
 
 All path components are sanitised to lowercase slug form: only ``a-z``,
 ``0-9``, and ``-`` are allowed.  Spaces become hyphens; other characters
@@ -56,17 +56,17 @@ def sanitise_slug(value: str) -> str:
 
 def build_kml_archive_path(
     source_filename: str,
-    orchard_name: str,
+    project_name: str,
     *,
     timestamp: datetime | None = None,
 ) -> str:
     """Build the blob path for archiving the original KML file.
 
-    Format: ``kml/{YYYY}/{MM}/{orchard-name}/{filename}.kml``
+    Format: ``kml/{YYYY}/{MM}/{project-name}/{filename}.kml``
 
     Args:
         source_filename: Original KML filename (e.g. ``"orchard_alpha.kml"``).
-        orchard_name: Orchard/project name (will be sanitised).
+        project_name: Project name (will be sanitised).
         timestamp: Processing timestamp. Defaults to current UTC time.
 
     Returns:
@@ -75,24 +75,24 @@ def build_kml_archive_path(
     ts = timestamp or datetime.now(UTC)
     year = f"{ts.year:04d}"
     month = f"{ts.month:02d}"
-    orchard_slug = sanitise_slug(orchard_name)
+    project_slug = sanitise_slug(project_name)
     filename_slug = sanitise_slug(source_filename.removesuffix(".kml")) + ".kml"
-    return f"{KML_PREFIX}/{year}/{month}/{orchard_slug}/{filename_slug}"
+    return f"{KML_PREFIX}/{year}/{month}/{project_slug}/{filename_slug}"
 
 
 def build_metadata_path(
     feature_name: str,
-    orchard_name: str,
+    project_name: str,
     *,
     timestamp: datetime | None = None,
 ) -> str:
     """Build the blob path for a metadata JSON document.
 
-    Format: ``metadata/{YYYY}/{MM}/{orchard-name}/{feature-name}.json``
+    Format: ``metadata/{YYYY}/{MM}/{project-name}/{feature-name}.json``
 
     Args:
         feature_name: Feature/Placemark name (will be sanitised).
-        orchard_name: Orchard/project name (will be sanitised).
+        project_name: Project name (will be sanitised).
         timestamp: Processing timestamp. Defaults to current UTC time.
 
     Returns:
@@ -101,24 +101,24 @@ def build_metadata_path(
     ts = timestamp or datetime.now(UTC)
     year = f"{ts.year:04d}"
     month = f"{ts.month:02d}"
-    orchard_slug = sanitise_slug(orchard_name)
+    project_slug = sanitise_slug(project_name)
     feature_slug = sanitise_slug(feature_name) + ".json"
-    return f"{METADATA_PREFIX}/{year}/{month}/{orchard_slug}/{feature_slug}"
+    return f"{METADATA_PREFIX}/{year}/{month}/{project_slug}/{feature_slug}"
 
 
 def build_imagery_path(
     feature_name: str,
-    orchard_name: str,
+    project_name: str,
     *,
     timestamp: datetime | None = None,
 ) -> str:
     """Build the blob path for raw imagery (GeoTIFF).
 
-    Format: ``imagery/raw/{YYYY}/{MM}/{orchard-name}/{feature-name}.tif``
+    Format: ``imagery/raw/{YYYY}/{MM}/{project-name}/{feature-name}.tif``
 
     Args:
         feature_name: Feature/Placemark name (will be sanitised).
-        orchard_name: Orchard/project name (will be sanitised).
+        project_name: Project name (will be sanitised).
         timestamp: Processing timestamp. Defaults to current UTC time.
 
     Returns:
@@ -131,24 +131,24 @@ def build_imagery_path(
     ts = timestamp or datetime.now(UTC)
     year = f"{ts.year:04d}"
     month = f"{ts.month:02d}"
-    orchard_slug = sanitise_slug(orchard_name)
+    project_slug = sanitise_slug(project_name)
     feature_slug = sanitise_slug(feature_name) + ".tif"
-    return f"{IMAGERY_RAW_PREFIX}/{year}/{month}/{orchard_slug}/{feature_slug}"
+    return f"{IMAGERY_RAW_PREFIX}/{year}/{month}/{project_slug}/{feature_slug}"
 
 
 def build_clipped_imagery_path(
     feature_name: str,
-    orchard_name: str,
+    project_name: str,
     *,
     timestamp: datetime | None = None,
 ) -> str:
     """Build the blob path for clipped (post-processed) imagery.
 
-    Format: ``imagery/clipped/{YYYY}/{MM}/{orchard-name}/{feature-name}.tif``
+    Format: ``imagery/clipped/{YYYY}/{MM}/{project-name}/{feature-name}.tif``
 
     Args:
         feature_name: Feature/Placemark name (will be sanitised).
-        orchard_name: Orchard/project name (will be sanitised).
+        project_name: Project name (will be sanitised).
         timestamp: Processing timestamp. Defaults to current UTC time.
 
     Returns:
@@ -161,6 +161,6 @@ def build_clipped_imagery_path(
     ts = timestamp or datetime.now(UTC)
     year = f"{ts.year:04d}"
     month = f"{ts.month:02d}"
-    orchard_slug = sanitise_slug(orchard_name)
+    project_slug = sanitise_slug(project_name)
     feature_slug = sanitise_slug(feature_name) + ".tif"
-    return f"{IMAGERY_CLIPPED_PREFIX}/{year}/{month}/{orchard_slug}/{feature_slug}"
+    return f"{IMAGERY_CLIPPED_PREFIX}/{year}/{month}/{project_slug}/{feature_slug}"

--- a/tests/unit/test_blob_paths.py
+++ b/tests/unit/test_blob_paths.py
@@ -5,7 +5,7 @@ Covers:
 - build_kml_archive_path: format, determinism
 - build_metadata_path: format, determinism
 - build_clipped_imagery_path: format, determinism, slug sanitisation
-- Path hierarchy: {prefix}/{YYYY}/{MM}/{orchard-slug}/{name}.{ext}
+- Path hierarchy: {prefix}/{YYYY}/{MM}/{project-slug}/{name}.{ext}
 """
 
 from __future__ import annotations
@@ -95,8 +95,8 @@ class TestBuildKmlArchivePath:
         path = build_kml_archive_path("x.kml", "y", timestamp=ts)
         assert "/2026/03/" in path
 
-    def test_orchard_name_sanitised(self) -> None:
-        """Orchard name with special chars is slugified."""
+    def test_project_name_sanitised(self) -> None:
+        """Project name with special chars is slugified."""
         ts = datetime(2026, 6, 15, tzinfo=UTC)
         path = build_kml_archive_path("f.kml", "O'Brien's Farm!", timestamp=ts)
         assert "obriens-farm" in path
@@ -153,8 +153,8 @@ class TestBuildMetadataPath:
         path = build_metadata_path("Block A (polygon 2)", "Orchard", timestamp=ts)
         assert "block-a-polygon-2" in path
 
-    def test_missing_orchard_name(self) -> None:
-        """Empty orchard name falls back to 'unknown'."""
+    def test_missing_project_name(self) -> None:
+        """Empty project name falls back to 'unknown'."""
         ts = datetime(2026, 1, 1, tzinfo=UTC)
         path = build_metadata_path("F1", "", timestamp=ts)
         assert "/unknown/" in path
@@ -209,8 +209,8 @@ class TestBuildClippedImageryPath:
         path = build_clipped_imagery_path("Block A (polygon 2)", "Orchard", timestamp=ts)
         assert "block-a-polygon-2" in path
 
-    def test_missing_orchard_name(self) -> None:
-        """Empty orchard name falls back to 'unknown'."""
+    def test_missing_project_name(self) -> None:
+        """Empty project name falls back to 'unknown'."""
         ts = datetime(2026, 1, 1, tzinfo=UTC)
         path = build_clipped_imagery_path("F1", "", timestamp=ts)
         assert "/unknown/" in path

--- a/tests/unit/test_download_imagery.py
+++ b/tests/unit/test_download_imagery.py
@@ -69,7 +69,7 @@ class TestDownloadImagery(unittest.TestCase):
 
         result = download_imagery(
             _SAMPLE_OUTCOME,
-            orchard_name="Test Orchard",
+            project_name="Test Orchard",
             timestamp="2026-03-15T12:00:00+00:00",
         )
 
@@ -92,7 +92,7 @@ class TestDownloadImagery(unittest.TestCase):
 
         result = download_imagery(
             _SAMPLE_OUTCOME,
-            orchard_name="Alpha Orchard",
+            project_name="Alpha Orchard",
             timestamp="2026-03-15T12:00:00+00:00",
         )
 
@@ -174,8 +174,8 @@ class TestDownloadImagery(unittest.TestCase):
         assert ctx.exception.retryable is False
 
     @patch("kml_satellite.activities.download_imagery.get_provider")
-    def test_default_orchard_name(self, mock_get_provider: MagicMock) -> None:
-        """Missing orchard_name defaults to 'unknown' in blob path."""
+    def test_default_project_name(self, mock_get_provider: MagicMock) -> None:
+        """Missing project_name defaults to 'unknown' in blob path."""
         mock_provider = MagicMock()
         mock_provider.download.return_value = _make_blob_ref()
         mock_get_provider.return_value = mock_provider
@@ -199,7 +199,7 @@ class TestDownloadImagery(unittest.TestCase):
 
         result = download_imagery(
             outcome,
-            orchard_name="orchard",
+            project_name="orchard",
             timestamp="2026-06-01T00:00:00+00:00",
         )
 
@@ -237,7 +237,7 @@ class TestDownloadImagery(unittest.TestCase):
 
         result = download_imagery(
             _SAMPLE_OUTCOME,
-            orchard_name="Test Orchard",
+            project_name="Test Orchard",
             timestamp="2026-03-15T12:00:00+00:00",
         )
 

--- a/tests/unit/test_metadata_model.py
+++ b/tests/unit/test_metadata_model.py
@@ -21,7 +21,7 @@ from kml_satellite.models.metadata import (
     GeometryMetadata,
     ImageryMetadata,
     ProcessingMetadata,
-    _extract_orchard_name,
+    _extract_project_name,
 )
 
 # ---------------------------------------------------------------------------
@@ -82,11 +82,11 @@ class TestFromAOI:
         record = AOIMetadataRecord.from_aoi(_make_aoi())
         assert record.schema_version == SCHEMA_VERSION
 
-    def test_orchard_name_from_metadata(self) -> None:
-        """Orchard name is extracted from metadata."""
+    def test_project_name_from_metadata(self) -> None:
+        """Project name is extracted from metadata."""
         aoi = _make_aoi(metadata={"orchard_name": "Beta Ranch"})
         record = AOIMetadataRecord.from_aoi(aoi)
-        assert record.orchard_name == "Beta Ranch"
+        assert record.project_name == "Beta Ranch"
 
     def test_tree_variety_from_metadata(self) -> None:
         """Tree variety is extracted from metadata key."""
@@ -269,7 +269,7 @@ class TestSchemaValidation:
             "processing_id": "test-456",
             "kml_filename": "test.kml",
             "feature_name": "Plot 1",
-            "orchard_name": "Test Orchard",
+            "project_name": "Test Orchard",
             "tree_variety": "Cherry",
             "geometry": {
                 "type": "Polygon",
@@ -297,37 +297,37 @@ class TestSchemaValidation:
 # ===========================================================================
 
 
-class TestOrchardNameExtraction:
-    """Test the _extract_orchard_name helper."""
-
-    def test_from_orchard_name_key(self) -> None:
-        """Uses 'orchard_name' metadata key first."""
-        name = _extract_orchard_name({"orchard_name": "Alpha"}, "fallback.kml")
-        assert name == "Alpha"
+class TestProjectNameExtraction:
+    """Test the _extract_project_name helper."""
 
     def test_from_project_name_key(self) -> None:
-        """Falls back to 'project_name' metadata key."""
-        name = _extract_orchard_name({"project_name": "Beta Project"}, "fallback.kml")
-        assert name == "Beta Project"
+        """Uses 'project_name' metadata key first."""
+        name = _extract_project_name({"project_name": "Alpha"}, "fallback.kml")
+        assert name == "Alpha"
+
+    def test_from_orchard_name_key(self) -> None:
+        """Falls back to 'orchard_name' metadata key."""
+        name = _extract_project_name({"orchard_name": "Beta Ranch"}, "fallback.kml")
+        assert name == "Beta Ranch"
 
     def test_from_filename(self) -> None:
         """Falls back to filename stem when metadata is empty."""
-        name = _extract_orchard_name({}, "my_orchard.kml")
+        name = _extract_project_name({}, "my_orchard.kml")
         assert name == "my_orchard"
 
     def test_empty_metadata_and_file(self) -> None:
         """Returns 'unknown' when both metadata and filename are empty."""
-        name = _extract_orchard_name({}, "")
+        name = _extract_project_name({}, "")
         assert name == "unknown"
 
     def test_whitespace_only_value(self) -> None:
         """Whitespace-only metadata values are treated as empty."""
-        name = _extract_orchard_name({"orchard_name": "  "}, "backup.kml")
+        name = _extract_project_name({"orchard_name": "  "}, "backup.kml")
         assert name == "backup"
 
-    def test_orchard_name_takes_priority(self) -> None:
-        """orchard_name is preferred over project_name."""
-        name = _extract_orchard_name(
-            {"orchard_name": "First", "project_name": "Second"}, "file.kml"
+    def test_project_name_takes_priority(self) -> None:
+        """project_name is preferred over orchard_name."""
+        name = _extract_project_name(
+            {"orchard_name": "Second", "project_name": "First"}, "file.kml"
         )
         assert name == "First"

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -503,8 +503,8 @@ class TestOrchestratorFunction:
         assert dl[0]["state"] == "failed"
         assert "Download exploded" in str(dl[0]["error"])
 
-    def test_orchard_name_from_blob_filename(self) -> None:
-        """Orchestrator derives orchard_name from blob_name stem."""
+    def test_project_name_from_blob_filename(self) -> None:
+        """Orchestrator derives project_name from blob_name stem."""
         context = _make_context(_sample_blob_event())
         _run_orchestrator(
             context,
@@ -516,7 +516,7 @@ class TestOrchestratorFunction:
         ]
         assert len(dl_calls) == 1
         # blob_name="orchard.kml" → stem="orchard"
-        assert dl_calls[0][0][1]["orchard_name"] == "orchard"
+        assert dl_calls[0][0][1]["project_name"] == "orchard"
 
     def test_calls_post_process_per_download(self) -> None:
         """Orchestrator calls post_process_imagery for each successful download."""

--- a/tests/unit/test_phases.py
+++ b/tests/unit/test_phases.py
@@ -324,7 +324,7 @@ class TestFulfillmentPhase:
             aois,
             provider_name="planetary_computer",
             provider_config=None,
-            orchard_name="test-orchard",
+            project_name="test-orchard",
             timestamp="2026-02-17T12:00:00+00:00",
             instance_id=instance_id or context.instance_id,
             blob_name=blob_name,
@@ -384,7 +384,7 @@ class TestFulfillmentPhase:
             aois,
             provider_name="planetary_computer",
             provider_config=None,
-            orchard_name="test",
+            project_name="test",
             timestamp="2026-02-17T12:00:00+00:00",
         )
         next(gen)  # download batch yield
@@ -407,7 +407,7 @@ class TestFulfillmentPhase:
             [],
             provider_name="pc",
             provider_config=None,
-            orchard_name="test",
+            project_name="test",
             timestamp="2026-02-17T12:00:00+00:00",
         )
         try:
@@ -436,7 +436,7 @@ class TestFulfillmentPhase:
             aois,
             provider_name="pc",
             provider_config=None,
-            orchard_name="test",
+            project_name="test",
             timestamp="2026-02-17T12:00:00+00:00",
         )
         next(gen)  # download batch yield

--- a/tests/unit/test_post_process_imagery.py
+++ b/tests/unit/test_post_process_imagery.py
@@ -119,7 +119,7 @@ class TestPostProcessImagery(unittest.TestCase):
         result = post_process_imagery(
             dict(_SAMPLE_DOWNLOAD_RESULT),
             dict(_SAMPLE_AOI),
-            orchard_name="Orchard",
+            project_name="Orchard",
             timestamp="2026-03-15T12:00:00+00:00",
         )
 
@@ -145,7 +145,7 @@ class TestPostProcessImagery(unittest.TestCase):
         result = post_process_imagery(
             dict(_SAMPLE_DOWNLOAD_RESULT),
             dict(_SAMPLE_AOI),
-            orchard_name="Alpha Orchard",
+            project_name="Alpha Orchard",
             timestamp="2026-03-15T12:00:00+00:00",
         )
 
@@ -283,8 +283,8 @@ class TestPostProcessImagery(unittest.TestCase):
         assert result["target_crs"] == "EPSG:32756"
 
     @patch("kml_satellite.activities.post_process_imagery._process_raster")
-    def test_default_orchard_becomes_unknown(self, mock_process: MagicMock) -> None:
-        """Missing orchard_name defaults to 'unknown' in path."""
+    def test_default_project_becomes_unknown(self, mock_process: MagicMock) -> None:
+        """Missing project_name defaults to 'unknown' in path."""
         mock_process.return_value = {
             "clipped": True,
             "reprojected": False,
@@ -321,7 +321,7 @@ class TestPostProcessImagery(unittest.TestCase):
         post_process_imagery(
             dict(_SAMPLE_DOWNLOAD_RESULT),
             aoi,
-            orchard_name="orchard",
+            project_name="orchard",
             timestamp="2026-06-01T00:00:00+00:00",
         )
 

--- a/tests/unit/test_write_metadata.py
+++ b/tests/unit/test_write_metadata.py
@@ -134,13 +134,13 @@ class TestWriteMetadataLocal:
         # Should still have a non-empty timestamp
         assert proc["timestamp"] != ""
 
-    def test_orchard_name_derived_from_metadata(self) -> None:
+    def test_project_name_derived_from_metadata(self) -> None:
         """Orchard name in path is derived from AOI metadata."""
         aoi = _make_aoi(metadata={"orchard_name": "Sunset Valley"})
         result = write_metadata(aoi, timestamp="2026-06-15T00:00:00+00:00")
         assert "sunset-valley" in result["metadata_path"]
 
-    def test_orchard_name_from_filename(self) -> None:
+    def test_project_name_from_filename(self) -> None:
         """Orchard name falls back to filename when metadata is empty."""
         aoi = _make_aoi(source_file="my_farm.kml", metadata={})
         result = write_metadata(aoi, timestamp="2026-06-15T00:00:00+00:00")
@@ -219,7 +219,7 @@ class TestSchemaConformance:
             "processing_id",
             "kml_filename",
             "feature_name",
-            "orchard_name",
+            "project_name",
             "tree_variety",
             "geometry",
             "imagery",


### PR DESCRIPTION
## Summary

Renames the domain-specific `orchard_name` identifier to the generic `project_name` throughout the codebase, aligning with the v2.0 multi-tenant SaaS pivot described in PID.md.

Closes #67

## Changes

**Source code (10 files):**
- `kml_satellite/utils/blob_paths.py` — All 4 path builder functions: parameter `orchard_name` → `project_name`, internal var `orchard_slug` → `project_slug`, docstrings updated
- `kml_satellite/models/metadata.py` — Field `orchard_name` → `project_name` on `AOIMetadataRecord`; helper renamed `_extract_orchard_name()` → `_extract_project_name()`; **priority flipped** so `project_name` is checked first with `orchard_name` as backward-compat fallback
- `kml_satellite/models/payloads.py` — `DownloadImageryInput` and `PostProcessImageryInput` TypedDict fields renamed
- `kml_satellite/models/contracts.py` — `DownloadImageryInput` and `PostProcessInput` TypedDict fields renamed
- `kml_satellite/activities/download_imagery.py` — Parameter renamed
- `kml_satellite/activities/post_process_imagery.py` — Parameter renamed
- `kml_satellite/activities/write_metadata.py` — Field access updated
- `kml_satellite/orchestrators/kml_pipeline.py` — Variable and kwarg renamed
- `kml_satellite/orchestrators/phases.py` — Parameter and payload dict keys renamed
- `function_app.py` — Activity wrapper parameter names updated

**Test files (7 files):**
- `test_blob_paths.py`, `test_metadata_model.py`, `test_download_imagery.py`, `test_orchestrator.py`, `test_phases.py`, `test_post_process_imagery.py`, `test_write_metadata.py` — All references updated to match source changes

**Documentation (1 file):**
- `DEFENSIVE_CODE_REVIEW.md` — Function reference updated

## Backward Compatibility

- `_extract_project_name()` still reads the `"orchard_name"` key from KML metadata dicts as a fallback, so existing KML files with `orchard_name` in their ExtendedData will continue to work
- KML test data files are deliberately unchanged — they represent real-world input

## Verification

- ✅ `ruff check` — All checks passed
- ✅ `pyright` — 0 errors, 0 warnings
- ✅ `pytest tests/unit` — 711 passed
- ✅ All pre-commit hooks passed

**18 files changed, 110 insertions(+), 110 deletions(−)**