### PR TITLE
fix: use sku flexconsumption and remote-build for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,15 +62,14 @@ jobs:
           mkdir -p .deploy
           cp function_app.py host.json requirements.txt .deploy/
           cp -r kml_satellite .deploy/
-          cd .deploy
-          pip install -r requirements.txt --target=".python_packages/lib/site-packages" --quiet
-          zip -r ../deploy.zip .
 
       - name: Deploy to Azure Functions
         uses: azure/functions-action@v1
         with:
           app-name: ${{ env.FUNCTION_APP_NAME }}
-          package: deploy.zip
+          package: .deploy
+          sku: flexconsumption
+          remote-build: true
 
       - name: Wait for functions to be discoverable
         run: |


### PR DESCRIPTION
## Problem

All 21 deploy workflow runs have failed with:
```
No functions detected after 5 minutes
```

The `azure/functions-action@v1` was not configured for Flex Consumption deployment. Without the `sku: flexconsumption` parameter, the action uses standard zip deploy which is incompatible with Flex Consumption's blob-based deployment model. The deployment package was uploaded but the function host could never discover the functions.

## Root Cause

Flex Consumption function apps require:
1. `sku: flexconsumption` — tells the action to use the correct deployment mechanism
2. `remote-build: true` — lets Azure's build environment handle native Python dependencies (GDAL, rasterio, fiona) rather than pre-installing them locally on ubuntu-latest

## Changes

- **deploy.yml**: Add `sku: flexconsumption` and `remote-build: true` to `azure/functions-action@v1`
- **deploy.yml**: Remove local `pip install --target` step (remote-build handles dependency installation)
- **test_deploy_workflow.py**: Update test assertions from checking for local pip install to validating `sku: flexconsumption` and `remote-build: true`

## Test Results

All 790 unit tests pass.