### PR TITLE
fix: pre-install Python deps in deploy package instead of remote-build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,14 +62,13 @@ jobs:
           mkdir -p .deploy
           cp function_app.py host.json requirements.txt .deploy/
           cp -r kml_satellite .deploy/
+          pip install -r requirements.txt --target ".deploy/.python_packages/lib/site-packages"
 
       - name: Deploy to Azure Functions
         uses: azure/functions-action@v1
         with:
           app-name: ${{ env.FUNCTION_APP_NAME }}
           package: .deploy
-          sku: flexconsumption
-          remote-build: true
 
       - name: Wait for functions to be discoverable
         run: |


### PR DESCRIPTION
## Problem

Deploy workflow fails with "No functions detected after 5 minutes" (runs #21, #22). The `azure/functions-action` with `remote-build: true` was not correctly installing Python dependencies, causing the function host to fail silently when importing `function_app.py`.

## Root Cause

The [official `azure/functions-action` Python Flex Consumption template](https://github.com/Azure/functions-action/blob/master/.github/workflows/test-workflow-python310-flexcon.yaml) does **not** use `remote-build`. Instead, it pre-installs dependencies into `.python_packages/lib/site-packages` during the build step:

```yaml
pip install -r requirements.txt --target ".python_packages/lib/site-packages"
```

The `remote-build: true` approach (PR #94) either wasn't triggering correctly for Flex Consumption or the Oryx build environment couldn't resolve the native dependencies.

## Changes

- **deploy.yml**: Replace `sku: flexconsumption` + `remote-build: true` with `pip install --target` to pre-install deps into the deployment package
- **test_deploy_workflow.py**: Update tests to verify the new approach — assert pip install to `.python_packages/lib/site-packages` and no `remote-build`

## Evidence

The [parameter reference docs](https://github.com/Azure/functions-action#parameter-reference) confirm:
- `sku` is only required with `publish-profile` auth (we use OIDC — auto-resolved)
- `remote-build` defaults to `false`; the official Python Flex Consumption workflow doesn't use it

The [Flex Consumption deployment docs](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-how-to) state the deployment package must contain "all build output files **and referenced libraries** required for your project to run."