### PR TITLE
fix: broaden Event Grid filter for multi-tenant container routing

### DIFF
--- a/infra/modules/event-grid.bicep
+++ b/infra/modules/event-grid.bicep
@@ -1,6 +1,8 @@
 // ---------------------------------------------------------------------------
 // Event Grid — System Topic on Storage Account + Subscription for .kml files
-// Triggers the Function App when a blob is created in kml-input container.
+// Triggers the Function App when a .kml blob is created in any container.
+// Container-level routing is handled by the trigger function's code-level
+// validation (endsWith("-input")), not by the Event Grid filter.
 // ---------------------------------------------------------------------------
 
 @description('Azure region for Event Grid resources.')
@@ -35,8 +37,10 @@ resource systemTopic 'Microsoft.EventGrid/systemTopics@2024-06-01-preview' = {
 }
 
 // ---------------------------------------------------------------------------
-// Event Subscription — filters for .kml files in kml-input container
-// Delivers to the Function App's Event Grid trigger endpoint.
+// Event Subscription — filters for .kml files in any container.
+// Container-level routing (e.g. *-input) is enforced by the Function App
+// trigger code, not by Event Grid. This allows multi-tenant container
+// pairs (e.g. acme-input, woodland-trust-input) without IaC changes.
 // ---------------------------------------------------------------------------
 resource eventSubscription 'Microsoft.EventGrid/systemTopics/eventSubscriptions@2024-06-01-preview' = if (enableSubscription) {
   parent: systemTopic
@@ -54,7 +58,6 @@ resource eventSubscription 'Microsoft.EventGrid/systemTopics/eventSubscriptions@
       includedEventTypes: [
         'Microsoft.Storage.BlobCreated'
       ]
-      subjectBeginsWith: '/blobServices/default/containers/kml-input/'
       subjectEndsWith: '.kml'
       isSubjectCaseSensitive: false
     }

--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -1,6 +1,8 @@
 // ---------------------------------------------------------------------------
 // Storage Account — GPv2, Hot tier
-// Two containers: kml-input (Event Grid source) and kml-output (processed)
+// Default containers: kml-input / kml-output for single-tenant and local dev.
+// Multi-tenant containers ({tenant_id}-input / {tenant_id}-output) are
+// provisioned dynamically by the tenant provisioning service (#72).
 // ---------------------------------------------------------------------------
 
 @description('Azure region for the storage account.')
@@ -43,6 +45,8 @@ resource blobServices 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01
   name: 'default'
 }
 
+// Default input container — used for single-tenant mode and local development.
+// Tenant-specific containers are provisioned dynamically (#72).
 resource kmlInputContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
   parent: blobServices
   name: 'kml-input'
@@ -51,6 +55,8 @@ resource kmlInputContainer 'Microsoft.Storage/storageAccounts/blobServices/conta
   }
 }
 
+// Default output container — used for single-tenant mode and local development.
+// Tenant-specific containers are provisioned dynamically (#72).
 resource kmlOutputContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
   parent: blobServices
   name: 'kml-output'
@@ -67,7 +73,10 @@ resource deploymentsContainer 'Microsoft.Storage/storageAccounts/blobServices/co
   }
 }
 
-// Lifecycle management — archive old imagery, delete old logs
+// Lifecycle management — archive old imagery, delete old logs.
+// These rules target the default kml-output container. Per-tenant lifecycle
+// policies are created during tenant provisioning (#72) to cover
+// {tenant_id}-output/imagery/raw/ prefixes.
 resource lifecyclePolicy 'Microsoft.Storage/storageAccounts/managementPolicies@2023-05-01' = {
   parent: storageAccount
   name: 'default'

--- a/kml_satellite/core/config.py
+++ b/kml_satellite/core/config.py
@@ -79,8 +79,12 @@ class PipelineConfig:
                 parsed (e.g. ``AOI_BUFFER_M=abc``).
         """
         config = cls(
-            kml_input_container=os.getenv("KML_INPUT_CONTAINER", "kml-input"),
-            kml_output_container=os.getenv("KML_OUTPUT_CONTAINER", "kml-output"),
+            kml_input_container=os.getenv(
+                "DEFAULT_INPUT_CONTAINER", os.getenv("KML_INPUT_CONTAINER", "kml-input")
+            ),
+            kml_output_container=os.getenv(
+                "DEFAULT_OUTPUT_CONTAINER", os.getenv("KML_OUTPUT_CONTAINER", "kml-output")
+            ),
             imagery_provider=os.getenv("IMAGERY_PROVIDER", "planetary_computer"),
             imagery_resolution_target_m=float(os.getenv("IMAGERY_RESOLUTION_TARGET_M", "0.5")),
             imagery_max_cloud_cover_pct=float(os.getenv("IMAGERY_MAX_CLOUD_COVER_PCT", "20")),
@@ -124,14 +128,14 @@ def _validate(config: PipelineConfig) -> None:
 
     if not config.kml_input_container:
         raise ConfigValidationError(
-            "KML_INPUT_CONTAINER",
+            "DEFAULT_INPUT_CONTAINER",
             config.kml_input_container,
             "must not be empty",
         )
 
     if not config.kml_output_container:
         raise ConfigValidationError(
-            "KML_OUTPUT_CONTAINER",
+            "DEFAULT_OUTPUT_CONTAINER",
             config.kml_output_container,
             "must not be empty",
         )

--- a/local.settings.json.template
+++ b/local.settings.json.template
@@ -5,8 +5,8 @@
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "FUNCTIONS_EXTENSION_VERSION": "~4",
 
-    "KML_INPUT_CONTAINER": "kml-input",
-    "KML_OUTPUT_CONTAINER": "kml-output",
+    "DEFAULT_INPUT_CONTAINER": "kml-input",
+    "DEFAULT_OUTPUT_CONTAINER": "kml-output",
 
     "IMAGERY_PROVIDER": "planetary_computer",
     "IMAGERY_RESOLUTION_TARGET_M": "0.5",

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -56,8 +56,8 @@ class TestPipelineConfigFromEnv:
     def test_loads_from_environment(self) -> None:
         """All env vars are read and coerced to correct types."""
         env = {
-            "KML_INPUT_CONTAINER": "custom-input",
-            "KML_OUTPUT_CONTAINER": "custom-output",
+            "DEFAULT_INPUT_CONTAINER": "custom-input",
+            "DEFAULT_OUTPUT_CONTAINER": "custom-output",
             "IMAGERY_PROVIDER": "skywatch",
             "IMAGERY_RESOLUTION_TARGET_M": "2.0",
             "IMAGERY_MAX_CLOUD_COVER_PCT": "30",
@@ -175,15 +175,15 @@ class TestPipelineConfigValidation:
 
     def test_empty_input_container_rejected(self) -> None:
         with (
-            patch.dict(os.environ, {"KML_INPUT_CONTAINER": ""}, clear=True),
-            pytest.raises(ConfigValidationError, match="KML_INPUT_CONTAINER"),
+            patch.dict(os.environ, {"DEFAULT_INPUT_CONTAINER": ""}, clear=True),
+            pytest.raises(ConfigValidationError, match="DEFAULT_INPUT_CONTAINER"),
         ):
             PipelineConfig.from_env()
 
     def test_empty_output_container_rejected(self) -> None:
         with (
-            patch.dict(os.environ, {"KML_OUTPUT_CONTAINER": ""}, clear=True),
-            pytest.raises(ConfigValidationError, match="KML_OUTPUT_CONTAINER"),
+            patch.dict(os.environ, {"DEFAULT_OUTPUT_CONTAINER": ""}, clear=True),
+            pytest.raises(ConfigValidationError, match="DEFAULT_OUTPUT_CONTAINER"),
         ):
             PipelineConfig.from_env()
 


### PR DESCRIPTION
## Summary

Broaden the Event Grid subscription filter so `.kml` uploads in **any** container trigger the pipeline — not just the static `kml-input` container. This is required for multi-tenant support where each tenant gets their own container pair (e.g. `acme-input`, `woodland-trust-input`).

## What changed

### Infrastructure
- **`event-grid.bicep`** — Removed `subjectBeginsWith: '/blobServices/default/containers/kml-input/'` filter. Only `subjectEndsWith: '.kml'` remains. Container-level routing is handled by the trigger function's code-level validation (`endsWith("-input")`).
- **`storage.bicep`** — Added documentation comments clarifying that `kml-input`/`kml-output` are default containers for single-tenant/local dev, and that tenant-specific containers are provisioned dynamically (#72).

### Application
- **`config.py`** — Renamed env vars to `DEFAULT_INPUT_CONTAINER` / `DEFAULT_OUTPUT_CONTAINER` with backward-compatible fallback to old `KML_INPUT_CONTAINER` / `KML_OUTPUT_CONTAINER` names.
- **`local.settings.json.template`** — Updated env var names.

### Tests
- **`test_config.py`** — Updated to use new env var names.

## Why this is safe
The Event Grid filter removal doesn't compromise security — it only determines which blob events are delivered to the Function App. The trigger function already validates container names in code before processing, which is the correct enforcement point for multi-tenant routing.

Fixes #70