### PR TITLE
fix: use transitive deps for runtime GDAL libs in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,12 +32,11 @@ RUN pip install --no-cache-dir --target=/home/site/wwwroot/.python_packages/lib/
 # ---------------------------------------------------------------------------
 FROM mcr.microsoft.com/azure-functions/python:4-python3.12
 
-# Install only the runtime GDAL libraries (no build tools)
+# Install only the runtime GDAL/GEOS/PROJ libraries (no build tools).
+# gdal-bin transitively pulls the correct versioned libgdal, libgeos, and
+# libproj for whichever Debian release the base image ships.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gdal-bin \
-    libgdal34 \
-    libgeos3.12.1 \
-    libproj25 \
     libxml2 \
     libxslt1.1 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

Fix Docker build failure caused by hardcoded version-specific package names that don't exist in the base image's Debian repos.

## Problem

The runtime stage installed `libgdal34`, `libgeos3.12.1`, and `libproj25` — these are version-specific package names that don't exist in the `mcr.microsoft.com/azure-functions/python:4-python3.12` base image (Bookworm).

Deploy run: https://github.com/Hardcoreprawn/azure-workflow-for-kml-satellite/actions/runs/22266010408

## Fix

Replace hardcoded packages with `gdal-bin`, which transitively pulls the correct versioned `libgdal`, `libgeos`, and `libproj` runtime libraries for whichever Debian release the base image ships. This makes the Dockerfile resilient to base image updates.