### PR TITLE
chore: add workflow_dispatch trigger to infra workflow

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -13,6 +13,7 @@
 name: Infrastructure
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
Add `workflow_dispatch` trigger to the infrastructure workflow so it can be re-run manually without needing a code change to `infra/` files.

Needed now because the existing Function App had to be deleted (can't convert FC1 → Container Apps in-place) and the infra workflow needs to recreate it.