### PR TITLE
fix: allow infra deploy job on workflow_dispatch events

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -52,7 +52,7 @@ jobs:
   deploy-dev:
     name: Deploy (Dev)
     needs: validate
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     environment: dev
     steps:


### PR DESCRIPTION
The `deploy-dev` job condition was `github.event_name == 'push'` only, so manually triggered `workflow_dispatch` runs would validate Bicep but skip actual deployment. This meant our manual infra re-run after deleting the old Function App didn't actually deploy anything.