### PR TITLE
Hotfix: Correct metric alert aggregation for failed requests

### DIFF
--- a/infra/modules/monitoring.bicep
+++ b/infra/modules/monitoring.bicep
@@ -65,7 +65,7 @@ resource failedRequestsAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
           metricName: 'requests/failed'
           operator: 'GreaterThan'
           threshold: 5
-          timeAggregation: 'Total'
+          timeAggregation: 'Count'
           criterionType: 'StaticThresholdCriterion'
         }
       ]

--- a/tests/unit/test_infrastructure.py
+++ b/tests/unit/test_infrastructure.py
@@ -428,6 +428,20 @@ class TestMonitoringModule:
             scope_text = " ".join(str(s) for s in scopes)
             assert "Microsoft.Insights/components" in scope_text
 
+    def test_failed_requests_alert_uses_count_aggregation(
+        self, monitoring_arm_template: dict[str, Any]
+    ) -> None:
+        """Failed requests alert must use Count aggregation for requests/failed metric."""
+        alerts = _get_resources_by_type(monitoring_arm_template, "Microsoft.Insights/metricAlerts")
+        assert alerts, "Expected at least one metric alert"
+        failed_alerts = [a for a in alerts if "failed-requests" in str(a.get("name", "")).lower()]
+        assert failed_alerts, "Expected failed requests metric alert"
+        criteria = failed_alerts[0].get("properties", {}).get("criteria", {}).get("allOf", [])
+        assert criteria, "Failed requests alert must define criteria"
+        criterion = criteria[0]
+        assert criterion.get("metricName") == "requests/failed"
+        assert criterion.get("timeAggregation") == "Count"
+
 
 # ---------------------------------------------------------------------------
 # Test: Key Vault module


### PR DESCRIPTION
Fixes Azure deployment failure by changing monitoring alert timeAggregation for requests/failed from Total to Count and adds a regression test in tests/unit/test_infrastructure.py.