### PR TITLE
Follow-up: retry-safe Event Grid enablement after function deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,22 +140,48 @@ jobs:
             sleep 10
           done
           if ! echo "$function_names" | grep -q '/kml_blob_trigger$'; then
-            echo "::error::kml_blob_trigger not discoverable after 5 minutes"
+            echo "::warning::kml_blob_trigger not discoverable after 5 minutes; continuing to Event Grid enable retries"
             if [ -n "$last_error" ]; then
-              echo "::error::Last az CLI error: $last_error"
+              echo "::warning::Last az CLI error during discovery: $last_error"
+            fi
+          fi
+
+      - name: Enable Event Grid subscription (retry until endpoint validates)
+        run: |
+          success=0
+          last_error=""
+          for i in $(seq 1 20); do
+            set +e
+            deploy_output=$(az deployment sub create \
+              --location ${{ vars.AZURE_LOCATION || 'uksouth' }} \
+              --template-file infra/main.bicep \
+              --parameters infra/parameters/dev.bicepparam \
+              --parameters enableEventGridSubscription=true \
+              --parameters containerImage='${{ steps.image.outputs.name }}' \
+              --name "deploy-eg-$(date +%Y%m%d-%H%M%S)-$i" 2>&1)
+            deploy_status=$?
+            set -e
+
+            if [ "$deploy_status" -eq 0 ]; then
+              echo "✔ Event Grid subscription enabled after attempt $i/20"
+              success=1
+              break
+            fi
+
+            last_error="$deploy_output"
+            echo "  attempt $i/20 — Event Grid enablement not ready, retrying in 15s…"
+            echo "$deploy_output" | tail -n 8
+            sleep 15
+          done
+
+          if [ "$success" -ne 1 ]; then
+            echo "::error::Failed to enable Event Grid subscription after 20 attempts"
+            if [ -n "$last_error" ]; then
+              echo "::error::Last deployment error:"
+              echo "$last_error"
             fi
             exit 1
           fi
-
-      - name: Enable Event Grid subscription (post-function-discovery)
-        run: |
-          az deployment sub create \
-            --location ${{ vars.AZURE_LOCATION || 'uksouth' }} \
-            --template-file infra/main.bicep \
-            --parameters infra/parameters/dev.bicepparam \
-            --parameters enableEventGridSubscription=true \
-            --parameters containerImage='${{ steps.image.outputs.name }}' \
-            --name "deploy-eg-$(date +%Y%m%d-%H%M%S)"
 
       - name: Verify Event Grid subscription exists
         run: |

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ For Azure Functions on Container Apps, infrastructure dependencies alone are not
 Required deployment order:
 
 1. Deploy infra + Function App container image with `enableEventGridSubscription=false`.
-2. Poll function discovery until `kml_blob_trigger` appears in `az functionapp function list`.
-3. Re-apply infra with `enableEventGridSubscription=true`.
+2. Poll function discovery (`az functionapp function list`) as telemetry.
+3. Re-apply infra with `enableEventGridSubscription=true` using retry-on-validation-failure.
 4. Verify `evgs-kml-upload` subscription exists on `evgt-<baseName>`.
 
 This sequencing is enforced in [.github/workflows/deploy.yml](.github/workflows/deploy.yml) to prevent race conditions where Event Grid fails with "validation request did not receive expected response."

--- a/tests/unit/test_deploy_workflow.py
+++ b/tests/unit/test_deploy_workflow.py
@@ -197,14 +197,14 @@ class TestReadinessCheck:
         has_sleep = "sleep" in run_script
         assert has_loop and has_sleep, "Readiness check must include a retry loop with sleep"
 
-    def test_readiness_has_failure_exit(self, deploy_workflow: dict[str, Any]) -> None:
-        """Readiness check must fail the workflow if functions never appear."""
+    def test_readiness_does_not_hard_fail(self, deploy_workflow: dict[str, Any]) -> None:
+        """Readiness check should be advisory; Event Grid enable step handles hard failure."""
         steps = _get_steps(deploy_workflow)
         readiness = _find_step(steps, "wait") or _find_step(steps, "discoverable")
         assert readiness is not None
         run_script = readiness.get("run", "")
-        assert "exit 1" in run_script, (
-            "Readiness check must 'exit 1' if functions are never detected"
+        assert "::warning::kml_blob_trigger not discoverable" in run_script, (
+            "Readiness check should emit warning if trigger is not yet discoverable"
         )
 
     def test_event_grid_uses_two_pass_toggle(self, deploy_workflow: dict[str, Any]) -> None:
@@ -226,3 +226,15 @@ class TestReadinessCheck:
         assert "enableEventGridSubscription=true" in second_run, (
             "Second pass must set enableEventGridSubscription=true"
         )
+
+    def test_event_grid_enable_has_retry_and_failure_exit(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        """Event Grid enable step must retry and fail if endpoint never validates."""
+        steps = _get_steps(deploy_workflow)
+        second_pass = _find_step(steps, "enable event grid subscription")
+        assert second_pass is not None, "Second-pass Event Grid enable step not found"
+        run_script = second_pass.get("run", "")
+        assert "for i in $(seq" in run_script, "Enable step must include retry loop"
+        assert "sleep 15" in run_script, "Enable step must back off between retries"
+        assert "exit 1" in run_script, "Enable step must fail after exhausting retries"


### PR DESCRIPTION
Follow-up to merged PR #112.

This includes the additional robustness fix that landed after #112 merged:
- Readiness polling is advisory telemetry (no hard fail)
- Event Grid enablement deployment retries up to 20 attempts with backoff
- Hard failure occurs only after retries are exhausted
- Unit tests updated to enforce this contract

This avoids false negatives when function indexing lags while still failing deterministically if Event Grid endpoint validation never succeeds.