### PR TITLE
fix: add missing pydantic dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pyproj>=3.7.0
 rasterio>=1.4.0
 pystac-client>=0.8.0
 httpx>=0.28.0
+pydantic>=2.0.0


### PR DESCRIPTION
Adds pydantic>=2.0.0 to requirements.txt - discovered during deployment testing when write_metadata activity failed with ModuleNotFoundError.