### PR TITLE
Fix canonical blob path materialization after download

### DIFF
--- a/kml_satellite/activities/download_imagery.py
+++ b/kml_satellite/activities/download_imagery.py
@@ -29,6 +29,7 @@ References:
 from __future__ import annotations
 
 import logging
+import os
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -153,6 +154,14 @@ def download_imagery(
         timestamp=ts,
     )
 
+    # Ensure the canonical blob path exists for downstream consumers.
+    _promote_blob_to_canonical_path(
+        container=blob_ref.container,
+        source_blob_path=blob_ref.blob_path,
+        canonical_blob_path=blob_path,
+        order_id=order_id,
+    )
+
     logger.info(
         "download_imagery completed | order=%s | scene=%s | feature=%s | "
         "blob_path=%s | size=%d bytes | duration=%.2fs | retries=%d",
@@ -239,6 +248,81 @@ def _download_with_retry(
 
     msg = f"Download failed after {max_retries + 1} attempts: {last_error}"
     raise DownloadError(msg, retryable=False) from last_error
+
+
+def _promote_blob_to_canonical_path(
+    *,
+    container: str,
+    source_blob_path: str,
+    canonical_blob_path: str,
+    order_id: str,
+) -> None:
+    """Promote provider blob to canonical path when needed.
+
+    Provider adapters may persist to a staging path (e.g. scene-based).
+    This helper copies the blob to the canonical project/date/feature path
+    so downstream steps read a stable, contract-compliant location.
+
+    Raises:
+        DownloadError: If canonicalization cannot be completed.
+    """
+    if source_blob_path == canonical_blob_path:
+        return
+
+    connection_string = os.environ.get("AzureWebJobsStorage", "")  # noqa: SIM112
+    if not connection_string:
+        logger.warning(
+            "Skipping canonical blob promotion (no AzureWebJobsStorage) | "
+            "order=%s | source=%s | canonical=%s",
+            order_id,
+            source_blob_path,
+            canonical_blob_path,
+        )
+        return
+
+    try:
+        from azure.storage.blob import BlobServiceClient
+
+        blob_service = BlobServiceClient.from_connection_string(connection_string)
+        source_client = blob_service.get_blob_client(container=container, blob=source_blob_path)
+        canonical_client = blob_service.get_blob_client(container=container, blob=canonical_blob_path)
+
+        if not source_client.exists():
+            msg = (
+                "Source blob missing during canonical promotion "
+                f"| order={order_id} | container={container} | blob={source_blob_path}"
+            )
+            raise DownloadError(msg, retryable=True)
+
+        source_props = source_client.get_blob_properties()
+        source_content_type = source_props.content_settings.content_type or "image/tiff"
+        stream = source_client.download_blob()
+
+        canonical_client.upload_blob(
+            stream.chunks(),
+            overwrite=True,
+            content_type=source_content_type,
+        )
+
+        if not canonical_client.exists():
+            msg = (
+                "Canonical blob write verification failed "
+                f"| order={order_id} | container={container} | blob={canonical_blob_path}"
+            )
+            raise DownloadError(msg, retryable=True)
+
+        logger.info(
+            "Canonical blob path materialized | order=%s | container=%s | source=%s | canonical=%s",
+            order_id,
+            container,
+            source_blob_path,
+            canonical_blob_path,
+        )
+    except DownloadError:
+        raise
+    except Exception as exc:
+        msg = f"Failed canonical blob promotion for order {order_id}: {exc}"
+        raise DownloadError(msg, retryable=True) from exc
 
 
 def _validate_download(blob_ref: BlobReference, order_id: str) -> None:

--- a/tests/unit/test_download_imagery.py
+++ b/tests/unit/test_download_imagery.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 from kml_satellite.activities.download_imagery import (
     DEFAULT_MAX_DOWNLOAD_RETRIES,
     DownloadError,
+    _promote_blob_to_canonical_path,
     _validate_download,
     _validate_raster_content,
     download_imagery,
@@ -259,6 +260,90 @@ class TestDownloadImagery(unittest.TestCase):
         )
 
         assert result["order_id"] == "pc-SCENE_A"
+
+
+class TestCanonicalPromotion(unittest.TestCase):
+    """Canonical blob promotion for downstream contract stability."""
+
+    @patch("azure.storage.blob.BlobServiceClient")
+    def test_promotes_when_source_and_canonical_differ(self, mock_bsc_cls: MagicMock) -> None:
+        """Copies staging blob to canonical path when paths differ."""
+        source_client = MagicMock()
+        source_client.exists.return_value = True
+        source_client.download_blob.return_value.chunks.return_value = [b"a", b"b"]
+
+        source_props = MagicMock()
+        source_props.content_settings.content_type = "image/tiff"
+        source_client.get_blob_properties.return_value = source_props
+
+        canonical_client = MagicMock()
+        canonical_client.exists.return_value = True
+
+        blob_service = MagicMock()
+
+        def _get_blob_client(*, container: str, blob: str) -> MagicMock:
+            if blob == "imagery/raw/SCENE_A.tif":
+                return source_client
+            if blob == "imagery/raw/2026/03/orchard/block-a.tif":
+                return canonical_client
+            raise AssertionError(f"Unexpected blob requested: {blob}")
+
+        blob_service.get_blob_client.side_effect = _get_blob_client
+        mock_bsc_cls.from_connection_string.return_value = blob_service
+
+        with patch.dict("os.environ", {"AzureWebJobsStorage": "conn"}, clear=False):
+            _promote_blob_to_canonical_path(
+                container="kml-output",
+                source_blob_path="imagery/raw/SCENE_A.tif",
+                canonical_blob_path="imagery/raw/2026/03/orchard/block-a.tif",
+                order_id="order-1",
+            )
+
+        canonical_client.upload_blob.assert_called_once()
+
+    @patch("azure.storage.blob.BlobServiceClient")
+    def test_noop_when_paths_match(self, mock_bsc_cls: MagicMock) -> None:
+        """No Azure I/O is performed when source is already canonical."""
+        _promote_blob_to_canonical_path(
+            container="kml-output",
+            source_blob_path="imagery/raw/same.tif",
+            canonical_blob_path="imagery/raw/same.tif",
+            order_id="order-1",
+        )
+        mock_bsc_cls.from_connection_string.assert_not_called()
+
+    @patch("azure.storage.blob.BlobServiceClient")
+    def test_missing_connection_string_skips(self, mock_bsc_cls: MagicMock) -> None:
+        """When storage config is missing, promotion is skipped defensively."""
+        with patch.dict("os.environ", {}, clear=True):
+            _promote_blob_to_canonical_path(
+                container="kml-output",
+                source_blob_path="imagery/raw/SCENE_A.tif",
+                canonical_blob_path="imagery/raw/2026/03/orchard/block-a.tif",
+                order_id="order-1",
+            )
+        mock_bsc_cls.from_connection_string.assert_not_called()
+
+    @patch("azure.storage.blob.BlobServiceClient")
+    def test_missing_source_blob_raises_retryable(self, mock_bsc_cls: MagicMock) -> None:
+        """If source blob is missing, treat as retryable transient fault."""
+        source_client = MagicMock()
+        source_client.exists.return_value = False
+        canonical_client = MagicMock()
+
+        blob_service = MagicMock()
+        blob_service.get_blob_client.side_effect = [source_client, canonical_client]
+        mock_bsc_cls.from_connection_string.return_value = blob_service
+
+        with patch.dict("os.environ", {"AzureWebJobsStorage": "conn"}, clear=False):
+            with self.assertRaises(DownloadError) as ctx:
+                _promote_blob_to_canonical_path(
+                    container="kml-output",
+                    source_blob_path="imagery/raw/SCENE_A.tif",
+                    canonical_blob_path="imagery/raw/2026/03/orchard/block-a.tif",
+                    order_id="order-1",
+                )
+        assert ctx.exception.retryable is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add canonical blob promotion in `download_imagery` so canonical `blob_path` is physically materialized
- copy provider staging blob (`adapter_blob_path`) to canonical project/date/feature path when paths differ
- keep no-op behavior when paths already match
- add defensive checks for missing source and write verification
- add regression tests for promotion success, no-op, missing config skip, and missing source retryable failure

## Validation
- `pytest tests/unit/test_download_imagery.py -q` -> 25 passed

## Why
After the previous fix, provider staging blobs were persisted, but downstream post-processing still looked at canonical paths that did not exist. This closes that contract gap.
