### PR TITLE
feat: #154 wire contact-form handler and website form submission

### DIFF
--- a/function_app.py
+++ b/function_app.py
@@ -11,12 +11,15 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+from datetime import UTC, datetime
+from uuid import uuid4
 
 import azure.durable_functions as df
 import azure.functions as func
 
 from kml_satellite.core.config import PipelineConfig, config_get_int
-from kml_satellite.core.constants import DEFAULT_OUTPUT_CONTAINER
+from kml_satellite.core.constants import DEFAULT_OUTPUT_CONTAINER, PIPELINE_PAYLOADS_CONTAINER
 from kml_satellite.core.exceptions import ContractError
 from kml_satellite.core.ingress import (
     build_and_validate_orchestrator_input,
@@ -36,6 +39,45 @@ from kml_satellite.models.payloads import (
 app = func.FunctionApp()
 
 logger = logging.getLogger("kml_satellite.function_app")
+
+
+_EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def _sanitize_marketing_field(value: object, *, max_length: int = 2000) -> str:
+    """Return a trimmed string field suitable for persistence and logging."""
+    if value is None:
+        return ""
+    return str(value).strip()[:max_length]
+
+
+def _validate_marketing_interest_payload(
+    payload: object,
+) -> tuple[dict[str, str] | None, str | None]:
+    """Validate and normalize incoming contact form payload."""
+    if not isinstance(payload, dict):
+        return None, "Request body must be a JSON object"
+
+    email = _sanitize_marketing_field(payload.get("email"), max_length=320).lower()
+    organization = _sanitize_marketing_field(payload.get("organization"), max_length=256)
+    use_case = _sanitize_marketing_field(payload.get("use_case"), max_length=4000)
+    aoi_size = _sanitize_marketing_field(payload.get("aoi_size"), max_length=64)
+
+    if not email:
+        return None, "Field 'email' is required"
+    if not _EMAIL_PATTERN.match(email):
+        return None, "Field 'email' must be a valid email address"
+    if not organization:
+        return None, "Field 'organization' is required"
+    if not use_case:
+        return None, "Field 'use_case' is required"
+
+    return {
+        "email": email,
+        "organization": organization,
+        "use_case": use_case,
+        "aoi_size": aoi_size,
+    }, None
 
 
 # ---------------------------------------------------------------------------
@@ -294,6 +336,80 @@ async def health_readiness(req: func.HttpRequest) -> func.HttpResponse:
     )
 
     return func.HttpResponse(response_body, status_code=status_code, mimetype="application/json")
+
+
+@app.function_name("marketing_interest")
+@app.route(route="contact-form", methods=["POST", "OPTIONS"])
+async def marketing_interest(req: func.HttpRequest) -> func.HttpResponse:
+    """Capture early-access requests from the marketing website (#154)."""
+    if req.method == "OPTIONS":
+        return func.HttpResponse(status_code=204)
+
+    try:
+        payload = req.get_json()
+    except ValueError:
+        response = json.dumps({"error": "Request body must be valid JSON"})
+        return func.HttpResponse(response, status_code=400, mimetype="application/json")
+
+    normalized, validation_error = _validate_marketing_interest_payload(payload)
+    if validation_error:
+        response = json.dumps({"error": validation_error})
+        return func.HttpResponse(response, status_code=400, mimetype="application/json")
+
+    assert normalized is not None  # Type narrowing: validation guarantees normalized payload.
+
+    submitted_at = datetime.now(UTC).isoformat()
+    submission_id = uuid4().hex
+    source_ip = _sanitize_marketing_field(
+        req.headers.get("x-forwarded-for") or req.headers.get("x-client-ip"),
+        max_length=256,
+    )
+    user_agent = _sanitize_marketing_field(req.headers.get("user-agent"), max_length=512)
+
+    submission = {
+        "submission_id": submission_id,
+        "submitted_at": submitted_at,
+        "source_ip": source_ip,
+        "user_agent": user_agent,
+        **normalized,
+    }
+
+    blob_name = f"marketing-interest/{submitted_at[:10]}/{submission_id}.json"
+
+    try:
+        blob_service = get_blob_service_client()
+        container_client = blob_service.get_container_client(PIPELINE_PAYLOADS_CONTAINER)
+        container_client.create_container()
+    except Exception:
+        # Container likely already exists; continue to upload.
+        pass
+
+    try:
+        blob_service = get_blob_service_client()
+        blob_client = blob_service.get_blob_client(
+            container=PIPELINE_PAYLOADS_CONTAINER,
+            blob=blob_name,
+        )
+        blob_client.upload_blob(json.dumps(submission), overwrite=False)
+    except Exception as exc:
+        logger.exception("Failed to persist marketing interest submission: %s", str(exc))
+        response = json.dumps({"error": "Failed to capture request. Please try again."})
+        return func.HttpResponse(response, status_code=500, mimetype="application/json")
+
+    logger.info(
+        "Marketing interest captured | submission_id=%s | organization=%s",
+        submission_id,
+        normalized["organization"],
+    )
+
+    response = json.dumps(
+        {
+            "status": "accepted",
+            "submission_id": submission_id,
+            "message": "Interest request received",
+        }
+    )
+    return func.HttpResponse(response, status_code=202, mimetype="application/json")
 
 
 # ---------------------------------------------------------------------------

--- a/kml_satellite/core/constants.py
+++ b/kml_satellite/core/constants.py
@@ -22,6 +22,9 @@ DEFAULT_INPUT_CONTAINER: str = "kml-input"
 DEFAULT_OUTPUT_CONTAINER: str = "kml-output"
 """Default blob container for all pipeline outputs (imagery, metadata, KML archive)."""
 
+PIPELINE_PAYLOADS_CONTAINER: str = "pipeline-payloads"
+"""Container used for offloaded payloads and lightweight operational captures."""
+
 
 # ---------------------------------------------------------------------------
 # Numeric defaults and bounds

--- a/tests/unit/test_contact_form_endpoint.py
+++ b/tests/unit/test_contact_form_endpoint.py
@@ -1,0 +1,58 @@
+"""Tests for marketing contact form endpoint wiring and payload validation (#154)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from function_app import _validate_marketing_interest_payload
+
+
+def test_validate_marketing_interest_payload_accepts_valid_payload() -> None:
+    payload = {
+        "email": "hello@example.com",
+        "organization": "TreeSight Labs",
+        "use_case": "Track orchard health over seasons",
+        "aoi_size": "500",
+    }
+
+    normalized, err = _validate_marketing_interest_payload(payload)
+
+    assert err is None
+    assert normalized is not None
+    assert normalized["email"] == "hello@example.com"
+    assert normalized["organization"] == "TreeSight Labs"
+    assert normalized["use_case"] == "Track orchard health over seasons"
+
+
+def test_validate_marketing_interest_payload_requires_required_fields() -> None:
+    payload = {
+        "email": "",
+        "organization": "",
+        "use_case": "",
+    }
+
+    normalized, err = _validate_marketing_interest_payload(payload)
+
+    assert normalized is None
+    assert err is not None
+
+
+def test_validate_marketing_interest_payload_rejects_invalid_email() -> None:
+    payload = {
+        "email": "not-an-email",
+        "organization": "TreeSight Labs",
+        "use_case": "Track orchard health",
+    }
+
+    normalized, err = _validate_marketing_interest_payload(payload)
+
+    assert normalized is None
+    assert err == "Field 'email' must be a valid email address"
+
+
+def test_contact_form_endpoint_registered_in_function_app() -> None:
+    function_app_path = Path(__file__).parent.parent.parent / "function_app.py"
+    content = function_app_path.read_text(encoding="utf-8")
+
+    assert '@app.function_name("marketing_interest")' in content
+    assert '@app.route(route="contact-form", methods=["POST", "OPTIONS"])' in content

--- a/website/static/app.js
+++ b/website/static/app.js
@@ -4,6 +4,8 @@
  */
 
 const API_ENDPOINT = '/api/readiness';
+const CONTACT_FORM_ENDPOINT = '/api/contact-form';
+const CONTACT_FORM_FALLBACK_ENDPOINT = 'https://func-kmlsat-dev.azurewebsites.net/api/contact-form';
 const STATUS_CHECK_INTERVAL = 30000; // 30 seconds
 
 /**
@@ -125,9 +127,45 @@ async function handleInterestFormSubmit(event) {
     messageEl.textContent = '';
 
     try {
-        // In #154, this will POST to /api/contact-form
-        // For now, just acknowledge
-        console.log('Interest form data:', data);
+        const payload = {
+            email: String(data.email || '').trim(),
+            organization: String(data.organization || '').trim(),
+            use_case: String(data.use_case || '').trim(),
+            aoi_size: String(data.aoi_size || '').trim(),
+        };
+
+        let response;
+        try {
+            response = await fetch(CONTACT_FORM_ENDPOINT, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(payload),
+            });
+        } catch (relativeError) {
+            console.warn('Relative API endpoint failed, trying fallback endpoint:', relativeError);
+            response = await fetch(CONTACT_FORM_FALLBACK_ENDPOINT, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(payload),
+            });
+        }
+
+        if (!response.ok) {
+            let errorMessage = 'Something went wrong. Please try again.';
+            try {
+                const errorPayload = await response.json();
+                if (errorPayload && errorPayload.error) {
+                    errorMessage = String(errorPayload.error);
+                }
+            } catch (_ignored) {
+                // Keep default message if response body is not JSON.
+            }
+            throw new Error(errorMessage);
+        }
 
         messageEl.textContent = '✅ Thank you! We\'ll be in touch within 24 hours. Check your email.';
         messageEl.style.color = '#22c55e';
@@ -142,7 +180,7 @@ async function handleInterestFormSubmit(event) {
 
     } catch (error) {
         console.error('Form submission error:', error);
-        messageEl.textContent = '❌ Something went wrong. Please try again.';
+        messageEl.textContent = `❌ ${error.message || 'Something went wrong. Please try again.'}`;
         messageEl.style.color = '#ef4444';
         submitBtn.disabled = false;
         submitBtn.textContent = 'Get Early Access';


### PR DESCRIPTION
## Issue
#154 - Build Azure Function contact form handler (captures email, org, use case)

## What changed
- Added new HTTP endpoint in function app:
  - POST /api/contact-form
  - OPTIONS /api/contact-form for browser preflight
- Added payload validation helpers in function_app.py:
  - required fields: email, organization, use_case
  - email format validation
  - field sanitization and max length caps
- Added blob persistence for submissions:
  - container: pipeline-payloads
  - path: marketing-interest/YYYY-MM-DD/<submission_id>.json
  - captures metadata: submission_id, submitted_at, source_ip, user_agent
- Updated website form logic in website/static/app.js:
  - sends JSON payload to /api/contact-form
  - fallback endpoint retry to deployed function host
  - user-facing API error messages shown in form
- Added tests:
  - tests/unit/test_contact_form_endpoint.py
  - covers payload validation and route registration

## Response behavior
- 202 Accepted on successful capture
- 400 Bad Request for invalid JSON/validation failures
- 500 Internal Server Error for storage persistence failures

## Validation run
- uv run ruff check function_app.py kml_satellite/core/constants.py tests/unit/test_contact_form_endpoint.py
- uv run pyright function_app.py tests/unit/test_contact_form_endpoint.py
- uv run pytest tests/unit/test_contact_form_endpoint.py tests/unit/test_health_endpoints.py tests/unit/test_container_apps_spec.py -q

All passed.

## Notes
- JavaScript was excluded from Ruff checks (Ruff is Python-only).
- Node is not installed in this local shell, so dedicated JS linting was not run here.