### PR TITLE
fix(ci): make Event Grid drift cleanup non-interactive

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -354,7 +354,8 @@ jobs:
               az eventgrid system-topic event-subscription delete \
                 --name "$SUBSCRIPTION_NAME" \
                 --system-topic-name "$SYSTEM_TOPIC_NAME" \
-                --resource-group "$RESOURCE_GROUP"
+                --resource-group "$RESOURCE_GROUP" \
+                --yes
             fi
           fi
 

--- a/tests/unit/test_deploy_workflow.py
+++ b/tests/unit/test_deploy_workflow.py
@@ -296,6 +296,22 @@ class TestReadinessCheck:
         assert "endpoint" in run_script, "Reconciliation must verify subscription endpoint URL"
         assert "properties" in run_script, "Reconciliation must check subscription properties"
 
+    def test_reconcile_deletes_drifted_subscription_non_interactively(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        """Drift cleanup must not prompt for confirmation on headless CI runners."""
+        steps = _get_steps(deploy_workflow)
+        reconcile = _find_step(steps, "reconcile")
+        assert reconcile is not None
+        run_script = reconcile.get("run", "")
+
+        assert "event-subscription delete" in run_script, (
+            "Reconciliation must delete drifted Event Grid subscriptions before recreate"
+        )
+        assert "--yes" in run_script, (
+            "Drift cleanup must pass --yes so Azure CLI does not prompt in CI"
+        )
+
     def test_reconcile_detects_webhook_key_availability(
         self, deploy_workflow: dict[str, Any]
     ) -> None:


### PR DESCRIPTION
## Summary
- add a regression test for drifted Event Grid subscription cleanup in deploy workflow
- pass --yes to the Azure CLI delete command so deploy reconciliation does not hang or cancel in CI

## Validation
- uv run pytest tests/unit/test_deploy_workflow.py -q

## Context
- This fixes the current main deploy failure where the reconcile step detects subscription drift, attempts deletion, and Azure CLI cancels because no interactive confirmation is possible on the runner.
