### PR TITLE
fix(ci): retry Event Grid endpoint convergence during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -403,6 +403,10 @@ jobs:
 
             VERIFY_UNTIL=$(( $(date +%s) + SUBSCRIPTION_POLL_INTERVAL_SECONDS ))
             while (( $(date +%s) < VERIFY_UNTIL )); do
+              if (( $(date +%s) >= RECONCILE_DEADLINE )); then
+                break
+              fi
+
               CURRENT_JSON=$(read_existing_subscription)
               if [[ -z "$CURRENT_JSON" ]]; then
                 sleep 5
@@ -413,7 +417,8 @@ jobs:
               CURRENT_ENDPOINT=$(extract_subscription_endpoint "$CURRENT_JSON")
 
               if [[ "$CURRENT_ENDPOINT" != "$WEBHOOK_URL" ]]; then
-                log "Event Grid subscription endpoint has not converged yet. Waiting for the reconciled endpoint to appear..."
+                LAST_CREATE_ERROR="Endpoint mismatch during reconcile: current_state=${CURRENT_STATE:-unknown}, current_endpoint=${CURRENT_ENDPOINT:-none}, expected_endpoint=${WEBHOOK_URL:-none}"
+                log "Event Grid subscription endpoint has not converged yet (state=${CURRENT_STATE:-unknown}, current_endpoint=${CURRENT_ENDPOINT:-none}, expected=${WEBHOOK_URL:-none}). Waiting for the reconciled endpoint to appear..."
                 sleep 5
                 continue
               fi

--- a/tests/unit/test_deploy_workflow.py
+++ b/tests/unit/test_deploy_workflow.py
@@ -333,6 +333,25 @@ class TestReadinessCheck:
         ), (
             "Transient endpoint mismatch during recreate verification should not hard-fail immediately"
         )
+        assert 'LAST_CREATE_ERROR="Endpoint mismatch during reconcile:' in run_script, (
+            "Endpoint mismatch should record actionable diagnostics for timeout failures"
+        )
+        assert "current_endpoint=${CURRENT_ENDPOINT:-none}" in run_script, (
+            "Endpoint mismatch diagnostics should include the last observed endpoint"
+        )
+
+    def test_reconcile_inner_verify_loop_respects_outer_deadline(
+        self, deploy_workflow: dict[str, Any]
+    ) -> None:
+        """The inner verification loop must not run past the overall reconcile timeout."""
+        steps = _get_steps(deploy_workflow)
+        reconcile = _find_step(steps, "reconcile")
+        assert reconcile is not None
+        run_script = reconcile.get("run", "")
+
+        assert "if (( $(date +%s) >= RECONCILE_DEADLINE )); then" in run_script, (
+            "Inner verification should stop when the outer reconcile deadline is reached"
+        )
 
     def test_reconcile_detects_webhook_key_availability(
         self, deploy_workflow: dict[str, Any]


### PR DESCRIPTION
## Summary
- add a regression test for transient endpoint mismatch during Event Grid recreate verification
- treat endpoint mismatch as a retryable convergence state instead of an immediate hard failure
- keep final verification strict after the reconcile deadline

## Validation
- uv run pytest tests/unit/test_deploy_workflow.py -q

## Context
- After fixing non-interactive deletion, the main deploy still failed because Azure reported the old Event Grid endpoint briefly after recreate. This patch keeps polling until the reconciled endpoint appears or the existing reconcile timeout expires.
