### PR TITLE
test(#14): concurrent upload stress test (>=20 files)

### DIFF
--- a/.github/workflows/stress-e2e.yml
+++ b/.github/workflows/stress-e2e.yml
@@ -1,0 +1,96 @@
+# ---------------------------------------------------------------------------
+# Stress E2E Pipeline Test (Issue #14)
+# ---------------------------------------------------------------------------
+# Manual workflow to validate >=20 concurrent uploads against the live dev
+# environment. Uses OIDC (no static cloud credentials), resolves runtime
+# endpoints dynamically, and runs the dedicated stress integration test.
+# ---------------------------------------------------------------------------
+
+name: Stress E2E Pipeline Test
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  FUNCTION_APP_NAME: func-kmlsat-dev
+  RESOURCE_GROUP: rg-kmlsat-dev
+
+jobs:
+  stress-e2e:
+    name: Live Stress E2E (Dev)
+    runs-on: ubuntu-latest
+    environment: dev
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Resolve live environment values
+        id: env
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          fail() { echo "::error::$*"; exit 1; }
+
+          HOSTNAME=$(az functionapp show \
+            --name "${{ env.FUNCTION_APP_NAME }}" \
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --query defaultHostName -o tsv)
+          [[ -n "$HOSTNAME" ]] || fail "Could not resolve Function App hostname"
+
+          STORAGE_ACCOUNT=$(az storage account list \
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --query "[0].name" -o tsv)
+          [[ -n "$STORAGE_ACCOUNT" ]] || fail "Could not resolve storage account name"
+          STORAGE_URL="https://${STORAGE_ACCOUNT}.blob.core.windows.net"
+
+          HOST_KEY=$(az functionapp keys list \
+            --name "${{ env.FUNCTION_APP_NAME }}" \
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --query "functionKeys.default" -o tsv)
+
+          if [[ -z "$HOST_KEY" ]]; then
+            HOST_KEY=$(az functionapp keys list \
+              --name "${{ env.FUNCTION_APP_NAME }}" \
+              --resource-group "${{ env.RESOURCE_GROUP }}" \
+              --query "masterKey" -o tsv)
+          fi
+          [[ -n "$HOST_KEY" ]] || fail "Could not retrieve function host key"
+
+          echo "hostname=${HOSTNAME}" >> "$GITHUB_OUTPUT"
+          echo "storage_url=${STORAGE_URL}" >> "$GITHUB_OUTPUT"
+          echo "::add-mask::${HOST_KEY}"
+          echo "host_key=${HOST_KEY}" >> "$GITHUB_OUTPUT"
+
+      - name: Run concurrent stress test
+        env:
+          E2E_FUNCTION_APP_HOSTNAME: ${{ steps.env.outputs.hostname }}
+          E2E_STORAGE_ACCOUNT_URL: ${{ steps.env.outputs.storage_url }}
+          E2E_FUNCTION_HOST_KEY: ${{ steps.env.outputs.host_key }}
+        run: |
+          set -euo pipefail
+          uv run pytest tests/integration/test_stress_pipeline.py -m "e2e and slow" -v --tb=short --maxfail=1

--- a/docs/reviews/STRESS_TEST_VALIDATION.md
+++ b/docs/reviews/STRESS_TEST_VALIDATION.md
@@ -1,0 +1,46 @@
+# Stress Test Validation (Issue #14)
+
+## Scope
+
+This validation covers concurrent upload behavior for at least 20 KML inputs, aligned with PID NFR-2, FR-5.4, and AC-10.
+
+## Test Entry Point
+
+- Test file: tests/integration/test_stress_pipeline.py
+- Workflow: .github/workflows/stress-e2e.yml
+- Marker profile: e2e + slow
+
+## What Is Verified
+
+1. 20 concurrent uploads are submitted to the live pipeline.
+2. Every upload resolves to an independent orchestration instance.
+3. Every orchestration reaches runtimeStatus=Completed.
+4. Metadata artifact paths are unique across all concurrent runs.
+5. Metadata blobs exist and are non-empty in the output container.
+6. Throughput and latency distribution are measured and emitted as test properties.
+
+## Runtime Metrics Captured
+
+- concurrent_uploads
+- total_duration_s
+- throughput_per_s
+- duration_mean_s
+- duration_p50_s
+- duration_p95_s
+- duration_max_s
+
+## Operational Review Checklist
+
+Use the stress workflow run window to inspect live telemetry:
+
+1. Function App instance count scale-out behavior
+2. Memory pressure and host throttling events
+3. Activity retry spikes and provider-side latency shifts
+4. Event Grid and Durable orchestration backlog growth
+
+## Production Recommendations
+
+1. Keep blob naming fully unique per upload trigger to preserve idempotency under contention.
+2. Alert on sustained orchestration queue growth and long-tail latency (P95/P99).
+3. Preserve host-key retrieval fail-fast behavior in CI workflows.
+4. Re-run stress validation after infrastructure/runtime changes and before major releases.

--- a/tests/integration/test_stress_pipeline.py
+++ b/tests/integration/test_stress_pipeline.py
@@ -1,0 +1,187 @@
+"""Concurrent stress tests for live pipeline validation (Issue #14).
+
+These tests upload 20 KML files concurrently and verify:
+- each upload maps to a unique orchestration instance
+- all runs reach terminal Completed state
+- metadata artifacts are collision-free across concurrent runs
+- metadata blobs exist and are non-empty
+
+The test is marked both e2e and slow, and uses the same environment-driven
+skip model as test_live_pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from statistics import mean
+from typing import Any
+
+import pytest
+
+from tests.integration.test_live_pipeline import (
+    _OUTPUT_CONTAINER,
+    _blob_exists,
+    _blob_service,
+    _live,
+    _run_pipeline,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+_MAX_CONCURRENCY = 20
+_WORKLOAD_KMLS: list[str] = [
+    "01_single_polygon_orchard.kml",
+    "02_multipolygon_orchard_blocks.kml",
+    "03_multi_feature_vineyard.kml",
+    "04_complex_polygon_with_hole.kml",
+    "05_irregular_polygon_steep_terrain.kml",
+    "06_large_area_plantation.kml",
+    "07_small_area_garden.kml",
+    "08_no_extended_data.kml",
+    "09_folder_nested_features.kml",
+    "10_schema_typed_extended_data.kml",
+    "uk-mountsorrel-halstead-road-park.kml",
+    "uk-mountsorrel-millenium-green.kml",
+    "uk-mountsorrel-wood-lane-quarry.kml",
+    "uk-newton-linford-bradgate-country-park.kml",
+    "uk-oakworth-griff-wood.kml",
+    "01_single_polygon_orchard.kml",
+    "03_multi_feature_vineyard.kml",
+    "04_complex_polygon_with_hole.kml",
+    "06_large_area_plantation.kml",
+    "09_folder_nested_features.kml",
+]
+
+
+@dataclass(frozen=True)
+class StressRunResult:
+    workload_idx: int
+    kml_filename: str
+    instance_id: str
+    runtime_status: str
+    pipeline_status: str
+    aoi_count: int
+    metadata_count: int
+    metadata_paths: list[str]
+    duration_s: float
+
+
+def _run_one(workload_idx: int, kml_filename: str) -> StressRunResult:
+    started = time.monotonic()
+    instance_id, payload = _run_pipeline(kml_filename)
+    elapsed = time.monotonic() - started
+
+    output: dict[str, Any] = payload.get("output") or {}
+    artifacts: dict[str, Any] = output.get("artifacts") or {}
+
+    return StressRunResult(
+        workload_idx=workload_idx,
+        kml_filename=kml_filename,
+        instance_id=instance_id,
+        runtime_status=str(payload.get("runtimeStatus") or ""),
+        pipeline_status=str(output.get("status") or ""),
+        aoi_count=int(output.get("aoiCount") or 0),
+        metadata_count=int(output.get("metadataCount") or 0),
+        metadata_paths=list(artifacts.get("metadataPaths") or []),
+        duration_s=elapsed,
+    )
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    """Compute an inclusive nearest-rank percentile for a non-empty list."""
+    assert values, "values must be non-empty"
+    assert 0 <= percentile <= 1, "percentile must be in [0, 1]"
+    sorted_values = sorted(values)
+    rank = int((len(sorted_values) - 1) * percentile)
+    return sorted_values[rank]
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+class TestLiveConcurrentStress:
+    """AC-10: pipeline should process >=20 concurrent uploads without conflicts."""
+
+    @_live
+    def test_20_concurrent_uploads_are_isolated_and_complete(
+        self, record_property: pytest.RecordProperty
+    ) -> None:
+        """Run 20 concurrent uploads and verify correctness + basic throughput metrics."""
+        started = time.monotonic()
+        results: list[StressRunResult] = []
+
+        with ThreadPoolExecutor(max_workers=_MAX_CONCURRENCY) as pool:
+            futures = [
+                pool.submit(_run_one, idx, filename)
+                for idx, filename in enumerate(_WORKLOAD_KMLS, start=1)
+            ]
+            for future in as_completed(futures):
+                results.append(future.result())
+
+        total_elapsed_s = time.monotonic() - started
+
+        assert len(results) == len(_WORKLOAD_KMLS), (
+            f"Expected {len(_WORKLOAD_KMLS)} completed runs, got {len(results)}"
+        )
+
+        not_completed = [r for r in results if r.runtime_status != "Completed"]
+        assert not not_completed, "Some orchestrations did not reach Completed: " + ", ".join(
+            f"idx={r.workload_idx} kml={r.kml_filename} status={r.runtime_status}"
+            for r in not_completed
+        )
+
+        instance_ids = [r.instance_id for r in results]
+        assert len(instance_ids) == len(set(instance_ids)), (
+            "Duplicate orchestration instance IDs detected under concurrency"
+        )
+
+        all_metadata_paths: list[str] = []
+        for run in results:
+            assert run.metadata_count >= 1, (
+                f"No metadata produced for idx={run.workload_idx} kml={run.kml_filename}; "
+                f"pipeline_status={run.pipeline_status}"
+            )
+            assert len(run.metadata_paths) == len(set(run.metadata_paths)), (
+                f"Duplicate metadata paths within run idx={run.workload_idx}: {run.metadata_paths}"
+            )
+            all_metadata_paths.extend(run.metadata_paths)
+
+        assert len(all_metadata_paths) == len(set(all_metadata_paths)), (
+            "Metadata path collisions detected across concurrent runs"
+        )
+
+        blob_svc = _blob_service()
+        missing = [
+            p for p in all_metadata_paths if not _blob_exists(blob_svc, _OUTPUT_CONTAINER, p)
+        ]
+        assert not missing, "Some metadata artifacts are missing or empty: " + ", ".join(
+            missing[:10]
+        )
+
+        durations = [r.duration_s for r in results]
+        throughput = len(results) / total_elapsed_s if total_elapsed_s > 0 else 0.0
+        p50 = _percentile(durations, 0.50)
+        p95 = _percentile(durations, 0.95)
+        max_duration = max(durations)
+
+        LOGGER.info(
+            "Stress run metrics | uploads=%d | total_s=%.2f | throughput=%.2f/s | "
+            "mean_s=%.2f | p50_s=%.2f | p95_s=%.2f | max_s=%.2f",
+            len(results),
+            total_elapsed_s,
+            throughput,
+            mean(durations),
+            p50,
+            p95,
+            max_duration,
+        )
+
+        record_property("concurrent_uploads", len(results))
+        record_property("total_duration_s", round(total_elapsed_s, 2))
+        record_property("throughput_per_s", round(throughput, 4))
+        record_property("duration_mean_s", round(mean(durations), 2))
+        record_property("duration_p50_s", round(p50, 2))
+        record_property("duration_p95_s", round(p95, 2))
+        record_property("duration_max_s", round(max_duration, 2))


### PR DESCRIPTION
## Summary

Implements issue #14 with a test-first, live-environment stress validation path.

## Changes

- Added tests/integration/test_stress_pipeline.py
  - 20 concurrent uploads with mixed KML corpus
  - Verifies independent orchestration instance IDs
  - Verifies all runs reach runtimeStatus=Completed
  - Verifies no metadata path collisions across concurrent runs
  - Verifies metadata blobs exist and are non-empty
  - Captures throughput and latency metrics (mean, p50, p95, max)
  - Marked as e2e + slow and guarded by the same live env skip condition

- Added .github/workflows/stress-e2e.yml
  - Manual workflow_dispatch stress runner
  - OIDC Azure login
  - Runtime env resolution (hostname, storage URL, host key)
  - Runs the dedicated stress test module

- Added docs/reviews/STRESS_TEST_VALIDATION.md
  - Run scope, verification matrix, metrics list, and operational checklist
  - Production-oriented recommendations for scale and observability

## Validation

- uv run ruff check tests/integration/test_stress_pipeline.py
- uv run pytest tests/integration/test_stress_pipeline.py -q
  - skipped locally without live env vars (expected)

Closes #14