### PR TITLE
docs(#18): architecture guide, ops runbook, API reference, metadata schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,21 @@ KML Upload → Blob Storage → Event Grid → Durable Functions Orchestrator
 **Orchestration:** Azure Durable Functions — fan-out/fan-in, async polling with zero-cost timers
 **Providers:** Planetary Computer (free STAC API, all tiers). Commercial adapters (Phase 5+).
 
-See [PID.md](PID.md) for the full Project Initiation Document and [ARCHITECTURE_REVIEW.md](ARCHITECTURE_REVIEW.md) for implementation-level architecture notes.
+See [PID.md](docs/PID.md) for the full Project Initiation Document and [ARCHITECTURE_REVIEW.md](docs/reviews/ARCHITECTURE_REVIEW.md) for implementation-level architecture notes.
 
 ## Architecture Reference
 
-- **System architecture:** [PID.md §7](PID.md)
-- **Codebase architecture review:** [ARCHITECTURE_REVIEW.md](ARCHITECTURE_REVIEW.md)
+- **System architecture:** [PID.md §7](docs/PID.md)
+- **Deployed component/data-flow guide:** [docs/ARCHITECTURE_OVERVIEW.md](docs/ARCHITECTURE_OVERVIEW.md)
+- **Codebase architecture review:** [docs/reviews/ARCHITECTURE_REVIEW.md](docs/reviews/ARCHITECTURE_REVIEW.md)
 - **Execution plan and phase gates:** [ROADMAP.md](ROADMAP.md)
+
+## Documentation Index
+
+- **Operations runbook:** [docs/OPERATIONS_RUNBOOK.md](docs/OPERATIONS_RUNBOOK.md)
+- **API and interfaces:** [docs/API_INTERFACE_REFERENCE.md](docs/API_INTERFACE_REFERENCE.md)
+- **Metadata JSON schema:** [docs/schemas/aoi-metadata-v2.schema.json](docs/schemas/aoi-metadata-v2.schema.json)
+- **UAT execution plan:** [docs/reviews/UAT_VALIDATION.md](docs/reviews/UAT_VALIDATION.md)
 
 ## Operations Runbook
 
@@ -155,7 +163,7 @@ Test coverage: [test_deploy_workflow.py](tests/unit/test_deploy_workflow.py)
 
 ```text
 ├── .github/workflows/ci.yml    CI pipeline (lint, type check, test)
-├── infra/                       Bicep IaC templates
+├── infra/                       OpenTofu IaC modules and environments
 ├── kml_satellite/               Application package
 │   ├── activities/              Durable Functions activity functions
 │   ├── orchestrators/           Durable Functions orchestrators
@@ -187,7 +195,7 @@ Test coverage: [test_deploy_workflow.py](tests/unit/test_deploy_workflow.py)
 | Linting | ruff |
 | Type Checking | pyright |
 | Testing | pytest |
-| IaC | Bicep |
+| IaC | OpenTofu (Terraform-compatible) |
 | CI/CD | GitHub Actions |
 
 ## Getting Started

--- a/docs/API_INTERFACE_REFERENCE.md
+++ b/docs/API_INTERFACE_REFERENCE.md
@@ -1,0 +1,70 @@
+# API and Interface Reference
+
+Issue: #18
+
+## Public HTTP Endpoints
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | /api/health | Liveness probe |
+| GET | /api/readiness | Dependency readiness probe |
+| GET | /api/orchestrator/{instance_id} | Durable diagnostics payload |
+| POST | /api/marketing-interest | Contact form ingestion endpoint |
+
+## Trigger and Orchestrator Entry Points
+
+- Event Grid trigger: kml_blob_trigger
+- Main orchestrator: kml_processing_orchestrator
+- Polling sub-orchestrator: poll_order_suborchestrator
+
+## Activity Functions and Contracts
+
+Durable activity payload contracts are defined in kml_satellite/models/payloads.py.
+
+| Activity | Input Contract | Output Contract |
+| --- | --- | --- |
+| parse_kml | ParseKmlInput | list[FeatureDict] |
+| prepare_aoi | FeatureDict | AOIDict |
+| write_metadata | WriteMetadataInput | WriteMetadataOutput |
+| acquire_imagery | AcquireImageryInput | AcquireImageryOutput |
+| poll_order | PollOrderInput | PollOrderOutput |
+| download_imagery | DownloadImageryInput | DownloadImageryOutput |
+| post_process_imagery | PostProcessImageryInput | PostProcessImageryOutput |
+
+## ImageryProvider Contract
+
+Base interface: kml_satellite/providers/base.py
+
+Required methods:
+
+- search(aoi, filters) -> list[SearchResult]
+- order(scene_id) -> OrderId
+- poll(order_id) -> OrderStatus
+- download(order_id) -> BlobReference
+
+Failure model:
+
+- ProviderError (base)
+- ProviderAuthError
+- ProviderSearchError
+- ProviderOrderError
+- ProviderDownloadError
+
+## Metadata JSON Schema
+
+Canonical model: kml_satellite/models/metadata.py
+
+Formal schema file:
+
+- docs/schemas/aoi-metadata-v2.schema.json
+
+## Blob Path Conventions
+
+Path builders: kml_satellite/utils/blob_paths.py
+
+- kml/YYYY/MM/{project}/{filename}.kml
+- metadata/YYYY/MM/{project}/{feature}.json
+- imagery/raw/YYYY/MM/{project}/{feature}.tif
+- imagery/clipped/YYYY/MM/{project}/{feature}.tif
+
+All path segments are lowercased, slug-sanitized, and deterministic for idempotent writes.

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -1,0 +1,82 @@
+# Architecture Overview
+
+Issue: #18
+
+## Deployed Components
+
+The production pipeline is deployed as Azure Functions on Container Apps with event-driven orchestration.
+
+- Event Grid topic: evgt-<baseName>
+- Event Grid subscription: evgs-kml-upload
+- Function App: func-<baseName>
+- Resource group: rg-<baseName>
+- Input container: kml-input
+- Output container: kml-output
+- Durable task hub: KmlSatelliteHub
+
+For dev this commonly resolves to:
+
+- Function App: func-kmlsat-dev
+- Resource group: rg-kmlsat-dev
+
+## Data Flow
+
+1. User uploads KML into input blob container.
+2. Event Grid emits a BlobCreated event.
+3. kml_blob_trigger validates event payload and starts kml_processing_orchestrator.
+4. Orchestrator runs phase pipeline:
+   - parse_kml
+   - prepare_aoi + write_metadata
+   - acquire_imagery + poll_order_suborchestrator + download_imagery + post_process_imagery
+5. Metadata and imagery artifacts are written to output blob paths.
+6. Operational diagnostics are available at /api/orchestrator/{instance_id}.
+
+## Provider Adapter Boundary
+
+The orchestrator calls provider adapters only through the ImageryProvider contract in kml_satellite/providers/base.py.
+
+Required adapter methods:
+
+- search(aoi, filters) -> list[SearchResult]
+- order(scene_id) -> OrderId
+- poll(order_id) -> OrderStatus
+- download(order_id) -> BlobReference
+
+This allows provider-specific logic to evolve without changing orchestration flow.
+
+## Configuration Reference (Environment)
+
+Core runtime settings:
+
+- DEFAULT_INPUT_CONTAINER or KML_INPUT_CONTAINER
+- DEFAULT_OUTPUT_CONTAINER or KML_OUTPUT_CONTAINER
+- IMAGERY_PROVIDER
+- IMAGERY_RESOLUTION_TARGET_M
+- IMAGERY_MAX_CLOUD_COVER_PCT
+- AOI_BUFFER_M
+- AOI_MAX_AREA_HA
+- KEYVAULT_URL
+- AzureWebJobsStorage
+- APPLICATIONINSIGHTS_CONNECTION_STRING
+
+Validation and defaults are implemented in kml_satellite/core/config.py.
+
+## Observability Surface
+
+HTTP diagnostics:
+
+- GET /api/health
+- GET /api/readiness
+- GET /api/orchestrator/{instance_id}
+
+Structured logs include correlation and entity fields such as:
+
+- instance, correlation_id
+- blob, feature
+- order_id, provider
+
+## Deployment Model
+
+Infrastructure is managed with OpenTofu under infra/tofu.
+
+Deployment sequencing must ensure host readiness before Event Grid subscription enablement, to avoid webhook validation race conditions.

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -1,0 +1,79 @@
+# Operations Runbook
+
+Issue: #18
+
+## Deploy
+
+1. Run CI checks.
+2. Deploy infrastructure and app via GitHub Actions deploy workflow.
+3. Verify Function host readiness using /api/health.
+4. Verify Event Grid subscription reconciliation succeeds.
+
+Reference: .github/workflows/deploy.yml and infra/tofu/README.md.
+
+## Monitor
+
+Primary telemetry:
+
+- Application Insights traces/exceptions
+- Durable orchestration status endpoint
+- Azure Monitor alerts for failed requests and latency
+
+Operational checks:
+
+1. Query failed orchestration runs by instance_id.
+2. Correlate instance_id with activity logs.
+3. Verify artifact presence in output blob container.
+
+## Troubleshoot Common Failures
+
+### Orchestration never appears
+
+1. Confirm Event Grid subscription exists and is healthy.
+2. Confirm uploaded blob is in expected input container and has .kml suffix.
+3. Check trigger logs for validation rejection.
+
+### Orchestration failed in activity stage
+
+1. Use /api/orchestrator/{instance_id} for stage/output summary.
+2. Review activity-specific exceptions in App Insights.
+3. Re-run with corrected input or configuration as needed.
+
+### Provider transient failures
+
+1. Confirm retry/backoff behavior in logs.
+2. Wait for retries to complete before manual intervention.
+3. Escalate if repeated failure exceeds operational threshold.
+
+## Add New Imagery Provider Adapter
+
+1. Implement ImageryProvider in kml_satellite/providers.
+2. Implement search/order/poll/download with typed returns.
+3. Register adapter in provider factory.
+4. Add unit tests for success and error/retry paths.
+5. Validate with integration tests before enabling in env config.
+
+## Rotate Secrets
+
+1. Rotate source secrets in Key Vault.
+2. Validate managed identity role assignments still allow read.
+3. Restart/redeploy function app if required for refresh.
+4. Run /api/readiness and a live smoke upload to verify.
+
+## Re-process Failed KML
+
+1. Locate failed instance id and root cause.
+2. Correct data/config issue.
+3. Re-upload KML with a new blob name.
+4. Confirm new orchestration reaches Completed and writes artifacts.
+
+## Tune Processing Thresholds
+
+Adjust via app settings and redeploy:
+
+- AOI_BUFFER_M
+- IMAGERY_RESOLUTION_TARGET_M
+- IMAGERY_MAX_CLOUD_COVER_PCT
+- AOI_MAX_AREA_HA
+
+Validate changes with integration tests and one live sample upload.

--- a/docs/schemas/aoi-metadata-v2.schema.json
+++ b/docs/schemas/aoi-metadata-v2.schema.json
@@ -1,0 +1,305 @@
+{
+  "$defs": {
+    "AnalysisMetadata": {
+      "description": "Analysis section \u2014 populated by the analytical pipeline (Phase 5+).\n\nAll fields default to None/0/empty so records are valid before analysis runs.",
+      "properties": {
+        "ndvi_blob_path": {
+          "default": "",
+          "title": "Ndvi Blob Path",
+          "type": "string"
+        },
+        "ndvi_mean": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ndvi Mean"
+        },
+        "ndvi_min": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ndvi Min"
+        },
+        "ndvi_max": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ndvi Max"
+        },
+        "canopy_cover_pct": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Canopy Cover Pct"
+        },
+        "tree_count": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tree Count"
+        },
+        "detections_blob_path": {
+          "default": "",
+          "title": "Detections Blob Path",
+          "type": "string"
+        }
+      },
+      "title": "AnalysisMetadata",
+      "type": "object"
+    },
+    "GeometryMetadata": {
+      "description": "Geometry section of the per-AOI metadata.\n\nContains the polygon coordinates, bounding boxes, area, and centroid.\nAll coordinates are WGS 84 (EPSG:4326).\n\nAttributes:\n    type: GeoJSON geometry type, always ``\"Polygon\"``.\n    coordinates: GeoJSON-style nested coordinate arrays\n        ``[exterior_ring, *interior_rings]`` where each ring is a list\n        of ``[lon, lat]`` pairs.\n    centroid: Polygon centroid as ``[lon, lat]``.\n    bounding_box: Tight bounding box\n        ``[min_lon, min_lat, max_lon, max_lat]``.\n    buffered_bounding_box: Bounding box expanded by ``buffer_m`` metres.\n    area_hectares: Geodesic polygon area in hectares (PID 7.4.5).\n    crs: Coordinate reference system EPSG code.",
+      "properties": {
+        "type": {
+          "default": "Polygon",
+          "title": "Type",
+          "type": "string"
+        },
+        "coordinates": {
+          "items": {
+            "items": {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "title": "Coordinates",
+          "type": "array"
+        },
+        "centroid": {
+          "items": {
+            "type": "number"
+          },
+          "title": "Centroid",
+          "type": "array"
+        },
+        "bounding_box": {
+          "items": {
+            "type": "number"
+          },
+          "title": "Bounding Box",
+          "type": "array"
+        },
+        "buffered_bounding_box": {
+          "items": {
+            "type": "number"
+          },
+          "title": "Buffered Bounding Box",
+          "type": "array"
+        },
+        "area_hectares": {
+          "default": 0.0,
+          "title": "Area Hectares",
+          "type": "number"
+        },
+        "crs": {
+          "default": "EPSG:4326",
+          "title": "Crs",
+          "type": "string"
+        }
+      },
+      "title": "GeometryMetadata",
+      "type": "object"
+    },
+    "ImageryMetadata": {
+      "description": "Imagery section of the per-AOI metadata.\n\nPopulated during imagery acquisition (M-2.x).  All fields default\nto empty/zero for the M-1.6 milestone \u2014 the schema is defined now\nso metadata JSON is always structurally complete.\n\nAttributes:\n    provider: Imagery provider name (e.g. ``\"maxar\"``, ``\"planet\"``).\n    scene_id: Provider-specific scene identifier.\n    acquisition_date: Scene acquisition timestamp (ISO 8601).\n    spatial_resolution_m: Ground sample distance in metres.\n    crs: Scene CRS EPSG code (may differ from AOI CRS after reproject).\n    cloud_cover_pct: Cloud cover percentage over the AOI.\n    off_nadir_angle_deg: Off-nadir viewing angle in degrees.\n    format: Image file format (e.g. ``\"GeoTIFF\"``).\n    raw_blob_path: Blob path to the raw (unclipped) imagery.\n    clipped_blob_path: Blob path to the clipped imagery.",
+      "properties": {
+        "provider": {
+          "default": "",
+          "title": "Provider",
+          "type": "string"
+        },
+        "scene_id": {
+          "default": "",
+          "title": "Scene Id",
+          "type": "string"
+        },
+        "acquisition_date": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Acquisition Date"
+        },
+        "spatial_resolution_m": {
+          "default": 0.0,
+          "title": "Spatial Resolution M",
+          "type": "number"
+        },
+        "crs": {
+          "default": "",
+          "title": "Crs",
+          "type": "string"
+        },
+        "cloud_cover_pct": {
+          "default": 0.0,
+          "title": "Cloud Cover Pct",
+          "type": "number"
+        },
+        "off_nadir_angle_deg": {
+          "default": 0.0,
+          "title": "Off Nadir Angle Deg",
+          "type": "number"
+        },
+        "format": {
+          "default": "",
+          "title": "Format",
+          "type": "string"
+        },
+        "raw_blob_path": {
+          "default": "",
+          "title": "Raw Blob Path",
+          "type": "string"
+        },
+        "clipped_blob_path": {
+          "default": "",
+          "title": "Clipped Blob Path",
+          "type": "string"
+        }
+      },
+      "title": "ImageryMetadata",
+      "type": "object"
+    },
+    "ProcessingMetadata": {
+      "description": "Processing section of the per-AOI metadata.\n\nRecords how the AOI was processed: buffer distance, clipping status,\ntiming, and any errors.\n\nAttributes:\n    buffer_m: Buffer distance applied in metres.\n    clipped: Whether the imagery was clipped to the AOI polygon.\n    reprojected: Whether the imagery was reprojected.\n    timestamp: Processing timestamp (ISO 8601).\n    duration_s: Total processing duration in seconds.\n    status: Processing status (``\"success\"``, ``\"partial\"``, ``\"failed\"``).\n    errors: List of error messages encountered during processing.",
+      "properties": {
+        "buffer_m": {
+          "default": 100.0,
+          "title": "Buffer M",
+          "type": "number"
+        },
+        "clipped": {
+          "default": false,
+          "title": "Clipped",
+          "type": "boolean"
+        },
+        "reprojected": {
+          "default": false,
+          "title": "Reprojected",
+          "type": "boolean"
+        },
+        "timestamp": {
+          "default": "",
+          "title": "Timestamp",
+          "type": "string"
+        },
+        "duration_s": {
+          "default": 0.0,
+          "title": "Duration S",
+          "type": "number"
+        },
+        "status": {
+          "default": "pending",
+          "title": "Status",
+          "type": "string"
+        },
+        "errors": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Errors",
+          "type": "array"
+        }
+      },
+      "title": "ProcessingMetadata",
+      "type": "object"
+    }
+  },
+  "description": "Top-level per-AOI metadata record (PID Section 9.2).\n\nThis is the complete JSON document written to\n``/metadata/{YYYY}/{MM}/{orchard-name}/{feature-name}.json``.\n\nAttributes:\n    schema_version: Schema identifier for forward compatibility.\n    processing_id: Orchestration instance ID (PID 7.4.4: traceability).\n    kml_filename: Name of the source KML file.\n    feature_name: Name of the feature / Placemark.\n    project_name: Project name (from metadata or filename).\n    tree_variety: Tree/crop variety (from KML ExtendedData, if present).\n    geometry: Polygon geometry and derived measurements.\n    imagery: Imagery acquisition details (populated in M-2.x).\n    processing: Pipeline execution details.",
+  "properties": {
+    "$schema": {
+      "default": "aoi-metadata-v2",
+      "title": "$Schema",
+      "type": "string"
+    },
+    "processing_id": {
+      "default": "",
+      "title": "Processing Id",
+      "type": "string"
+    },
+    "tenant_id": {
+      "default": "",
+      "title": "Tenant Id",
+      "type": "string"
+    },
+    "kml_filename": {
+      "default": "",
+      "title": "Kml Filename",
+      "type": "string"
+    },
+    "feature_name": {
+      "default": "",
+      "title": "Feature Name",
+      "type": "string"
+    },
+    "project_name": {
+      "default": "",
+      "title": "Project Name",
+      "type": "string"
+    },
+    "tree_variety": {
+      "default": "",
+      "title": "Tree Variety",
+      "type": "string"
+    },
+    "geometry": {
+      "$ref": "#/$defs/GeometryMetadata"
+    },
+    "imagery": {
+      "$ref": "#/$defs/ImageryMetadata"
+    },
+    "analysis": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/AnalysisMetadata"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "processing": {
+      "$ref": "#/$defs/ProcessingMetadata"
+    }
+  },
+  "title": "AOIMetadataRecord",
+  "type": "object"
+}


### PR DESCRIPTION
## Summary

Implements issue #18 documentation deliverables to unblock UAT (#19) and give operators/developers a complete reference set.

## Deliverables included

- New architecture document: docs/ARCHITECTURE_OVERVIEW.md
  - Deployed component map and resource naming
  - Data flow and provider boundary
  - Config and observability references

- New operational runbook: docs/OPERATIONS_RUNBOOK.md
  - Deploy, monitor, troubleshooting workflows
  - How to add provider adapter
  - Secret rotation flow
  - Re-processing failed KMLs
  - Tuning buffer/resolution/cloud-threshold settings

- New API/interface reference: docs/API_INTERFACE_REFERENCE.md
  - Public HTTP routes
  - Trigger/orchestrator entrypoints
  - Activity contracts linked to TypedDict payload schemas
  - ImageryProvider ABC contract and error model
  - Blob path conventions

- New formal metadata schema: docs/schemas/aoi-metadata-v2.schema.json
  - Generated from AOIMetadataRecord Pydantic model

- README updates
  - Added links to new docs set
  - Corrected IaC references from Bicep to OpenTofu

## Validation

- uv run pre-commit run --files README.md docs/ARCHITECTURE_OVERVIEW.md docs/OPERATIONS_RUNBOOK.md docs/API_INTERFACE_REFERENCE.md docs/schemas/aoi-metadata-v2.schema.json

Closes #18