### PR TITLE
Roadmap: codify imagery output decision + kick off Wave 2 (#152)

### DIFF
--- a/.github/workflows/base-image-refresh.yml
+++ b/.github/workflows/base-image-refresh.yml
@@ -73,3 +73,12 @@ jobs:
         run: |
           set -euo pipefail
           docker push "${{ steps.image.outputs.name }}"
+
+          stable_ref="ghcr.io/${GITHUB_REPOSITORY,,}:geo-base-stable"
+          latest_ref="ghcr.io/${GITHUB_REPOSITORY,,}:geo-base-latest"
+
+          docker tag "${{ steps.image.outputs.name }}" "$stable_ref"
+          docker tag "${{ steps.image.outputs.name }}" "$latest_ref"
+
+          docker push "$stable_ref"
+          docker push "$latest_ref"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,8 +69,8 @@ env:
   EVENT_GRID_SYSTEM_TOPIC_NAME: evgt-kmlsat-dev
   EVENT_GRID_SUBSCRIPTION_NAME: evgs-kml-upload
   EVENT_GRID_TRIGGER_FUNCTION: kml_blob_trigger
-  BUILDER_BASE_IMAGE: mcr.microsoft.com/azure-functions/python:4-python3.12
-  RUNTIME_BASE_IMAGE: mcr.microsoft.com/azure-functions/python:4-python3.12
+  BUILDER_BASE_IMAGE: ${{ vars.BUILDER_BASE_IMAGE || 'mcr.microsoft.com/azure-functions/python:4-python3.12' }}
+  RUNTIME_BASE_IMAGE: ${{ vars.RUNTIME_BASE_IMAGE || 'mcr.microsoft.com/azure-functions/python:4-python3.12' }}
 
 jobs:
   deploy-dev:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # TreeSight - Development Roadmap
 
-**Last updated:** 11 March 2026
-**Status:** Active - E2E pipeline verification (production confidence gate)
+**Last updated:** 12 March 2026
+**Status:** Active - Wave 2 delivery-speed execution (#152), with Wave 1 sign-off pending domain expert approval (#19)
 
 This roadmap is synchronized to the current GitHub issue backlog. The execution order below is dependency-first (not time-based).
 
@@ -50,7 +50,7 @@ This roadmap is synchronized to the current GitHub issue backlog. The execution 
 
 ---
 
-### Wave 1 - E2E pipeline verification (CURRENT)
+### Wave 1 - E2E pipeline verification (ENGINEERING COMPLETE, SIGN-OFF PENDING)
 
 **Goal:** prove the deployed pipeline actually works end-to-end. Until this passes, all other work ships unverified software.
 
@@ -61,7 +61,7 @@ This roadmap is synchronized to the current GitHub issue backlog. The execution 
 3. **#14** - concurrent upload stress test (≥20 files) ✅
 4. **#16** - logging and alerting validated with correlation IDs in App Insights ✅
 5. **#17** - security review (Key Vault, Managed Identity, RBAC) ✅
-6. **#19** - UAT sign-off (in progress; documentation baseline complete, awaiting domain expert session)
+6. **#19** - UAT sign-off (blocked on domain expert visual review/sign-off; automated UAT run complete)
 
 **Exit criteria:**
 
@@ -96,6 +96,8 @@ This roadmap is synchronized to the current GitHub issue backlog. The execution 
 3. #132 - TypedDict to Pydantic migration (incremental, no behavior regressions)
 4. #163 - document readiness and diagnostics access model
 5. #164 - post-deploy smoke checks for artifact verification
+6. #176 - UX output framing policy (square-framed AOI outputs, multipolygon split default)
+7. #177 - optional H3-derived analytical outputs (AOI-first primary deliverables preserved)
 
 **Exit criteria:**
 
@@ -172,8 +174,8 @@ Decision gate before starting:
 
 Use this exact queue unless blocked:
 
-1. #19  ← CURRENT (UAT sign-off execution)
-2. #152
+1. #152  ← CURRENT (native geospatial base image strategy)
+2. #19   (human sign-off gate; unblock via domain expert review)
 3. #150
 4. #151
 5. #129

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -31,6 +31,22 @@ For dev this commonly resolves to:
 5. Metadata and imagery artifacts are written to output blob paths.
 6. Operational diagnostics are available at /api/orchestrator/{instance_id}.
 
+## Imagery Output Framing Policy (2026-03-12)
+
+User-facing imagery outputs follow an AOI-first UX policy:
+
+- Primary deliverable: regular framed outputs that fully contain each AOI feature.
+- Default framing mode target: square frame with small configurable padding.
+- MultiPolygon handling target: split into per-feature/per-polygon outputs by default.
+- Optional artifact: composite overview image for context.
+- Ground truth remains AOI geometry in metadata/contracts.
+
+Backlog tracking:
+
+- #176 (enhancement): implement regular framed output strategy and multipolygon split defaults.
+- #177 (enhancement): add optional H3-derived analytical outputs without replacing AOI-first deliverables.
+- #172 (bug): restore clipping pipeline path so framed/clipped outputs are generated from blob-backed imagery.
+
 ## Provider Adapter Boundary
 
 The orchestrator calls provider adapters only through the ImageryProvider contract in kml_satellite/providers/base.py.

--- a/docs/adr/0001-geospatial-base-image-strategy.md
+++ b/docs/adr/0001-geospatial-base-image-strategy.md
@@ -34,6 +34,8 @@ Hybrid model (Option 3).
 - `BUILDER_BASE_IMAGE` and `RUNTIME_BASE_IMAGE` are workflow-controlled inputs
 - Values can be pinned to immutable digests (recommended for production)
 - Defaults remain tag-based to avoid breaking immediate builds while rollout occurs
+- Deploy workflow reads `BUILDER_BASE_IMAGE` and `RUNTIME_BASE_IMAGE` from GitHub Actions repository variables with safe fallback defaults
+- Base-image refresh publishes stable rolling refs (`geo-base-stable`, `geo-base-latest`) alongside immutable run-scoped tags
 
 ## Consequences
 

--- a/docs/reviews/UAT_VALIDATION.md
+++ b/docs/reviews/UAT_VALIDATION.md
@@ -108,9 +108,14 @@ For each scenario, collect:
 
 | # | Finding | Severity | Action |
 |---|---|---|---|
-| F-1 | Post-process clipping fails with "No such file or directory" — `post_process_imagery` resolves the adapter blob path as a local filesystem path instead of reading from blob storage. Raw imagery is stored correctly; clipped images are not produced. | Non-blocking | Raise as backlog bug issue |
-| F-2 | KML archive path is recorded in metadata output (`kml_archive_path`) but the file is never written to `kml-output`. | Non-blocking | Raise as backlog bug issue |
-| F-3 | GHCR registry credential (`DOCKER_REGISTRY_SERVER_PASSWORD`) was null on the live function app, causing repeated `ImagePullBackOff` until fixed by supplying a PAT. Registry credential rotation should be automated or the package made public. | Non-blocking | Raise as operational enhancement issue |
+| F-1 | Post-process clipping fails with "No such file or directory" — `post_process_imagery` resolves the adapter blob path as a local filesystem path instead of reading from blob storage. Raw imagery is stored correctly; clipped images are not produced. | Non-blocking | Tracked in #172 |
+| F-2 | KML archive path is recorded in metadata output (`kml_archive_path`) but the file is never written to `kml-output`. | Non-blocking | Tracked in #173 |
+| F-3 | GHCR registry credential (`DOCKER_REGISTRY_SERVER_PASSWORD`) was null on the live function app, causing repeated `ImagePullBackOff` until fixed by supplying a PAT. Registry credential rotation should be automated or the package made public. | Non-blocking | Tracked in #174 |
+
+Related architecture/UX follow-up:
+
+- #176: regular framed AOI output policy (square-framed, multipolygon split default)
+- #177: optional H3-derived analytical outputs while preserving AOI-first primary outputs
 
 ## Defect Handling During UAT
 


### PR DESCRIPTION
## Summary
- Create/track output-shape decisions with new backlog items: #176 and #177
- Update architecture and UAT docs to reference decision and concrete issue IDs (#172, #173, #174)
- Update roadmap state to mark #152 as active and #19 as human sign-off gate
- Advance #152 by making deploy base image selection variable-driven
- Publish stable geospatial base tags (geo-base-stable, geo-base-latest) in refresh workflow

## Why
This keeps roadmap execution moving while capturing the UX decision in durable project docs and making base-image strategy consumable in deploy pipelines.

## Validation
- uv run pytest tests/unit/test_base_image_strategy.py tests/unit/test_base_image_refresh_workflow.py tests/unit/test_ci_workflow_lanes.py -q
- uv run pre-commit run --files ROADMAP.md docs/ARCHITECTURE_OVERVIEW.md docs/reviews/UAT_VALIDATION.md docs/adr/0001-geospatial-base-image-strategy.md .github/workflows/deploy.yml .github/workflows/base-image-refresh.yml