### PR TITLE
perf(image #148): skip duplicate geospatial wheels on geo base

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,8 +161,13 @@ jobs:
           set -euo pipefail
           builder="${MANUAL_BUILDER_BASE_IMAGE:-ghcr.io/hardcoreprawn/azure-workflow-for-kml-satellite:geo-base-stable}"
           runtime="${MANUAL_RUNTIME_BASE_IMAGE:-ghcr.io/hardcoreprawn/azure-workflow-for-kml-satellite:geo-base-stable}"
+          geo_preinstalled="false"
+          if [[ "$builder" == *"geo-base"* || "$runtime" == *"geo-base"* ]]; then
+            geo_preinstalled="true"
+          fi
           echo "builder=$builder" >> "$GITHUB_OUTPUT"
           echo "runtime=$runtime" >> "$GITHUB_OUTPUT"
+          echo "geo_preinstalled=$geo_preinstalled" >> "$GITHUB_OUTPUT"
 
       - name: Build and push container image
         uses: docker/build-push-action@v6
@@ -173,6 +178,7 @@ jobs:
           build-args: |
             BUILDER_BASE_IMAGE=${{ steps.base_images.outputs.builder }}
             RUNTIME_BASE_IMAGE=${{ steps.base_images.outputs.runtime }}
+            GEO_DEPS_PREINSTALLED=${{ steps.base_images.outputs.geo_preinstalled }}
           cache-from: type=registry,ref=${{ steps.image.outputs.cache_ref }}
           cache-to: type=registry,ref=${{ steps.image.outputs.cache_ref }},mode=max
           labels: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@
 # ---------------------------------------------------------------------------
 ARG BUILDER_BASE_IMAGE=mcr.microsoft.com/azure-functions/python:4-python3.12
 ARG RUNTIME_BASE_IMAGE=mcr.microsoft.com/azure-functions/python:4-python3.12
+ARG GEO_DEPS_PREINSTALLED=false
 FROM ${BUILDER_BASE_IMAGE} AS builder
 
 # Install system dependencies for building GDAL, Fiona, rasterio
@@ -30,8 +31,14 @@ RUN mkdir -p /build /home/site/wwwroot/.python_packages/lib/site-packages \
 USER app
 
 COPY --chown=app:app requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir --target=/home/site/wwwroot/.python_packages/lib/site-packages \
-    -r /tmp/requirements.txt
+ARG GEO_DEPS_PREINSTALLED
+RUN if [ "$GEO_DEPS_PREINSTALLED" = "true" ]; then \
+            grep -Evi '^(fiona|lxml|shapely|pyproj|rasterio)($|[<>=~!])' /tmp/requirements.txt > /tmp/requirements.runtime.txt; \
+        else \
+            cp /tmp/requirements.txt /tmp/requirements.runtime.txt; \
+        fi && \
+        pip install --no-cache-dir --target=/home/site/wwwroot/.python_packages/lib/site-packages \
+        -r /tmp/requirements.runtime.txt
 # Copy application code
 WORKDIR /build
 COPY --chown=app:app host.json /build/

--- a/tests/unit/test_base_image_strategy.py
+++ b/tests/unit/test_base_image_strategy.py
@@ -48,8 +48,10 @@ def deploy_workflow() -> dict[str, Any]:
 def test_dockerfile_uses_configurable_base_image_args(dockerfile_content: str) -> None:
     assert "ARG BUILDER_BASE_IMAGE=" in dockerfile_content
     assert "ARG RUNTIME_BASE_IMAGE=" in dockerfile_content
+    assert "ARG GEO_DEPS_PREINSTALLED=" in dockerfile_content
     assert "FROM ${BUILDER_BASE_IMAGE} AS builder" in dockerfile_content
     assert "FROM ${RUNTIME_BASE_IMAGE}" in dockerfile_content
+    assert 'if [ "$GEO_DEPS_PREINSTALLED" = "true" ]' in dockerfile_content
 
 
 def test_deploy_workflow_sets_base_image_build_args(deploy_workflow: dict[str, Any]) -> None:
@@ -64,3 +66,4 @@ def test_deploy_workflow_sets_base_image_build_args(deploy_workflow: dict[str, A
 
     assert "BUILDER_BASE_IMAGE=" in build_args
     assert "RUNTIME_BASE_IMAGE=" in build_args
+    assert "GEO_DEPS_PREINSTALLED=" in build_args


### PR DESCRIPTION
## Summary
- add conditional geospatial dependency installation in Dockerfile
- skip fiona/lxml/shapely/pyproj/rasterio install into .python_packages when base image already preinstalls them
- wire deploy workflow to set GEO_DEPS_PREINSTALLED for geo-base image refs
- add unit contract checks for the new optimization wiring

## Validation
- uv run pytest tests/unit/test_base_image_strategy.py tests/unit/test_architecture_compliance.py -v --tb=short

Refs #148