### PR TITLE
fix: wire blob I/O into post_process_imagery and write_metadata (#172, #173)

### DIFF
--- a/function_app.py
+++ b/function_app.py
@@ -651,6 +651,8 @@ def write_metadata_activity(activityInput: str) -> dict[str, object]:  # noqa: N
     processing_id = str(payload.get("processing_id", ""))
     timestamp = str(payload.get("timestamp", ""))
     tenant_id = str(payload.get("tenant_id", ""))
+    source_kml_container = str(payload.get("source_kml_container", ""))
+    source_kml_blob_name = str(payload.get("source_kml_blob_name", ""))
 
     logger.info(
         "write_metadata activity started | feature=%s | processing_id=%s",
@@ -670,6 +672,8 @@ def write_metadata_activity(activityInput: str) -> dict[str, object]:  # noqa: N
         timestamp=timestamp,
         tenant_id=tenant_id,
         blob_service_client=blob_service,
+        source_kml_container=source_kml_container,
+        source_kml_blob_name=source_kml_blob_name,
     )
 
     logger.info(

--- a/kml_satellite/activities/post_process_imagery.py
+++ b/kml_satellite/activities/post_process_imagery.py
@@ -30,6 +30,8 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
+import tempfile
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -122,6 +124,8 @@ def post_process_imagery(
         msg = "post_process_imagery: blob_path is missing from download_result"
         raise PostProcessError(msg, retryable=False)
 
+    source_container = str(download_result.get("container", ""))
+
     logger.info(
         "post_process_imagery started | order=%s | feature=%s | "
         "clipping=%s | reprojection=%s | target_crs=%s",
@@ -168,6 +172,8 @@ def post_process_imagery(
         enable_reprojection=enable_reprojection,
         order_id=order_id,
         feature_name=feature_name,
+        source_container=source_container,
+        output_container=output_container,
     )
 
     duration = time.monotonic() - start_time
@@ -214,6 +220,8 @@ def _process_raster(
     enable_reprojection: bool,
     order_id: str,
     feature_name: str,
+    source_container: str = "",
+    output_container: str = "",
 ) -> dict[str, Any]:
     """Execute the raster processing pipeline (reproject + clip).
 
@@ -241,13 +249,6 @@ def _process_raster(
             "clip_error": f"rasterio not available: {exc}",
         }
 
-    # NOTE: In production, source_blob_path would reference Azure Blob Storage.
-    # The actual blob download/upload is an infrastructure concern — currently
-    # the provider adapter streams data but doesn't persist it (see M-2.4 notes).
-    # This implementation processes local file paths for testability.
-    # When blob I/O is wired, this will use rasterio's GDAL vsicurl or
-    # download to a temp file first.
-
     source_crs = ""
     reprojected = False
     clipped = False
@@ -255,15 +256,23 @@ def _process_raster(
     output_path = source_blob_path
     output_size_bytes = 0
     reprojected_temp_path = ""
+    downloaded_temp_path = ""
+    clipped_temp_path = ""
 
     try:
-        source_crs = _get_raster_crs(source_blob_path, cast("RasterioModule", rasterio))
+        # Download source blob to a local temp file for rasterio.
+        # Falls back to treating source_blob_path as a local path when
+        # AzureWebJobsStorage is unavailable (e.g. unit tests / local dev).
+        downloaded_temp_path = _download_blob_to_temp(source_container, source_blob_path, order_id)
+        local_source = downloaded_temp_path or source_blob_path
+
+        source_crs = _get_raster_crs(local_source, cast("RasterioModule", rasterio))
 
         # Step 1: Reproject if needed (FR-3.11)
-        working_path = source_blob_path
+        working_path = local_source
         if enable_reprojection and source_crs and source_crs != target_crs:
             working_path = _reproject_raster(
-                source_blob_path,
+                local_source,
                 target_crs,
                 cast("RasterioModule", rasterio),
                 order_id=order_id,
@@ -280,20 +289,26 @@ def _process_raster(
         # Step 2: Clip to AOI polygon (FR-3.12)
         if enable_clipping:
             try:
-                output_path, output_size_bytes = _clip_raster(
+                with tempfile.NamedTemporaryFile(suffix=".tif", delete=False) as tmp:
+                    clipped_temp_path = tmp.name
+                _, output_size_bytes = _clip_raster(
                     working_path,
-                    clipped_blob_path,
+                    clipped_temp_path,
                     exterior_coords,
                     interior_coords,
                     cast("RasterioModule", rasterio),
                     order_id=order_id,
                     feature_name=feature_name,
                 )
+                # Upload clipped output to blob storage (FR-4.3).
+                _upload_local_to_blob(
+                    output_container, clipped_blob_path, clipped_temp_path, order_id
+                )
+                output_path = clipped_blob_path
                 clipped = True
             except Exception as exc:
                 # Graceful degradation (PID 7.4.2): clipping failed.
-                # Always fall back to the original source blob path so callers
-                # receive a stable, upload-safe location.
+                # Fall back to the raw blob path so callers receive a stable reference.
                 clip_error = str(exc)
                 output_path = source_blob_path
                 logger.warning(
@@ -305,11 +320,14 @@ def _process_raster(
                     output_path,
                 )
         else:
-            output_path = working_path
-            # Populate size when reprojection-only (no clipping)
-            if reprojected and working_path != source_blob_path:
+            # No clipping: upload reprojected result to output blob if applicable.
+            if reprojected and working_path != local_source:
                 with contextlib.suppress(OSError):
                     output_size_bytes = Path(working_path).stat().st_size
+                _upload_local_to_blob(output_container, clipped_blob_path, working_path, order_id)
+                output_path = clipped_blob_path
+            else:
+                output_path = source_blob_path
 
     except Exception as exc:
         # Fatal raster processing error — graceful degradation
@@ -320,17 +338,11 @@ def _process_raster(
             exc,
         )
     finally:
-        # Clean up temporary reprojected file if it's not the final output
-        if reprojected_temp_path and reprojected_temp_path != output_path:
-            try:
-                Path(reprojected_temp_path).unlink()
-                logger.debug(
-                    "Removed temporary reprojected file | order=%s | path=%s",
-                    order_id,
-                    reprojected_temp_path,
-                )
-            except OSError:
-                pass  # Best-effort cleanup
+        # Best-effort cleanup of all local temp files
+        for _temp in (downloaded_temp_path, reprojected_temp_path, clipped_temp_path):
+            if _temp and _temp != source_blob_path:
+                with contextlib.suppress(OSError):
+                    Path(_temp).unlink()
 
     return {
         "clipped": clipped,
@@ -523,3 +535,85 @@ def _build_geojson_polygon(
         "type": "Polygon",
         "coordinates": rings,
     }
+
+
+def _download_blob_to_temp(container: str, blob_path: str, order_id: str) -> str:
+    """Download a blob to a local temp file for rasterio processing.
+
+    Returns the temp file path on success, or empty string when
+    ``AzureWebJobsStorage`` is unavailable (tests / local dev).
+    """
+    connection_string = os.environ.get("AzureWebJobsStorage", "")
+    if not connection_string or not container or not blob_path:
+        return ""
+
+    try:
+        from azure.storage.blob import BlobServiceClient
+
+        blob_service = BlobServiceClient.from_connection_string(connection_string)
+        blob_client = blob_service.get_blob_client(container=container, blob=blob_path)
+
+        with tempfile.NamedTemporaryFile(suffix=".tif", delete=False) as tmp:
+            temp_path = tmp.name
+
+        with Path(temp_path).open("wb") as f:
+            download_stream = blob_client.download_blob()
+            f.write(download_stream.readall())
+
+        logger.debug(
+            "Downloaded source blob to temp | order=%s | container=%s | blob=%s | temp=%s",
+            order_id,
+            container,
+            blob_path,
+            temp_path,
+        )
+        return temp_path
+    except Exception as exc:
+        logger.warning(
+            "Failed to download source blob | order=%s | container=%s | blob=%s | error=%s",
+            order_id,
+            container,
+            blob_path,
+            exc,
+        )
+        return ""
+
+
+def _upload_local_to_blob(
+    output_container: str, blob_path: str, local_path: str, order_id: str
+) -> None:
+    """Upload a local temp file to blob storage at the given path.
+
+    Raises ``PostProcessError`` (retryable) on upload failure so the caller
+    can apply graceful degradation.  Logs a warning and returns silently
+    when ``AzureWebJobsStorage`` is unavailable.
+    """
+    connection_string = os.environ.get("AzureWebJobsStorage", "")
+    if not connection_string or not output_container or not blob_path:
+        logger.warning(
+            "Skipping blob upload (no AzureWebJobsStorage) | order=%s | blob=%s",
+            order_id,
+            blob_path,
+        )
+        return
+
+    try:
+        from azure.storage.blob import BlobServiceClient
+
+        blob_service = BlobServiceClient.from_connection_string(connection_string)
+        blob_client = blob_service.get_blob_client(container=output_container, blob=blob_path)
+        with Path(local_path).open("rb") as f:
+            blob_client.upload_blob(f, overwrite=True, content_type="image/tiff")
+
+        logger.debug(
+            "Uploaded processed blob | order=%s | container=%s | blob=%s",
+            order_id,
+            output_container,
+            blob_path,
+        )
+    except Exception as exc:
+        msg = (
+            f"Failed to upload processed blob | order={order_id} | "
+            f"container={output_container} | blob={blob_path} | error={exc}"
+        )
+        raise PostProcessError(msg, retryable=True) from exc

--- a/kml_satellite/activities/write_metadata.py
+++ b/kml_satellite/activities/write_metadata.py
@@ -52,6 +52,8 @@ def write_metadata(
     tenant_id: str = "",
     blob_service_client: object | None = None,
     output_container: str = DEFAULT_OUTPUT_CONTAINER,
+    source_kml_container: str = "",
+    source_kml_blob_name: str = "",
 ) -> dict[str, object]:
     """Build and store a metadata JSON document for a processed AOI.
 
@@ -62,6 +64,8 @@ def write_metadata(
         blob_service_client: Optional ``BlobServiceClient`` for writing to
             Blob Storage.  If ``None``, metadata is built and returned
             without writing (useful for testing and local dev).
+        source_kml_container: Container holding the original KML file.
+        source_kml_blob_name: Blob name of the original KML file to archive.
 
     Returns:
         A dict containing:
@@ -114,6 +118,16 @@ def write_metadata(
     # Write to Blob Storage if a client is provided
     if blob_service_client is not None:
         _upload_metadata(blob_service_client, metadata_path, metadata_json, output_container)
+
+    # Archive the original KML file alongside its metadata (FR-4.4).
+    if blob_service_client is not None and source_kml_container and source_kml_blob_name:
+        _archive_kml(
+            blob_service_client,
+            source_container=source_kml_container,
+            source_blob_name=source_kml_blob_name,
+            archive_path=kml_archive_path,
+            output_container=output_container,
+        )
 
     logger.info(
         "Metadata written | feature=%s | path=%s | processing_id=%s | tenant_id=%s",
@@ -168,3 +182,69 @@ def _upload_metadata(
     except Exception as exc:
         msg = f"Failed to upload metadata to {metadata_path}: {exc}"
         raise MetadataWriteError(msg) from exc
+
+
+def _archive_kml(
+    blob_service_client: object,
+    *,
+    source_container: str,
+    source_blob_name: str,
+    archive_path: str,
+    output_container: str = DEFAULT_OUTPUT_CONTAINER,
+) -> None:
+    """Copy the original KML blob to the archive path in the output container.
+
+    Idempotent: overwrites if the archive blob already exists (PID 7.4.4).
+    Logs a warning and returns silently on failure — the metadata write
+    is already committed and KML archiving is best-effort.
+
+    Args:
+        blob_service_client: An Azure ``BlobServiceClient`` instance.
+        source_container: Container holding the original KML file.
+        source_blob_name: Blob name of the original KML file.
+        archive_path: Destination blob path in the output container.
+        output_container: Output container for the archive.
+    """
+    try:
+        from azure.storage.blob import BlobServiceClient
+
+        if not isinstance(blob_service_client, BlobServiceClient):
+            return
+
+        source_client = blob_service_client.get_blob_client(
+            container=source_container, blob=source_blob_name
+        )
+        dest_client = blob_service_client.get_blob_client(
+            container=output_container, blob=archive_path
+        )
+
+        if not source_client.exists():
+            logger.warning(
+                "KML source blob not found — skipping archive | container=%s | blob=%s",
+                source_container,
+                source_blob_name,
+            )
+            return
+
+        source_data = source_client.download_blob().readall()
+        dest_client.upload_blob(
+            source_data,
+            overwrite=True,
+            content_type="application/vnd.google-earth.kml+xml",
+        )
+
+        logger.info(
+            "KML archived | source=%s/%s | dest=%s/%s",
+            source_container,
+            source_blob_name,
+            output_container,
+            archive_path,
+        )
+    except Exception as exc:
+        logger.warning(
+            "KML archive failed (non-fatal) | source=%s/%s | dest=%s | error=%s",
+            source_container,
+            source_blob_name,
+            archive_path,
+            exc,
+        )

--- a/kml_satellite/models/payloads.py
+++ b/kml_satellite/models/payloads.py
@@ -54,6 +54,8 @@ class WriteMetadataInput(TypedDict):
     processing_id: str
     timestamp: str
     tenant_id: NotRequired[str]
+    source_kml_container: NotRequired[str]
+    source_kml_blob_name: NotRequired[str]
 
 
 class WriteMetadataOutput(TypedDict):

--- a/kml_satellite/orchestrators/phases.py
+++ b/kml_satellite/orchestrators/phases.py
@@ -215,6 +215,8 @@ def run_ingestion_phase(
                 "processing_id": instance_id,
                 "timestamp": timestamp,
                 "tenant_id": tenant_id,
+                "source_kml_container": str(blob_event.get("container_name", "")),
+                "source_kml_blob_name": str(blob_event.get("blob_name", "")),
             },
         )
         for a in aois_list

--- a/tests/unit/test_post_process_imagery.py
+++ b/tests/unit/test_post_process_imagery.py
@@ -23,7 +23,9 @@ from kml_satellite.activities.post_process_imagery import (
     PostProcessError,
     _build_geojson_polygon,
     _clip_raster,
+    _download_blob_to_temp,
     _get_raster_crs,
+    _upload_local_to_blob,
     post_process_imagery,
 )
 
@@ -491,3 +493,71 @@ class TestPostProcessDefaults(unittest.TestCase):
 
     def test_default_target_crs(self) -> None:
         assert DEFAULT_TARGET_CRS == "EPSG:4326"
+
+
+# ---------------------------------------------------------------------------
+# Tests — blob I/O helpers (Issue #172)
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadBlobToTemp(unittest.TestCase):
+    """_download_blob_to_temp — returns empty string when unavailable."""
+
+    def test_returns_empty_when_no_connection_string(self) -> None:
+        """No AzureWebJobsStorage → returns empty string without error."""
+        with patch.dict("os.environ", {}, clear=True):
+            result = _download_blob_to_temp("container", "blob/path.tif", "order-1")
+        assert result == ""
+
+    def test_returns_empty_when_container_empty(self) -> None:
+        """Empty container → returns empty string."""
+        with patch.dict("os.environ", {"AzureWebJobsStorage": "DefaultEndpointsProtocol=https"}):
+            result = _download_blob_to_temp("", "blob/path.tif", "order-1")
+        assert result == ""
+
+    def test_returns_empty_on_sdk_error(self) -> None:
+        """SDK raises -> logs warning and returns empty string."""
+        with (
+            patch.dict("os.environ", {"AzureWebJobsStorage": "UseDevelopmentStorage=true"}),
+            patch(
+                "azure.storage.blob.BlobServiceClient.from_connection_string",
+                side_effect=ValueError("bad conn"),
+            ),
+        ):
+            result = _download_blob_to_temp("ctr", "blob.tif", "order-1")
+        assert result == ""
+
+
+class TestUploadLocalToBlob(unittest.TestCase):
+    """_upload_local_to_blob — contract tests."""
+
+    def test_skips_when_no_connection_string(self) -> None:
+        """No AzureWebJobsStorage → logs warning, no exception."""
+        with patch.dict("os.environ", {}, clear=True):
+            # Should not raise
+            _upload_local_to_blob("container", "blob/path.tif", "/tmp/file.tif", "order-1")
+
+    def test_skips_when_container_empty(self) -> None:
+        """Empty container → silently skips."""
+        with patch.dict("os.environ", {"AzureWebJobsStorage": "DefaultEndpointsProtocol=https"}):
+            _upload_local_to_blob("", "blob/path.tif", "/tmp/file.tif", "order-1")
+
+    def test_raises_post_process_error_on_sdk_failure(self) -> None:
+        """SDK raises → PostProcessError (retryable) is raised."""
+
+        # Patch open so we don't need a real file, then make blob upload raise
+        with (
+            patch.dict("os.environ", {"AzureWebJobsStorage": "UseDevelopmentStorage=true"}),
+            patch("builtins.open", unittest.mock.mock_open(read_data=b"")),
+            patch("azure.storage.blob.BlobServiceClient.from_connection_string") as mock_from_cs,
+        ):
+            mock_client = MagicMock()
+            mock_blob = MagicMock()
+            mock_blob.upload_blob.side_effect = RuntimeError("upload error")
+            mock_client.get_blob_client.return_value = mock_blob
+            mock_from_cs.return_value = mock_client
+
+            with self.assertRaises(PostProcessError) as ctx:
+                _upload_local_to_blob("container", "blob.tif", "/tmp/f.tif", "order-1")
+
+        assert ctx.exception.retryable is True

--- a/tests/unit/test_write_metadata.py
+++ b/tests/unit/test_write_metadata.py
@@ -16,6 +16,7 @@ import pytest
 
 from kml_satellite.activities.write_metadata import (
     MetadataWriteError,
+    _archive_kml,
     write_metadata,
 )
 from kml_satellite.models.aoi import AOI
@@ -277,3 +278,97 @@ class TestSchemaConformance:
         aoi = _make_aoi()
         result = write_metadata(aoi)
         assert result["metadata"].get("analysis") is None
+
+
+# ===========================================================================
+# KML archive (Issue #173)
+# ===========================================================================
+
+
+class TestKMLArchive:
+    """Tests for _archive_kml and write_metadata KML archiving behaviour."""
+
+    def test_kml_archived_when_source_provided(self) -> None:
+        """KML is copied to archive path when source container/blob given."""
+        aoi = _make_aoi()
+        with (
+            patch("kml_satellite.activities.write_metadata._upload_metadata"),
+            patch("kml_satellite.activities.write_metadata._archive_kml") as mock_archive,
+        ):
+            from azure.storage.blob import BlobServiceClient
+
+            mock_client = MagicMock(spec=BlobServiceClient)
+            write_metadata(
+                aoi,
+                blob_service_client=mock_client,
+                source_kml_container="kml-input",
+                source_kml_blob_name="orchard_alpha.kml",
+                timestamp="2026-03-12T10:00:00+00:00",
+            )
+
+        mock_archive.assert_called_once()
+        call_kwargs = mock_archive.call_args
+        assert call_kwargs[1]["source_container"] == "kml-input"
+        assert call_kwargs[1]["source_blob_name"] == "orchard_alpha.kml"
+
+    def test_kml_not_archived_without_client(self) -> None:
+        """KML archive is skipped when no blob_service_client provided."""
+        aoi = _make_aoi()
+        with patch("kml_satellite.activities.write_metadata._archive_kml") as mock_archive:
+            write_metadata(
+                aoi,
+                blob_service_client=None,
+                source_kml_container="kml-input",
+                source_kml_blob_name="orchard_alpha.kml",
+            )
+        mock_archive.assert_not_called()
+
+    def test_kml_not_archived_when_source_empty(self) -> None:
+        """KML archive is skipped when source_kml_container is empty."""
+        aoi = _make_aoi()
+        with (
+            patch("kml_satellite.activities.write_metadata._upload_metadata"),
+            patch("kml_satellite.activities.write_metadata._archive_kml") as mock_archive,
+        ):
+            from azure.storage.blob import BlobServiceClient
+
+            mock_client = MagicMock(spec=BlobServiceClient)
+            write_metadata(aoi, blob_service_client=mock_client)
+
+        mock_archive.assert_not_called()
+
+    def test_archive_kml_non_fatal_on_error(self) -> None:
+        """_archive_kml logs warning and returns on error (non-fatal)."""
+        # If the source blob service raises any error, _archive_kml must not propagate.
+        from azure.storage.blob import BlobServiceClient
+
+        mock_client = MagicMock(spec=BlobServiceClient)
+        mock_blob_client = MagicMock()
+        mock_blob_client.exists.side_effect = RuntimeError("network error")
+        mock_client.get_blob_client.return_value = mock_blob_client
+
+        # Should not raise
+        _archive_kml(
+            mock_client,
+            source_container="kml-input",
+            source_blob_name="orchard.kml",
+            archive_path="kml/2026/03/alpha-orchard/orchard.kml",
+        )
+
+    def test_archive_kml_skips_missing_source_blob(self) -> None:
+        """_archive_kml skips and logs warning when source blob does not exist."""
+        from azure.storage.blob import BlobServiceClient
+
+        mock_client = MagicMock(spec=BlobServiceClient)
+        mock_blob_client = MagicMock()
+        mock_blob_client.exists.return_value = False
+        mock_client.get_blob_client.return_value = mock_blob_client
+
+        _archive_kml(
+            mock_client,
+            source_container="kml-input",
+            source_blob_name="missing.kml",
+            archive_path="kml/2026/03/unknown/missing.kml",
+        )
+
+        mock_blob_client.download_blob.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes two UAT-observed bugs where activities built correct blob paths but then treated them as local filesystem paths.

### Bug #172 — post_process_imagery clips always fail

**Root cause:** `_process_raster` called `rasterio.open(source_blob_path)` where `source_blob_path` was an Azure Blob Storage path (e.g. `imagery/raw/2026/03/...`), not a local file.

**Fix:**
- `_download_blob_to_temp()`: downloads the source blob to a local `NamedTemporaryFile` before rasterio processing
- `_upload_local_to_blob()`: uploads the clipped/reprojected output back to blob storage at the canonical blob path
- `_process_raster()` accepts `source_container` + `output_container` params and wires both helpers into the processing flow
- Falls back to treating the path as local when `AzureWebJobsStorage` is absent (unit tests / local dev)

### Bug #173 — KML never written to kml-output

**Root cause:** `write_metadata` computed `kml_archive_path` and returned it, but never actually copied the source KML blob to that path.

**Fix:**
- `_archive_kml()`: copies the source KML blob to `kml_archive_path` in the output container — non-fatal (logs warning on failure, metadata write already committed)
- `write_metadata()` accepts `source_kml_container` + `source_kml_blob_name` params and calls `_archive_kml` when both are non-empty
- `phases.py` ingestion step passes `blob_event["container_name"]` and `blob_event["blob_name"]` in the `write_metadata` activity input
- `WriteMetadataInput` TypedDict updated with two `NotRequired` fields

## Tests

- 52 unit tests pass (11 new tests covering blob helpers and KML archive)
- 1127 total unit tests pass
- pyright: 0 errors

Fixes #172
Fixes #173
