### PR TITLE
Issue #148: prune Python cache artifacts in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN if [ "$GEO_DEPS_PREINSTALLED" = "true" ]; then \
         else \
             cp /tmp/requirements.txt /tmp/requirements.runtime.txt; \
         fi && \
-        pip install --no-cache-dir --target=/home/site/wwwroot/.python_packages/lib/site-packages \
+        pip install --no-cache-dir --no-compile --target=/home/site/wwwroot/.python_packages/lib/site-packages \
         -r /tmp/requirements.runtime.txt
 # Copy application code
 WORKDIR /build
@@ -79,6 +79,12 @@ COPY --from=builder --chown=app:app /home/site/wwwroot/.python_packages /home/si
 COPY --from=builder --chown=app:app /build/host.json /home/site/wwwroot/
 COPY --from=builder --chown=app:app /build/function_app.py /home/site/wwwroot/
 COPY --from=builder --chown=app:app /build/kml_satellite/ /home/site/wwwroot/kml_satellite/
+
+# Remove bytecode and interpreter caches that do not provide runtime value.
+RUN find /home/site/wwwroot/.python_packages /home/site/wwwroot/kml_satellite \
+    -type d -name '__pycache__' -prune -exec rm -rf '{}' + \
+    && find /home/site/wwwroot/.python_packages /home/site/wwwroot/kml_satellite \
+    -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete
 
 USER app
 

--- a/tests/unit/test_dockerfile.py
+++ b/tests/unit/test_dockerfile.py
@@ -222,6 +222,18 @@ class TestGeospatialDependencies:
             "Dockerfile must include geospatial import smoke check"
         )
 
+    def test_prunes_python_cache_artifacts(self, dockerfile_content: str) -> None:
+        """Runtime image should prune pycache/bytecode from packaged deps and app code."""
+        assert "--no-compile --target=/home/site/wwwroot/.python_packages/lib/site-packages" in (
+            dockerfile_content
+        ), "Dockerfile should disable bytecode compilation during pip install"
+        assert "-type d -name '__pycache__'" in dockerfile_content, (
+            "Dockerfile should remove __pycache__ directories from packaged artifacts"
+        )
+        assert "-name '*.pyc' -o -name '*.pyo'" in dockerfile_content, (
+            "Dockerfile should remove compiled Python bytecode files from packaged artifacts"
+        )
+
     def test_sets_gdal_config_env(self, dockerfile_content: str) -> None:
         """Builder must set GDAL_CONFIG for pip to find GDAL during wheel builds."""
         assert "GDAL_CONFIG" in dockerfile_content, (


### PR DESCRIPTION
## Summary\n- add pip --no-compile to dependency install in the builder stage\n- prune __pycache__, .pyc, and .pyo artifacts from packaged dependencies/app code in runtime stage\n- add Dockerfile contract coverage to guard this slimming behavior\n\n## Validation\n- uv run pytest tests/unit/test_dockerfile.py tests/unit/test_base_image_strategy.py -q\n\n## Roadmap\n- Advances #148 (slim runtime Function image without regression).