### PR TITLE
Harden E2E storage auth with account-key fallback

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -97,6 +97,16 @@ jobs:
             --query "[?name=='AzureWebJobsStorage'].value | [0]" -o tsv)
           [[ -n "$STORAGE_CONNECTION_STRING" ]] || fail "Could not resolve AzureWebJobsStorage app setting"
 
+          if [[ "$STORAGE_CONNECTION_STRING" != *"AccountKey="* ]]; then
+            log "AzureWebJobsStorage is not key-based; resolving storage account key for E2E uploads"
+            STORAGE_KEY=$(az storage account keys list \
+              --account-name "$STORAGE_ACCOUNT" \
+              --resource-group "${{ env.RESOURCE_GROUP }}" \
+              --query "[0].value" -o tsv)
+            [[ -n "$STORAGE_KEY" ]] || fail "Could not resolve storage account key for E2E uploads"
+            STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=${STORAGE_ACCOUNT};AccountKey=${STORAGE_KEY};EndpointSuffix=core.windows.net"
+          fi
+
           # Retrieve default host key for the Durable management API.
           HOST_KEY=$(az functionapp keys list \
             --name "${{ env.FUNCTION_APP_NAME }}" \

--- a/tests/unit/test_e2e_workflow.py
+++ b/tests/unit/test_e2e_workflow.py
@@ -42,6 +42,12 @@ def test_resolve_step_exports_storage_connection_string(e2e_workflow: dict[str, 
     assert "::add-mask::${STORAGE_CONNECTION_STRING}" in run_script, (
         "E2E workflow must mask storage connection string in logs"
     )
+    assert 'if [[ "$STORAGE_CONNECTION_STRING" != *"AccountKey="* ]]; then' in run_script, (
+        "E2E workflow must detect non-key-based AzureWebJobsStorage values"
+    )
+    assert "az storage account keys list" in run_script, (
+        "E2E workflow must fallback to storage account key resolution when needed"
+    )
 
 
 def test_run_step_injects_storage_connection_string(e2e_workflow: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary\n- detect when AzureWebJobsStorage is not key-based (no AccountKey=)\n- fallback to z storage account keys list and build a key-based connection string for E2E uploads\n- add workflow contract assertions so fallback behavior remains enforced\n\n## Validation\n- uv run pytest tests/unit/test_e2e_workflow.py tests/integration/test_live_pipeline.py -q\n\n## Context\nPR #191 introduced connection-string auth for E2E, but this environment's app setting still yielded blob upload auth mismatch. This fallback closes that gap.