### PR TITLE
Use host master key for E2E durable API auth

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,6 +91,9 @@ jobs:
           STORAGE_URL="https://${STORAGE_ACCOUNT}.blob.core.windows.net"
           log "Storage account URL: $STORAGE_URL"
 
+          AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+          RESOURCE_ID="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${{ env.RESOURCE_GROUP }}/providers/Microsoft.Web/sites/${{ env.FUNCTION_APP_NAME }}"
+
           STORAGE_CONNECTION_STRING=$(az functionapp config appsettings list \
             --name "${{ env.FUNCTION_APP_NAME }}" \
             --resource-group "${{ env.RESOURCE_GROUP }}" \
@@ -107,19 +110,12 @@ jobs:
             STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=${STORAGE_ACCOUNT};AccountKey=${STORAGE_KEY};EndpointSuffix=core.windows.net"
           fi
 
-          # Retrieve default host key for the Durable management API.
-          HOST_KEY=$(az functionapp keys list \
-            --name "${{ env.FUNCTION_APP_NAME }}" \
-            --resource-group "${{ env.RESOURCE_GROUP }}" \
-            --query "functionKeys.default" -o tsv)
-
-          if [[ -z "$HOST_KEY" ]]; then
-            # Fallback: try the master key if default is not separately listed.
-            HOST_KEY=$(az functionapp keys list \
-              --name "${{ env.FUNCTION_APP_NAME }}" \
-              --resource-group "${{ env.RESOURCE_GROUP }}" \
-              --query "masterKey" -o tsv)
-          fi
+          # Retrieve host master key for Durable management API calls.
+          KEY_PAYLOAD=$(az rest \
+            --method post \
+            --uri "https://management.azure.com${RESOURCE_ID}/host/default/listKeys?api-version=2024-04-01" \
+            -o json)
+          HOST_KEY=$(echo "$KEY_PAYLOAD" | jq -r '.masterKey // empty')
           [[ -n "$HOST_KEY" ]] || fail "Could not retrieve function host key"
 
           echo "hostname=${HOSTNAME}" >> "$GITHUB_OUTPUT"

--- a/tests/unit/test_e2e_workflow.py
+++ b/tests/unit/test_e2e_workflow.py
@@ -48,6 +48,10 @@ def test_resolve_step_exports_storage_connection_string(e2e_workflow: dict[str, 
     assert "az storage account keys list" in run_script, (
         "E2E workflow must fallback to storage account key resolution when needed"
     )
+    assert "/host/default/listKeys?api-version=2024-04-01" in run_script, (
+        "E2E workflow must resolve a host master key for durable API auth"
+    )
+    assert "jq -r '.masterKey // empty'" in run_script
 
 
 def test_run_step_injects_storage_connection_string(e2e_workflow: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary\n- switch E2E workflow host key resolution to ARM host/default/listKeys\n- use .masterKey for durable management endpoint authentication\n- retain storage auth fallbacks added in #191/#192\n- enforce contract with unit assertions in 	est_e2e_workflow.py\n\n## Validation\n- uv run pytest tests/unit/test_e2e_workflow.py -q\n\n## Why\nE2E instance discovery can silently fail if a function key is used where the Durable management endpoint expects host-level auth.