### PR TITLE
Harden E2E host key resolution fallback

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -110,12 +110,29 @@ jobs:
             STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=${STORAGE_ACCOUNT};AccountKey=${STORAGE_KEY};EndpointSuffix=core.windows.net"
           fi
 
-          # Retrieve host master key for Durable management API calls.
+          # Retrieve host key for Durable management API calls.
+          HOST_KEY=""
           KEY_PAYLOAD=$(az rest \
             --method post \
             --uri "https://management.azure.com${RESOURCE_ID}/host/default/listKeys?api-version=2024-04-01" \
-            -o json)
-          HOST_KEY=$(echo "$KEY_PAYLOAD" | jq -r '.masterKey // empty')
+            -o json 2>/dev/null || true)
+          if [[ -n "$KEY_PAYLOAD" ]]; then
+            HOST_KEY=$(echo "$KEY_PAYLOAD" | jq -r '.masterKey // empty')
+          fi
+
+          if [[ -z "$HOST_KEY" ]]; then
+            HOST_KEY=$(az functionapp keys list \
+              --name "${{ env.FUNCTION_APP_NAME }}" \
+              --resource-group "${{ env.RESOURCE_GROUP }}" \
+              --query "masterKey" -o tsv)
+          fi
+
+          if [[ -z "$HOST_KEY" ]]; then
+            HOST_KEY=$(az functionapp keys list \
+              --name "${{ env.FUNCTION_APP_NAME }}" \
+              --resource-group "${{ env.RESOURCE_GROUP }}" \
+              --query "functionKeys.default" -o tsv)
+          fi
           [[ -n "$HOST_KEY" ]] || fail "Could not retrieve function host key"
 
           echo "hostname=${HOSTNAME}" >> "$GITHUB_OUTPUT"

--- a/tests/unit/test_e2e_workflow.py
+++ b/tests/unit/test_e2e_workflow.py
@@ -52,6 +52,10 @@ def test_resolve_step_exports_storage_connection_string(e2e_workflow: dict[str, 
         "E2E workflow must resolve a host master key for durable API auth"
     )
     assert "jq -r '.masterKey // empty'" in run_script
+    assert "az functionapp keys list" in run_script, (
+        "E2E workflow should fallback to functionapp key APIs when ARM listKeys fails"
+    )
+    assert '--query "masterKey" -o tsv' in run_script
 
 
 def test_run_step_injects_storage_connection_string(e2e_workflow: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary\n- keep ARM host/default/listKeys as the preferred source\n- fallback to z functionapp keys list --query masterKey if ARM call fails\n- final fallback to unctionKeys.default\n- extend unit workflow contracts for this fallback chain\n\n## Validation\n- uv run pytest tests/unit/test_e2e_workflow.py -q