### PR TITLE
ci(base-image): publish actionable Trivy findings artifacts (closes #206)

### DIFF
--- a/.github/workflows/base-image-refresh.yml
+++ b/.github/workflows/base-image-refresh.yml
@@ -59,14 +59,215 @@ jobs:
           set -euo pipefail
           docker run --rm "${{ steps.image.outputs.name }}" python -c "import rasterio, fiona, pyproj, shapely"
 
+      - name: Validate Trivy allowlist policy
+        id: allowlist
+        shell: bash
+        env:
+          POLICY_FILE: security/trivy/base-image-allowlist.yaml
+          RENDERED_IGNORE_FILE: artifacts/trivy/base-image/.trivyignore.yaml
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "$RENDERED_IGNORE_FILE")"
+
+          python - <<'PY'
+          from __future__ import annotations
+
+          import datetime as dt
+          import os
+          from pathlib import Path
+
+          import yaml
+
+          policy_file = Path(os.environ["POLICY_FILE"])
+          rendered_ignore_file = Path(os.environ["RENDERED_IGNORE_FILE"])
+
+          if not policy_file.exists():
+              raise SystemExit(f"Allowlist policy file missing: {policy_file}")
+
+          policy = yaml.safe_load(policy_file.read_text(encoding="utf-8")) or {}
+          exceptions = policy.get("exceptions", [])
+          if not isinstance(exceptions, list):
+              raise SystemExit("Allowlist policy must define exceptions as a list")
+
+          today = dt.date.today()
+          vulnerabilities: list[dict[str, object]] = []
+
+          for index, exception in enumerate(exceptions, start=1):
+              if not isinstance(exception, dict):
+                  raise SystemExit(f"Exception #{index} must be a mapping")
+
+              required_fields = ("id", "owner", "expires_on", "statement")
+              missing = [field for field in required_fields if not exception.get(field)]
+              if missing:
+                  raise SystemExit(
+                      f"Exception #{index} missing required fields: {', '.join(missing)}"
+                  )
+
+              expires_on = dt.date.fromisoformat(str(exception["expires_on"]))
+              if expires_on < today:
+                  raise SystemExit(
+                      f"Exception {exception['id']} expired on {expires_on.isoformat()}"
+                  )
+
+              rendered_exception: dict[str, object] = {
+                  "id": exception["id"],
+                  "expired_at": expires_on.isoformat(),
+                  "statement": f"{exception['statement']} [owner: {exception['owner']}]",
+              }
+
+              if exception.get("paths"):
+                  rendered_exception["paths"] = exception["paths"]
+              if exception.get("purls"):
+                  rendered_exception["purls"] = exception["purls"]
+
+              vulnerabilities.append(rendered_exception)
+
+          rendered = {
+              "vulnerabilities": vulnerabilities,
+              "misconfigurations": [],
+              "secrets": [],
+              "licenses": [],
+          }
+          rendered_ignore_file.write_text(
+              yaml.safe_dump(rendered, sort_keys=False),
+              encoding="utf-8",
+          )
+          PY
+
+          echo "ignorefile=${RENDERED_IGNORE_FILE}" >> "$GITHUB_OUTPUT"
+          echo "Allowlist policy validated: ${POLICY_FILE}"
+
       - name: Vulnerability scan (Trivy)
         uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: ${{ steps.image.outputs.name }}
-          format: table
+          format: json
+          output: artifacts/trivy/base-image/trivy-results.json
           vuln-type: os,library
           severity: HIGH,CRITICAL
-          exit-code: "1"
+          trivyignores: ${{ steps.allowlist.outputs.ignorefile }}
+          exit-code: "0"
+
+      - name: Generate Trivy SARIF report
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: ${{ steps.image.outputs.name }}
+          format: sarif
+          output: artifacts/trivy/base-image/trivy-results.sarif
+          vuln-type: os,library
+          severity: HIGH,CRITICAL
+          trivyignores: ${{ steps.allowlist.outputs.ignorefile }}
+          limit-severities-for-sarif: true
+          skip-setup-trivy: true
+          exit-code: "0"
+
+      - name: Publish Trivy blocker summary
+        id: trivy-summary
+        shell: bash
+        env:
+          JSON_REPORT: artifacts/trivy/base-image/trivy-results.json
+        run: |
+          set -euo pipefail
+
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          from pathlib import Path
+
+          json_report = Path(os.environ["JSON_REPORT"])
+          if not json_report.exists():
+              raise SystemExit(f"Trivy JSON report missing: {json_report}")
+
+          report = json.loads(json_report.read_text(encoding="utf-8"))
+          blockers: list[dict[str, str]] = []
+
+          for result in report.get("Results") or []:
+              for vulnerability in result.get("Vulnerabilities") or []:
+                  if vulnerability.get("Severity") not in {"HIGH", "CRITICAL"}:
+                      continue
+                  blockers.append(
+                      {
+                          "VulnerabilityID": str(vulnerability.get("VulnerabilityID", "")),
+                          "PkgName": str(vulnerability.get("PkgName", "")),
+                          "InstalledVersion": str(vulnerability.get("InstalledVersion", "")),
+                          "FixedVersion": str(vulnerability.get("FixedVersion", "")),
+                          "Severity": str(vulnerability.get("Severity", "")),
+                      }
+                  )
+
+          critical = sum(1 for blocker in blockers if blocker["Severity"] == "CRITICAL")
+          high = sum(1 for blocker in blockers if blocker["Severity"] == "HIGH")
+          top_blockers = blockers[:10]
+
+          summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
+          with summary_path.open("a", encoding="utf-8") as summary:
+              summary.write("### Trivy blocking vulnerabilities\n\n")
+              summary.write(f"- Blocking findings: {len(blockers)}\n")
+              summary.write(f"- Critical: {critical}\n")
+              summary.write(f"- High: {high}\n\n")
+              if top_blockers:
+                  summary.write("| CVE | Package | Severity | Installed | Fixed |\n")
+                  summary.write("| --- | --- | --- | --- | --- |\n")
+                  for blocker in top_blockers:
+                      fixed_version = blocker["FixedVersion"] or "none"
+                      summary.write(
+                          f"| {blocker['VulnerabilityID']} | {blocker['PkgName']} | {blocker['Severity']} | {blocker['InstalledVersion']} | {fixed_version} |\n"
+                      )
+              else:
+                  summary.write("No HIGH/CRITICAL blockers detected.\n")
+
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              output.write(f"blocking_count={len(blockers)}\n")
+              output.write(f"critical_count={critical}\n")
+              output.write(f"high_count={high}\n")
+          PY
+
+      - name: Upload Trivy findings artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-base-image-findings
+          path: |
+            artifacts/trivy/base-image/trivy-results.json
+            artifacts/trivy/base-image/trivy-results.sarif
+            security/trivy/base-image-allowlist.yaml
+          retention-days: 30
+
+      - name: Enforce HIGH/CRITICAL vulnerability gate
+        shell: bash
+        env:
+          JSON_REPORT: artifacts/trivy/base-image/trivy-results.json
+        run: |
+          set -euo pipefail
+
+          BLOCKING_COUNT=$(python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          from pathlib import Path
+
+          json_report = Path(os.environ["JSON_REPORT"])
+          if not json_report.exists():
+              raise SystemExit(f"Trivy JSON report missing: {json_report}")
+
+          report = json.loads(json_report.read_text(encoding="utf-8"))
+          blocking_count = 0
+          for result in report.get("Results") or []:
+              for vulnerability in result.get("Vulnerabilities") or []:
+                  if vulnerability.get("Severity") in {"HIGH", "CRITICAL"}:
+                      blocking_count += 1
+          print(blocking_count)
+          PY
+          )
+
+          echo "Blocking HIGH/CRITICAL findings: ${BLOCKING_COUNT}"
+          if [[ "${BLOCKING_COUNT}" -gt 0 ]]; then
+            echo "::error::HIGH/CRITICAL vulnerability gate failed based on trivy-results.json"
+            exit 1
+          fi
 
       - name: Publish validated base image
         shell: bash

--- a/security/trivy/base-image-allowlist.yaml
+++ b/security/trivy/base-image-allowlist.yaml
@@ -1,0 +1,4 @@
+# Temporary, auditable suppressions for the base-image refresh workflow.
+# Each exception must include an owner, expiry date, and rationale.
+# The workflow validates this file and renders a Trivy-compatible ignore file at runtime.
+exceptions: []

--- a/tests/unit/test_base_image_refresh_workflow.py
+++ b/tests/unit/test_base_image_refresh_workflow.py
@@ -88,6 +88,87 @@ def test_workflow_scans_vulnerabilities(workflow: dict[str, Any]) -> None:
     assert "trivy" in uses or "grype" in uses
 
 
+class TestTrivyDiagnosticsAndPolicy:
+    """Contracts for issue #206 actionable Trivy outputs and exception policy."""
+
+    def test_workflow_generates_structured_trivy_reports(self, workflow: dict[str, Any]) -> None:
+        steps = _steps(workflow)
+
+        scan = _step_with_name_fragment(steps, "vulnerability scan")
+        assert scan is not None, "Primary Trivy scan step missing"
+        scan_with = scan.get("with", {})
+        assert scan_with.get("format") == "json", (
+            "Primary Trivy scan must emit JSON so failures are actionable"
+        )
+        assert "trivy-results.json" in str(scan_with.get("output", ""))
+        assert str(scan_with.get("exit-code", "")) == "0", (
+            "Report generation step must not fail before summary/artifact publication"
+        )
+
+        sarif = _step_with_name_fragment(steps, "sarif")
+        assert sarif is not None, "Workflow must also generate a SARIF report"
+        sarif_with = sarif.get("with", {})
+        assert sarif_with.get("format") == "sarif"
+        assert "trivy-results.sarif" in str(sarif_with.get("output", ""))
+
+    def test_workflow_uploads_trivy_artifacts_even_on_failure(
+        self, workflow: dict[str, Any]
+    ) -> None:
+        steps = _steps(workflow)
+
+        upload = _step_with_name_fragment(steps, "upload trivy")
+        assert upload is not None, "Workflow must upload Trivy findings as an artifact"
+        assert "actions/upload-artifact" in str(upload.get("uses", ""))
+        assert upload.get("if") == "always()", (
+            "Trivy reports must upload even when the vulnerability gate fails"
+        )
+
+        upload_with = upload.get("with", {})
+        assert "trivy" in str(upload_with.get("name", "")).lower()
+        artifact_path = str(upload_with.get("path", ""))
+        assert "trivy-results.json" in artifact_path
+        assert "trivy-results.sarif" in artifact_path
+
+    def test_workflow_publishes_blocker_summary_from_json(self, workflow: dict[str, Any]) -> None:
+        steps = _steps(workflow)
+
+        summary = _step_with_name_fragment(steps, "summary")
+        assert summary is not None, "Workflow must publish a Trivy blocker summary"
+        run_script = str(summary.get("run", ""))
+        assert "GITHUB_STEP_SUMMARY" in run_script
+        assert "VulnerabilityID" in run_script
+        assert "PkgName" in run_script
+        assert "InstalledVersion" in run_script
+        assert "FixedVersion" in run_script
+        assert "Severity" in run_script
+        assert "blocking" in run_script.lower(), (
+            "Summary must include blocker counts for before/after comparison"
+        )
+
+    def test_workflow_validates_allowlist_metadata_and_renders_trivy_ignorefile(
+        self, workflow: dict[str, Any]
+    ) -> None:
+        steps = _steps(workflow)
+
+        validate = _step_with_name_fragment(steps, "allowlist")
+        assert validate is not None, "Workflow must validate allowlist metadata"
+        run_script = str(validate.get("run", ""))
+        assert "owner" in run_script.lower(), "Allowlist validation must require owner"
+        assert "expires_on" in run_script, "Allowlist validation must require expiry metadata"
+        assert "expired_at" in run_script, "Workflow must render Trivy-compatible expiry field"
+        assert "statement" in run_script, "Workflow must preserve exception rationale"
+
+    def test_workflow_enforces_gate_from_structured_report(self, workflow: dict[str, Any]) -> None:
+        steps = _steps(workflow)
+
+        gate = _step_with_name_fragment(steps, "gate")
+        assert gate is not None, "Workflow must enforce the vulnerability gate explicitly"
+        run_script = str(gate.get("run", ""))
+        assert "trivy-results.json" in run_script
+        assert "HIGH" in run_script and "CRITICAL" in run_script
+        assert "exit 1" in run_script, "Gate step must fail the job when blockers remain"
+
+
 def test_workflow_uses_immutable_run_scoped_tag(workflow: dict[str, Any]) -> None:
     steps = _steps(workflow)
     image_step = _step_with_name_fragment(steps, "set image name")


### PR DESCRIPTION
Fixes #206 by generating Trivy JSON and SARIF reports, uploading them as artifacts on failure, publishing a blocker summary, and validating an auditable allowlist with owner/expiry metadata before enforcing the HIGH/CRITICAL gate.