### PR TITLE
ci: add PR formatting autofix guardrails (closes #207)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,44 @@ jobs:
         run: uv sync --all-extras
 
       - name: Lint with ruff
+        run: uv run ruff check .
+
+      - name: Check formatting with ruff-format
+        id: ruff-format-check
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        run: uv run ruff format --check .
+
+      - name: Generate formatting autofix patch
+        if: github.event_name == 'pull_request' && steps.ruff-format-check.outcome == 'failure'
         run: |
-          uv run ruff check .
-          uv run ruff format --check .
+          set -euo pipefail
+          uv run ruff format .
+          git diff -- . ':(exclude).venv/**' > ruff-format.patch
+          if [[ ! -s ruff-format.patch ]]; then
+            echo "Expected ruff-format.patch to contain formatting changes"
+            exit 1
+          fi
+
+          {
+            echo "### Formatting autofix required"
+            echo ""
+            echo "Run \\`uv run ruff format .\\` locally, commit the result, and push again."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload formatting patch artifact
+        if: github.event_name == 'pull_request' && steps.ruff-format-check.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruff-format-autofix-patch
+          path: ruff-format.patch
+          retention-days: 7
+
+      - name: Fail on formatting drift
+        if: github.event_name == 'pull_request' && steps.ruff-format-check.outcome == 'failure'
+        run: |
+          echo "::error::Formatting drift detected. Run 'uv run ruff format .' locally, commit the changes, and push again."
+          exit 1
 
       - name: Type check with pyright
         run: uv run pyright

--- a/README.md
+++ b/README.md
@@ -526,9 +526,10 @@ If you deploy the frontend before the backend is ready, the gate will fail with 
 
 1. Create a feature branch from `main` (`git checkout -b feature/issue-number-description`)
 2. Make changes following the engineering principles in [PID.md §7.4](PID.md)
-3. Pre-commit hooks enforce lint, format, and type checks automatically
-4. Add/update tests — all new code requires unit tests
-5. Open a PR using the provided template
+3. Run `uv run ruff format .` before opening or updating a PR
+4. Pre-commit hooks enforce lint, format, and type checks automatically, and PR CI uploads a formatting patch artifact if drift is detected
+5. Add/update tests — all new code requires unit tests
+6. Open a PR using the provided template; changes to `main` should go through PRs rather than direct pushes
 
 ## Licence
 

--- a/tests/unit/test_ci_workflow_lanes.py
+++ b/tests/unit/test_ci_workflow_lanes.py
@@ -65,3 +65,77 @@ def test_native_job_runs_geospatial_validation(ci_workflow: dict[str, Any]) -> N
     assert "Run unit tests (geospatial lane)" in names
     assert "import rasterio, fiona, pyproj, shapely" in scripts
     assert 'uv run pytest tests/unit -v --tb=short -m "not integration and not e2e"' in scripts
+
+
+def test_prs_have_a_hard_format_gate_with_explicit_step(ci_workflow: dict[str, Any]) -> None:
+    job = ci_workflow.get("jobs", {}).get("fast-lint-type-unit", {})
+    format_step = next(
+        (step for step in _steps(job) if "format" in str(step.get("name", "")).lower()),
+        None,
+    )
+
+    assert format_step is not None, "Fast CI job must include an explicit format gate step"
+    assert "pull_request" in str(format_step.get("if", "")), (
+        "Formatting gate must run on PRs to block auto-fixable drift before merge"
+    )
+    assert "uv run ruff format --check ." in str(format_step.get("run", ""))
+
+
+def test_pr_format_failures_publish_autofix_patch(ci_workflow: dict[str, Any]) -> None:
+    job = ci_workflow.get("jobs", {}).get("fast-lint-type-unit", {})
+    steps = _steps(job)
+
+    patch_step = next(
+        (
+            step
+            for step in steps
+            if "patch" in str(step.get("name", "")).lower()
+            or "autofix" in str(step.get("name", "")).lower()
+        ),
+        None,
+    )
+    assert patch_step is not None, "CI must generate an autofix patch when formatting fails"
+    assert "uv run ruff format ." in str(patch_step.get("run", ""))
+    assert "ruff-format.patch" in str(patch_step.get("run", ""))
+
+    upload_step = next(
+        (
+            step
+            for step in steps
+            if "upload" in str(step.get("name", "")).lower()
+            and "patch" in str(step.get("name", "")).lower()
+        ),
+        None,
+    )
+    assert upload_step is not None, "CI must upload the formatting patch as an artifact"
+    assert "actions/upload-artifact" in str(upload_step.get("uses", ""))
+    assert "ruff-format.patch" in str(upload_step.get("with", {}).get("path", ""))
+
+
+def test_pr_format_failure_message_includes_local_fix_command(
+    ci_workflow: dict[str, Any],
+) -> None:
+    job = ci_workflow.get("jobs", {}).get("fast-lint-type-unit", {})
+    steps = _steps(job)
+
+    fail_step = next(
+        (
+            step
+            for step in steps
+            if "fail" in str(step.get("name", "")).lower()
+            and "format" in str(step.get("name", "")).lower()
+        ),
+        None,
+    )
+    assert fail_step is not None, "CI must fail with a contributor-facing formatting message"
+    fail_script = str(fail_step.get("run", ""))
+    assert "uv run ruff format ." in fail_script
+    assert "GITHUB_STEP_SUMMARY" in fail_script or "::error::" in fail_script
+
+
+def test_readme_documents_local_format_command() -> None:
+    readme_path = Path(__file__).resolve().parent.parent.parent / "README.md"
+    content = readme_path.read_text(encoding="utf-8")
+    assert "uv run ruff format ." in content, (
+        "README must document the local formatting command contributors should run before PRs"
+    )


### PR DESCRIPTION
Fixes #207 by keeping the formatting check as a hard PR gate, skipping that auto-fixable failure mode on direct push runs, uploading a formatting patch artifact for PR failures, and documenting the local Ruff format command in the README.