### PR TITLE
feat(demo): add valet-token result delivery (closes #200)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ Test coverage: [test_deploy_workflow.py](tests/unit/test_deploy_workflow.py)
 | GET | `/api/health` | Liveness probe | 200 | 500 |
 | GET | `/api/readiness` | Dependency readiness probe | 200 | 503 |
 | GET | `/api/orchestrator/{instance_id}` | Durable instance status + output artifact diagnostics | 200 | 400 / 404 |
+| GET | `/api/demo-results?token=...` | Validate valet token and reveal one authorized demo artifact | 200 | 401 / 403 |
+| GET | `/api/demo-results/download?token=...` | Proxy a single authorized demo artifact download | 200 | 401 / 403 / 404 |
+
+Protected/internal endpoint:
+
+- `POST /api/demo-results-token` — mint a short-lived, replay-limited valet token for one demo artifact (Function auth)
 
 ### Event-driven entrypoint
 

--- a/function_app.py
+++ b/function_app.py
@@ -9,10 +9,17 @@ the wiring layer between Azure Functions bindings and application code.
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import hmac
 import json
 import logging
+import mimetypes
+import os
 import re
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
 from uuid import uuid4
 
 import azure.durable_functions as df
@@ -43,6 +50,8 @@ logger = logging.getLogger("kml_satellite.function_app")
 
 _EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 _API_CONTRACT_VERSION = "2026-03-15.1"
+_DEMO_VALET_TOKEN_TTL_SECONDS = 24 * 60 * 60
+_DEMO_VALET_TOKEN_MAX_USES = 3
 
 
 def _isoformat_or_empty(value: object) -> str:
@@ -129,6 +138,268 @@ def _sanitize_marketing_field(value: object, *, max_length: int = 2000) -> str:
     if value is None:
         return ""
     return str(value).strip()[:max_length]
+
+
+def _get_demo_valet_secret() -> bytes:
+    """Return the HMAC secret for signed valet tokens."""
+    secret = os.getenv("DEMO_VALET_TOKEN_SECRET", "").strip()
+    if not secret:
+        raise RuntimeError("DEMO_VALET_TOKEN_SECRET is not configured")
+    return secret.encode("utf-8")
+
+
+def _base64url_encode_bytes(value: bytes) -> str:
+    """Encode bytes without `=` padding for URL-safe tokens."""
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _base64url_decode_bytes(value: str) -> bytes:
+    """Decode a URL-safe base64 segment with optional stripped padding."""
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(f"{value}{padding}")
+
+
+def _hash_demo_recipient(email: str) -> str:
+    """Return a stable hash for the token-bound recipient."""
+    normalized = email.strip().lower().encode("utf-8")
+    return hashlib.sha256(normalized).hexdigest()
+
+
+def _get_demo_valet_ttl_seconds() -> int:
+    """Return the configured valet token TTL in seconds."""
+    value = os.getenv("DEMO_VALET_TOKEN_TTL_SECONDS", str(_DEMO_VALET_TOKEN_TTL_SECONDS))
+    try:
+        parsed = int(value)
+    except ValueError:
+        return _DEMO_VALET_TOKEN_TTL_SECONDS
+    return parsed if parsed > 0 else _DEMO_VALET_TOKEN_TTL_SECONDS
+
+
+def _get_demo_valet_max_uses() -> int:
+    """Return the configured per-token replay limit."""
+    value = os.getenv("DEMO_VALET_TOKEN_MAX_USES", str(_DEMO_VALET_TOKEN_MAX_USES))
+    try:
+        parsed = int(value)
+    except ValueError:
+        return _DEMO_VALET_TOKEN_MAX_USES
+    return parsed if parsed > 0 else _DEMO_VALET_TOKEN_MAX_USES
+
+
+def _mint_demo_valet_token(
+    *,
+    submission_id: str,
+    submission_blob_name: str,
+    artifact_path: str,
+    recipient_email: str,
+    expires_at: datetime | None = None,
+    nonce: str | None = None,
+    max_uses: int | None = None,
+    output_container: str = DEFAULT_OUTPUT_CONTAINER,
+) -> str:
+    """Create a signed valet token scoped to a single demo artifact."""
+    now = datetime.now(UTC)
+    if expires_at is None:
+        expires_at = now + timedelta(seconds=_get_demo_valet_ttl_seconds())
+
+    claims = {
+        "submission_id": submission_id,
+        "submission_blob_name": submission_blob_name,
+        "artifact_path": artifact_path,
+        "recipient_hash": _hash_demo_recipient(recipient_email),
+        "exp": int(expires_at.timestamp()),
+        "nonce": nonce or uuid4().hex,
+        "max_uses": max_uses or _get_demo_valet_max_uses(),
+        "output_container": output_container,
+    }
+
+    payload = _base64url_encode_bytes(
+        json.dumps(claims, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    )
+    signature = _base64url_encode_bytes(
+        hmac.new(_get_demo_valet_secret(), payload.encode("utf-8"), hashlib.sha256).digest()
+    )
+    return f"{payload}.{signature}"
+
+
+def _verify_demo_valet_token(
+    token: str,
+    *,
+    now: datetime | None = None,
+) -> tuple[dict[str, object] | None, str | None]:
+    """Verify token signature and expiry without exposing internal failure detail."""
+    try:
+        payload_segment, signature_segment = token.split(".", 1)
+    except ValueError:
+        return None, "invalid"
+
+    try:
+        expected_signature = _base64url_encode_bytes(
+            hmac.new(
+                _get_demo_valet_secret(),
+                payload_segment.encode("utf-8"),
+                hashlib.sha256,
+            ).digest()
+        )
+    except RuntimeError:
+        return None, "misconfigured"
+
+    if not hmac.compare_digest(signature_segment, expected_signature):
+        return None, "invalid"
+
+    try:
+        claims = json.loads(_base64url_decode_bytes(payload_segment).decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        return None, "invalid"
+
+    if not isinstance(claims, dict):
+        return None, "invalid"
+
+    current_time = now or datetime.now(UTC)
+    expires_at = claims.get("exp")
+    if not isinstance(expires_at, int):
+        return None, "invalid"
+    if current_time.timestamp() > expires_at:
+        return None, "expired"
+
+    return claims, None
+
+
+def _extract_demo_artifact_paths(submission: object) -> list[str]:
+    """Collect unique artifact paths from a persisted demo submission record."""
+    if not isinstance(submission, dict):
+        return []
+
+    artifacts = submission.get("artifacts")
+    if not isinstance(artifacts, dict):
+        return []
+
+    paths: list[str] = []
+    for key in ("metadataPaths", "rawImageryPaths", "clippedImageryPaths"):
+        values = artifacts.get(key)
+        if not isinstance(values, list):
+            continue
+        for value in values:
+            if isinstance(value, str) and value and value not in paths:
+                paths.append(value)
+    return paths
+
+
+def _load_json_blob(
+    blob_service: Any, *, container: str, blob_name: str
+) -> dict[str, object] | None:
+    """Load a JSON blob from storage or return None when it does not exist."""
+    try:
+        blob_client = blob_service.get_blob_client(container=container, blob=blob_name)
+        payload = blob_client.download_blob().readall()
+    except Exception:
+        return None
+
+    try:
+        decoded = payload.decode("utf-8") if isinstance(payload, bytes) else str(payload)
+        data = json.loads(decoded)
+    except (UnicodeDecodeError, ValueError):
+        return None
+
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _find_demo_submission_blob_name(blob_service: Any, submission_id: str) -> str | None:
+    """Locate a persisted demo submission record by scanning the payload prefix."""
+    try:
+        container_client = blob_service.get_container_client(PIPELINE_PAYLOADS_CONTAINER)
+        blobs = container_client.list_blobs(name_starts_with="demo-submissions/")
+    except Exception:
+        return None
+
+    suffix = f"/{submission_id}.json"
+    for blob in blobs:
+        name = getattr(blob, "name", "")
+        if isinstance(name, str) and name.endswith(suffix):
+            return name
+    return None
+
+
+def _get_demo_token_usage_blob_name(nonce: str) -> str:
+    """Return the blob name used to track token replay usage."""
+    return f"demo-valet-usage/{nonce}.json"
+
+
+def _get_demo_token_usage_count(blob_service: Any, nonce: str) -> int:
+    """Return the current usage count for a replay-limited token."""
+    payload = _load_json_blob(
+        blob_service,
+        container=PIPELINE_PAYLOADS_CONTAINER,
+        blob_name=_get_demo_token_usage_blob_name(nonce),
+    )
+    if not payload:
+        return 0
+    count = payload.get("count", 0)
+    return count if isinstance(count, int) and count >= 0 else 0
+
+
+def _consume_demo_token_use(blob_service: Any, claims: dict[str, object]) -> bool:
+    """Increment the replay counter and return False once the max use count is exceeded."""
+    nonce = claims.get("nonce")
+    max_uses = claims.get("max_uses")
+    if not isinstance(nonce, str) or not isinstance(max_uses, int):
+        return False
+
+    usage_count = _get_demo_token_usage_count(blob_service, nonce)
+    if usage_count >= max_uses:
+        return False
+
+    blob_service.get_blob_client(
+        container=PIPELINE_PAYLOADS_CONTAINER,
+        blob=_get_demo_token_usage_blob_name(nonce),
+    ).upload_blob(
+        json.dumps(
+            {
+                "nonce": nonce,
+                "count": usage_count + 1,
+                "last_used_at": datetime.now(UTC).isoformat(),
+            }
+        ),
+        overwrite=True,
+    )
+    return True
+
+
+def _guess_artifact_mimetype(blob_path: str) -> str:
+    """Return a reasonable content type for proxied artifact downloads."""
+    guessed, _ = mimetypes.guess_type(blob_path)
+    return guessed or "application/octet-stream"
+
+
+def _load_demo_submission_for_claims(
+    blob_service: Any, claims: dict[str, object]
+) -> tuple[dict[str, object] | None, str | None]:
+    """Resolve the persisted submission record referenced by token claims."""
+    submission_blob_name = claims.get("submission_blob_name")
+    if not isinstance(submission_blob_name, str) or not submission_blob_name:
+        return None, None
+
+    submission = _load_json_blob(
+        blob_service,
+        container=PIPELINE_PAYLOADS_CONTAINER,
+        blob_name=submission_blob_name,
+    )
+    return submission, submission_blob_name
+
+
+def _artifact_is_authorized(submission: dict[str, object], claims: dict[str, object]) -> bool:
+    """Check that the token still matches the persisted submission record."""
+    artifact_path = claims.get("artifact_path")
+    recipient_hash = claims.get("recipient_hash")
+    if not isinstance(artifact_path, str) or not isinstance(recipient_hash, str):
+        return False
+
+    email = submission.get("email")
+    if not isinstance(email, str) or _hash_demo_recipient(email) != recipient_hash:
+        return False
+
+    return artifact_path in _extract_demo_artifact_paths(submission)
 
 
 def _validate_marketing_interest_payload(
@@ -460,6 +731,9 @@ async def api_contract(_req: func.HttpRequest) -> func.HttpResponse:
                 "/api/readiness",
                 "/api/contact-form",
                 "/api/demo-submit",
+                "/api/demo-results-token",
+                "/api/demo-results",
+                "/api/demo-results/download",
                 "/api/orchestrator/{instance_id}",
             ],
         }
@@ -618,6 +892,179 @@ async def demo_submission(req: func.HttpRequest) -> func.HttpResponse:
         }
     )
     return func.HttpResponse(response, status_code=202, mimetype="application/json")
+
+
+@app.function_name("demo_result_token")
+@app.route(
+    route="demo-results-token",
+    methods=["POST"],
+    auth_level=func.AuthLevel.FUNCTION,
+)
+async def demo_result_token(req: func.HttpRequest) -> func.HttpResponse:
+    """Issue a short-lived valet token scoped to one demo artifact."""
+    try:
+        payload = req.get_json()
+    except ValueError:
+        response = json.dumps({"error": "Request body must be valid JSON"})
+        return func.HttpResponse(response, status_code=400, mimetype="application/json")
+
+    if not isinstance(payload, dict):
+        response = json.dumps({"error": "Request body must be a JSON object"})
+        return func.HttpResponse(response, status_code=400, mimetype="application/json")
+
+    submission_id = _sanitize_marketing_field(payload.get("submission_id"), max_length=128)
+    artifact_path = _sanitize_marketing_field(payload.get("artifact_path"), max_length=1024)
+    if not submission_id or not artifact_path:
+        response = json.dumps({"error": "Fields 'submission_id' and 'artifact_path' are required"})
+        return func.HttpResponse(response, status_code=400, mimetype="application/json")
+
+    try:
+        blob_service = get_blob_service_client()
+        submission_blob_name = _find_demo_submission_blob_name(blob_service, submission_id)
+        if submission_blob_name is None:
+            return func.HttpResponse(status_code=404)
+
+        submission = _load_json_blob(
+            blob_service,
+            container=PIPELINE_PAYLOADS_CONTAINER,
+            blob_name=submission_blob_name,
+        )
+        if not submission or artifact_path not in _extract_demo_artifact_paths(submission):
+            return func.HttpResponse(status_code=404)
+
+        email = submission.get("email")
+        output_container = submission.get("output_container", DEFAULT_OUTPUT_CONTAINER)
+        if not isinstance(email, str) or not email:
+            return func.HttpResponse(status_code=409)
+        if not isinstance(output_container, str) or not output_container:
+            output_container = DEFAULT_OUTPUT_CONTAINER
+
+        token = _mint_demo_valet_token(
+            submission_id=submission_id,
+            submission_blob_name=submission_blob_name,
+            artifact_path=artifact_path,
+            recipient_email=email,
+            output_container=output_container,
+        )
+    except RuntimeError:
+        logger.exception("Demo valet token secret is not configured")
+        return func.HttpResponse(status_code=503)
+    except Exception:
+        logger.exception(
+            "Failed to issue demo result token | submission_id=%s | artifact_path=%s",
+            submission_id,
+            artifact_path,
+        )
+        return func.HttpResponse(status_code=500)
+
+    response = json.dumps(
+        {
+            "token": token,
+            "results_url": f"/api/demo-results?token={token}",
+            "download_url": f"/api/demo-results/download?token={token}",
+        }
+    )
+    return func.HttpResponse(response, status_code=200, mimetype="application/json")
+
+
+@app.function_name("demo_results")
+@app.route(
+    route="demo-results",
+    methods=["GET"],
+    auth_level=func.AuthLevel.ANONYMOUS,
+)
+async def demo_results(req: func.HttpRequest) -> func.HttpResponse:
+    """Validate a valet token and expose only the intended demo artifact metadata."""
+    token = _sanitize_marketing_field(getattr(req, "params", {}).get("token"), max_length=8192)
+    if not token:
+        return func.HttpResponse(status_code=401)
+
+    claims, error = _verify_demo_valet_token(token)
+    if error == "expired":
+        return func.HttpResponse(status_code=403)
+    if error == "misconfigured":
+        return func.HttpResponse(status_code=503)
+    if error or claims is None:
+        return func.HttpResponse(status_code=401)
+
+    try:
+        blob_service = get_blob_service_client()
+        submission, _ = _load_demo_submission_for_claims(blob_service, claims)
+        if not submission or not _artifact_is_authorized(submission, claims):
+            return func.HttpResponse(status_code=403)
+
+        artifact_path = str(claims["artifact_path"])
+        response = json.dumps(
+            {
+                "submission_id": str(claims["submission_id"]),
+                "status": str(submission.get("status", "unknown")),
+                "artifact": {
+                    "path": artifact_path,
+                    "kind": Path(artifact_path).suffix.lower().lstrip(".") or "blob",
+                    "download_url": f"/api/demo-results/download?token={token}",
+                },
+            }
+        )
+        return func.HttpResponse(response, status_code=200, mimetype="application/json")
+    except Exception:
+        logger.exception("Failed to resolve demo results for a valet token")
+        return func.HttpResponse(status_code=500)
+
+
+@app.function_name("demo_result_download")
+@app.route(
+    route="demo-results/download",
+    methods=["GET"],
+    auth_level=func.AuthLevel.ANONYMOUS,
+)
+async def demo_result_download(req: func.HttpRequest) -> func.HttpResponse:
+    """Proxy a demo artifact download after validating a signed valet token."""
+    token = _sanitize_marketing_field(getattr(req, "params", {}).get("token"), max_length=8192)
+    if not token:
+        return func.HttpResponse(status_code=401)
+
+    claims, error = _verify_demo_valet_token(token)
+    if error == "expired":
+        return func.HttpResponse(status_code=403)
+    if error == "misconfigured":
+        return func.HttpResponse(status_code=503)
+    if error or claims is None:
+        return func.HttpResponse(status_code=401)
+
+    try:
+        blob_service = get_blob_service_client()
+        submission, _ = _load_demo_submission_for_claims(blob_service, claims)
+        if not submission or not _artifact_is_authorized(submission, claims):
+            return func.HttpResponse(status_code=403)
+        if not _consume_demo_token_use(blob_service, claims):
+            return func.HttpResponse(status_code=403)
+
+        artifact_path = str(claims["artifact_path"])
+        output_container = claims.get("output_container", DEFAULT_OUTPUT_CONTAINER)
+        if not isinstance(output_container, str) or not output_container:
+            output_container = DEFAULT_OUTPUT_CONTAINER
+
+        blob_client = blob_service.get_blob_client(container=output_container, blob=artifact_path)
+        payload = blob_client.download_blob().readall()
+        try:
+            content_type = blob_client.get_blob_properties().content_settings.content_type
+        except Exception:
+            content_type = _guess_artifact_mimetype(artifact_path)
+
+        headers = {
+            "Content-Disposition": f'attachment; filename="{Path(artifact_path).name}"',
+        }
+        return func.HttpResponse(
+            body=payload,
+            status_code=200,
+            mimetype=content_type or _guess_artifact_mimetype(artifact_path),
+            headers=headers,
+        )
+    except FileNotFoundError:
+        return func.HttpResponse(status_code=404)
+    except Exception:
+        logger.exception("Failed to proxy demo artifact download")
+        return func.HttpResponse(status_code=500)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_demo_valet_tokens.py
+++ b/tests/unit/test_demo_valet_tokens.py
@@ -1,0 +1,249 @@
+"""Tests for secure demo result valet-token delivery (#200)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from function_app import (
+    _mint_demo_valet_token,
+    _verify_demo_valet_token,
+    demo_result_download,
+    demo_result_token,
+    demo_results,
+)
+
+
+class _FakeDownload:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def readall(self) -> bytes:
+        return self._data
+
+
+class _FakeBlobClient:
+    def __init__(
+        self,
+        storage: dict[tuple[str, str], bytes],
+        container: str,
+        blob: str,
+        content_types: dict[tuple[str, str], str],
+    ) -> None:
+        self._storage = storage
+        self._container = container
+        self._blob = blob
+        self._content_types = content_types
+
+    def upload_blob(self, data: str | bytes, overwrite: bool = False) -> None:
+        key = (self._container, self._blob)
+        if key in self._storage and not overwrite:
+            raise FileExistsError(self._blob)
+        if isinstance(data, str):
+            data = data.encode("utf-8")
+        self._storage[key] = data
+
+    def download_blob(self) -> _FakeDownload:
+        key = (self._container, self._blob)
+        if key not in self._storage:
+            raise FileNotFoundError(self._blob)
+        return _FakeDownload(self._storage[key])
+
+    def get_blob_properties(self) -> SimpleNamespace:
+        key = (self._container, self._blob)
+        return SimpleNamespace(
+            content_settings=SimpleNamespace(
+                content_type=self._content_types.get(key, "application/octet-stream")
+            )
+        )
+
+
+class _FakeContainerClient:
+    def __init__(self, storage: dict[tuple[str, str], bytes], container: str) -> None:
+        self._storage = storage
+        self._container = container
+
+    def list_blobs(self, name_starts_with: str = "") -> list[SimpleNamespace]:
+        names = [
+            blob_name
+            for container, blob_name in self._storage
+            if container == self._container and blob_name.startswith(name_starts_with)
+        ]
+        return [SimpleNamespace(name=name) for name in sorted(names)]
+
+
+class _FakeBlobService:
+    def __init__(self) -> None:
+        self.storage: dict[tuple[str, str], bytes] = {}
+        self.content_types: dict[tuple[str, str], str] = {}
+
+    def get_container_client(self, container: str) -> _FakeContainerClient:
+        return _FakeContainerClient(self.storage, container)
+
+    def get_blob_client(self, *, container: str, blob: str) -> _FakeBlobClient:
+        return _FakeBlobClient(self.storage, container, blob, self.content_types)
+
+
+def _seed_submission(
+    blob_service: _FakeBlobService,
+    *,
+    submission_id: str = "submission-123",
+    email: str = "demo@example.com",
+    artifact_path: str = "imagery/demo-output.tif",
+    status: str = "completed",
+) -> str:
+    blob_name = f"demo-submissions/2026-03-16/{submission_id}.json"
+    submission = {
+        "submission_id": submission_id,
+        "email": email,
+        "status": status,
+        "artifacts": {
+            "clippedImageryPaths": [artifact_path],
+            "metadataPaths": ["metadata/demo-output.json"],
+            "rawImageryPaths": [],
+        },
+        "output_container": "kml-output",
+    }
+    blob_service.storage[("pipeline-payloads", blob_name)] = json.dumps(submission).encode("utf-8")
+    return blob_name
+
+
+def test_mint_and_verify_demo_valet_token_round_trip(monkeypatch) -> None:
+    monkeypatch.setenv("DEMO_VALET_TOKEN_SECRET", "test-secret")
+
+    expires_at = datetime(2026, 3, 17, 12, 0, tzinfo=UTC)
+    token = _mint_demo_valet_token(
+        submission_id="submission-123",
+        submission_blob_name="demo-submissions/2026-03-16/submission-123.json",
+        artifact_path="imagery/demo-output.tif",
+        recipient_email="demo@example.com",
+        expires_at=expires_at,
+        nonce="nonce-123",
+        max_uses=2,
+    )
+
+    claims, error = _verify_demo_valet_token(
+        token,
+        now=datetime(2026, 3, 16, 12, 0, tzinfo=UTC),
+    )
+
+    assert error is None
+    assert claims is not None
+    assert claims["submission_id"] == "submission-123"
+    assert claims["artifact_path"] == "imagery/demo-output.tif"
+    assert claims["submission_blob_name"] == "demo-submissions/2026-03-16/submission-123.json"
+    assert claims["recipient_hash"] != "demo@example.com"
+    assert claims["nonce"] == "nonce-123"
+    assert claims["max_uses"] == 2
+
+
+def test_verify_demo_valet_token_rejects_expired_token(monkeypatch) -> None:
+    monkeypatch.setenv("DEMO_VALET_TOKEN_SECRET", "test-secret")
+
+    token = _mint_demo_valet_token(
+        submission_id="submission-123",
+        submission_blob_name="demo-submissions/2026-03-16/submission-123.json",
+        artifact_path="imagery/demo-output.tif",
+        recipient_email="demo@example.com",
+        expires_at=datetime(2026, 3, 16, 12, 0, tzinfo=UTC),
+    )
+
+    claims, error = _verify_demo_valet_token(
+        token,
+        now=datetime(2026, 3, 16, 12, 1, tzinfo=UTC),
+    )
+
+    assert claims is None
+    assert error == "expired"
+
+
+def test_demo_result_token_mints_scoped_token_for_known_artifact(monkeypatch) -> None:
+    monkeypatch.setenv("DEMO_VALET_TOKEN_SECRET", "test-secret")
+    blob_service = _FakeBlobService()
+    _seed_submission(blob_service)
+    monkeypatch.setattr("function_app.get_blob_service_client", lambda: blob_service)
+
+    req = SimpleNamespace(
+        method="POST",
+        headers={},
+        get_json=lambda: {
+            "submission_id": "submission-123",
+            "artifact_path": "imagery/demo-output.tif",
+        },
+    )
+
+    response = asyncio.run(demo_result_token(req))
+
+    assert response.status_code == 200
+    body = json.loads(response.get_body().decode("utf-8"))
+    assert body["results_url"].startswith("/api/demo-results?token=")
+    assert body["download_url"].startswith("/api/demo-results/download?token=")
+
+    claims, error = _verify_demo_valet_token(body["token"])
+    assert error is None
+    assert claims is not None
+    assert claims["artifact_path"] == "imagery/demo-output.tif"
+
+
+def test_demo_results_returns_scoped_artifact_view(monkeypatch) -> None:
+    monkeypatch.setenv("DEMO_VALET_TOKEN_SECRET", "test-secret")
+    blob_service = _FakeBlobService()
+    submission_blob_name = _seed_submission(blob_service)
+    monkeypatch.setattr("function_app.get_blob_service_client", lambda: blob_service)
+
+    token = _mint_demo_valet_token(
+        submission_id="submission-123",
+        submission_blob_name=submission_blob_name,
+        artifact_path="imagery/demo-output.tif",
+        recipient_email="demo@example.com",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+
+    req = SimpleNamespace(params={"token": token}, headers={})
+    response = asyncio.run(demo_results(req))
+
+    assert response.status_code == 200
+    body = json.loads(response.get_body().decode("utf-8"))
+    assert body["submission_id"] == "submission-123"
+    assert body["artifact"]["path"] == "imagery/demo-output.tif"
+    assert body["artifact"]["download_url"].startswith("/api/demo-results/download?token=")
+    assert "email" not in body
+
+
+def test_demo_result_download_enforces_replay_limit(monkeypatch) -> None:
+    monkeypatch.setenv("DEMO_VALET_TOKEN_SECRET", "test-secret")
+    blob_service = _FakeBlobService()
+    submission_blob_name = _seed_submission(blob_service)
+    blob_service.storage[("kml-output", "imagery/demo-output.tif")] = b"TIFFDATA"
+    blob_service.content_types[("kml-output", "imagery/demo-output.tif")] = "image/tiff"
+    monkeypatch.setattr("function_app.get_blob_service_client", lambda: blob_service)
+
+    token = _mint_demo_valet_token(
+        submission_id="submission-123",
+        submission_blob_name=submission_blob_name,
+        artifact_path="imagery/demo-output.tif",
+        recipient_email="demo@example.com",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        max_uses=1,
+        nonce="nonce-replay-limit",
+    )
+
+    req = SimpleNamespace(params={"token": token}, headers={})
+
+    first = asyncio.run(demo_result_download(req))
+    second = asyncio.run(demo_result_download(req))
+
+    assert first.status_code == 200
+    assert first.get_body() == b"TIFFDATA"
+    assert second.status_code == 403
+
+
+def test_demo_results_rejects_invalid_token(monkeypatch) -> None:
+    monkeypatch.setenv("DEMO_VALET_TOKEN_SECRET", "test-secret")
+
+    req = SimpleNamespace(params={"token": "not-a-valid-token"}, headers={})
+    response = asyncio.run(demo_results(req))
+
+    assert response.status_code == 401


### PR DESCRIPTION
Implements #200 with signed valet tokens scoped to one demo artifact, a protected token-issue endpoint, an anonymous token validation/results endpoint, a proxied download endpoint with replay limits, and unit coverage for mint, verify, expire, authorize, and replay behavior.