### PR TITLE
ci(website): handle persisted 404 API contract startup windows

### DIFF
--- a/.github/workflows/deploy-website-swapp.yml
+++ b/.github/workflows/deploy-website-swapp.yml
@@ -106,9 +106,13 @@ jobs:
           )
 
           API_CONTRACT_URL="https://${{ steps.function-app.outputs.hostname }}/api/api-contract"
+          HEALTH_URL="https://${{ steps.function-app.outputs.hostname }}/api/health"
+          READINESS_URL="https://${{ steps.function-app.outputs.hostname }}/api/readiness"
           MAX_ATTEMPTS=5
           ATTEMPT=0
           BACKOFF=5
+          only_404_window=1
+          observed_probe=0
 
           while [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; do
             ATTEMPT=$((ATTEMPT + 1))
@@ -123,12 +127,27 @@ jobs:
             ELAPSED_MS=$((END_MS - START_MS))
             HTTP_STATUS=$(echo "$API_CONTRACT_RESPONSE" | tail -1)
             BODY=$(echo "$API_CONTRACT_RESPONSE" | head -n -1)
+            observed_probe=1
+
+            if [[ "$HTTP_STATUS" != "404" ]]; then
+              only_404_window=0
+            fi
 
             echo "contract-check attempt=${ATTEMPT}/${MAX_ATTEMPTS} curl_exit=${CURL_EXIT} http=${HTTP_STATUS} elapsed=${ELAPSED_MS}ms endpoint=${API_CONTRACT_URL}"
 
             # Transient transport failure (timeout=28, connect=7, DNS=6): retry with backoff
             if [[ $CURL_EXIT -eq 28 || $CURL_EXIT -eq 7 || $CURL_EXIT -eq 6 ]]; then
               echo "::warning::Attempt ${ATTEMPT}: transient transport error (curl exit ${CURL_EXIT}). Retrying in ${BACKOFF}s..."
+              if [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; then
+                sleep $BACKOFF
+                BACKOFF=$((BACKOFF * 2))
+              fi
+              continue
+            fi
+
+            # Contract route can stay 404 for a short startup window while Functions are still indexing.
+            if [[ $CURL_EXIT -eq 22 && "$HTTP_STATUS" == "404" ]]; then
+              echo "::warning::Attempt ${ATTEMPT}: API contract endpoint returned 404. Treating as transient startup window and retrying in ${BACKOFF}s..."
               if [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; then
                 sleep $BACKOFF
                 BACKOFF=$((BACKOFF * 2))
@@ -162,6 +181,13 @@ jobs:
             echo "✅ API contract compatible (${LIVE_API_VERSION}) on attempt ${ATTEMPT}"
             exit 0
           done
+
+          if [[ "$observed_probe" == "1" && "$only_404_window" == "1" ]]; then
+            HEALTH_STATUS=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 "$HEALTH_URL" 2>/dev/null || echo "000")
+            READINESS_STATUS=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 "$READINESS_URL" 2>/dev/null || echo "000")
+            echo "::error::API contract endpoint persisted 404 across ${MAX_ATTEMPTS} attempts. health=${HEALTH_STATUS} readiness=${READINESS_STATUS}. Likely backend image/route is outdated; deploy backend before website."
+            exit 1
+          fi
 
           echo "::error::API contract check failed after ${MAX_ATTEMPTS} attempts (all transport errors)"
           exit 1

--- a/tests/unit/test_website_status_fallback.py
+++ b/tests/unit/test_website_status_fallback.py
@@ -182,3 +182,50 @@ class TestApiContractResiliency:
         assert "continue" in script or "break" in script or "exit 0" in script, (
             "Retry loop must have an explicit success exit/break when contract matches"
         )
+
+    def test_api_contract_step_tracks_404_only_window(
+        self, website_deploy_workflow: dict[str, Any]
+    ) -> None:
+        """Sustained 404 windows should be handled explicitly, not as generic curl failures."""
+        steps = _get_steps(website_deploy_workflow)
+        step = _find_step(steps, "verify backend api contract compatibility")
+        assert step is not None, "API contract step not found"
+        script = str(step.get("run", ""))
+
+        assert "only_404_window" in script, (
+            "API contract step must track whether failures are sustained 404 startup windows"
+        )
+        assert "HTTP_STATUS" in script and '"404"' in script, (
+            "API contract step must branch on explicit HTTP 404 responses"
+        )
+
+    def test_api_contract_step_checks_backend_health_on_404_window(
+        self, website_deploy_workflow: dict[str, Any]
+    ) -> None:
+        """If contract endpoint stays 404, workflow should probe backend health/readiness for diagnostics."""
+        steps = _get_steps(website_deploy_workflow)
+        step = _find_step(steps, "verify backend api contract compatibility")
+        assert step is not None, "API contract step not found"
+        script = str(step.get("run", ""))
+
+        assert "/api/health" in script, "404 handling must probe /api/health"
+        assert "/api/readiness" in script, "404 handling must probe /api/readiness"
+        assert "curl -sS -o /dev/null -w" in script, (
+            "404 diagnostics should log probe HTTP statuses"
+        )
+
+    def test_api_contract_step_emits_actionable_404_error_message(
+        self, website_deploy_workflow: dict[str, Any]
+    ) -> None:
+        """Final 404 failure should point to likely cause (backend missing/outdated route)."""
+        steps = _get_steps(website_deploy_workflow)
+        step = _find_step(steps, "verify backend api contract compatibility")
+        assert step is not None, "API contract step not found"
+        script = str(step.get("run", ""))
+
+        assert "persisted 404" in script.lower(), (
+            "Workflow should emit a specific persisted-404 diagnostic message"
+        )
+        assert "deploy backend" in script.lower() or "backend image" in script.lower(), (
+            "Persisted 404 guidance must tell operators to deploy/update backend before website"
+        )


### PR DESCRIPTION
Closed — superseded by the full rewrite. Changes no longer applicable.