### PR TITLE
security: rate limiting, auth enforcement, CIAM deploy fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,11 +143,18 @@ jobs:
             --resource-group "$FUNC_RG" \
             --image "${{ needs.build-image.outputs.image_uri }}"
 
+          # Read CIAM config from tfvars (body is ignore_changes in tofu)
+          CIAM_TENANT=$(grep 'ciam_tenant_name' environments/dev.tfvars | sed 's/.*= *"\(.*\)"/\1/')
+          CIAM_CLIENT=$(grep 'ciam_client_id' environments/dev.tfvars | sed 's/.*= *"\(.*\)"/\1/')
+
           az webapp config appsettings set \
             --name "$FUNC_NAME" \
             --resource-group "$FUNC_RG" \
             --settings \
-              WEBSITES_ENABLE_APP_SERVICE_STORAGE=false
+              WEBSITES_ENABLE_APP_SERVICE_STORAGE=false \
+              CIAM_TENANT_NAME="$CIAM_TENANT" \
+              CIAM_CLIENT_ID="$CIAM_CLIENT" \
+              CIAM_AUDIENCE="$CIAM_CLIENT"
 
   # ── 3. Deploy static website ───────────────────────────────
   deploy-website:

--- a/blueprints/analysis.py
+++ b/blueprints/analysis.py
@@ -13,8 +13,14 @@ import azure.functions as func
 
 from blueprints._helpers import check_auth, cors_preflight, error_response
 from treesight.ai import generate_analysis
+from treesight.security.rate_limit import ai_limiter, get_client_ip
 
 bp = func.Blueprint()
+
+# Maximum size (bytes) for the JSON body on AI endpoints to prevent cost abuse
+_MAX_AI_BODY_BYTES = 32_768  # 32 KiB
+# Maximum number of NDVI timeseries entries
+_MAX_TIMESERIES_ENTRIES = 120
 
 
 @bp.route(route="frame-analysis", methods=["POST", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
@@ -64,6 +70,13 @@ def frame_analysis(req: func.HttpRequest) -> func.HttpResponse:
         check_auth(req)
     except ValueError as exc:
         return error_response(401, str(exc))
+
+    if not ai_limiter.is_allowed(get_client_ip(req)):
+        return error_response(429, "Rate limit exceeded — try again shortly")
+
+    raw_body = req.get_body()
+    if len(raw_body) > _MAX_AI_BODY_BYTES:
+        return error_response(400, f"Request body too large (max {_MAX_AI_BODY_BYTES} bytes)")
 
     try:
         body = req.get_json()
@@ -218,6 +231,13 @@ def timelapse_analysis(req: func.HttpRequest) -> func.HttpResponse:
     except ValueError as exc:
         return error_response(401, str(exc))
 
+    if not ai_limiter.is_allowed(get_client_ip(req)):
+        return error_response(429, "Rate limit exceeded — try again shortly")
+
+    raw_body = req.get_body()
+    if len(raw_body) > _MAX_AI_BODY_BYTES:
+        return error_response(400, f"Request body too large (max {_MAX_AI_BODY_BYTES} bytes)")
+
     try:
         body = req.get_json()
     except ValueError:
@@ -228,9 +248,15 @@ def timelapse_analysis(req: func.HttpRequest) -> func.HttpResponse:
     if not context or not context.get("ndvi_timeseries"):
         return error_response(400, "Missing 'context' with ndvi_timeseries")
 
+    ndvi_ts = context.get("ndvi_timeseries", [])
+    if not isinstance(ndvi_ts, list) or len(ndvi_ts) > _MAX_TIMESERIES_ENTRIES:
+        return error_response(
+            400, f"ndvi_timeseries must be a list of at most {_MAX_TIMESERIES_ENTRIES} entries"
+        )
+
     try:
         # Extract timeseries data
-        ndvi_series = context.get("ndvi_timeseries", [])
+        ndvi_series = ndvi_ts
         weather_series = context.get("weather_timeseries", [])
 
         # Calculate trend statistics

--- a/blueprints/contact.py
+++ b/blueprints/contact.py
@@ -12,6 +12,7 @@ import azure.functions as func
 
 from blueprints._helpers import EMAIL_RE, error_response, sanitise
 from treesight.constants import PIPELINE_PAYLOADS_CONTAINER
+from treesight.security.rate_limit import form_limiter, get_client_ip
 from treesight.storage.client import BlobStorageClient
 
 bp = func.Blueprint()
@@ -21,6 +22,9 @@ bp = func.Blueprint()
 def contact_form(req: func.HttpRequest) -> func.HttpResponse:
     if req.method == "OPTIONS":
         return func.HttpResponse(status_code=204)
+
+    if not form_limiter.is_allowed(get_client_ip(req)):
+        return error_response(429, "Rate limit exceeded — try again later")
 
     try:
         body = req.get_json()

--- a/blueprints/demo.py
+++ b/blueprints/demo.py
@@ -19,6 +19,7 @@ from treesight.constants import (
     DEFAULT_OUTPUT_CONTAINER,
     PIPELINE_PAYLOADS_CONTAINER,
 )
+from treesight.security.rate_limit import demo_limiter, get_client_ip
 from treesight.security.valet import mint_valet_token, verify_valet_token
 from treesight.storage.client import BlobStorageClient
 
@@ -32,6 +33,9 @@ bp = func.Blueprint()
 def demo_submit(req: func.HttpRequest) -> func.HttpResponse:
     if req.method == "OPTIONS":
         return func.HttpResponse(status_code=204)
+
+    if not demo_limiter.is_allowed(get_client_ip(req)):
+        return error_response(429, "Rate limit exceeded — try again later")
 
     try:
         body = req.get_json()

--- a/blueprints/pipeline.py
+++ b/blueprints/pipeline.py
@@ -31,6 +31,7 @@ from treesight.constants import (
 from treesight.errors import ContractError
 from treesight.models.blob_event import BlobEvent
 from treesight.pipeline.orchestrator import build_pipeline_summary, derive_project_context
+from treesight.security.rate_limit import demo_limiter, get_client_ip
 
 # At runtime resolves to bare ``dict`` (Azure Functions binding requirement);
 # Pylance sees ``dict[str, Any]`` for full type-checking.
@@ -783,6 +784,14 @@ async def demo_process(
     Accepts ``{"kml_content": "..."}`` and returns ``{"instance_id": "..."}``
     which can be polled via ``GET /api/orchestrator/{instance_id}``.
     """
+    try:
+        check_auth(req)
+    except ValueError as exc:
+        return _error_response(401, str(exc))
+
+    if not demo_limiter.is_allowed(get_client_ip(req)):
+        return _error_response(429, "Rate limit exceeded — try again later")
+
     try:
         body = req.get_json()
     except ValueError:

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,31 @@
+"""Tests for treesight.security.rate_limit."""
+
+from treesight.security.rate_limit import RateLimiter
+
+
+class TestRateLimiter:
+    def test_allows_within_limit(self):
+        limiter = RateLimiter(max_requests=3, window_seconds=60)
+        assert limiter.is_allowed("ip1") is True
+        assert limiter.is_allowed("ip1") is True
+        assert limiter.is_allowed("ip1") is True
+
+    def test_blocks_over_limit(self):
+        limiter = RateLimiter(max_requests=2, window_seconds=60)
+        assert limiter.is_allowed("ip1") is True
+        assert limiter.is_allowed("ip1") is True
+        assert limiter.is_allowed("ip1") is False
+
+    def test_separate_keys_independent(self):
+        limiter = RateLimiter(max_requests=1, window_seconds=60)
+        assert limiter.is_allowed("ip1") is True
+        assert limiter.is_allowed("ip2") is True
+        assert limiter.is_allowed("ip1") is False
+        assert limiter.is_allowed("ip2") is False
+
+    def test_reset_clears_state(self):
+        limiter = RateLimiter(max_requests=1, window_seconds=60)
+        assert limiter.is_allowed("ip1") is True
+        assert limiter.is_allowed("ip1") is False
+        limiter.reset()
+        assert limiter.is_allowed("ip1") is True

--- a/treesight/security/rate_limit.py
+++ b/treesight/security/rate_limit.py
@@ -1,0 +1,62 @@
+"""In-memory per-IP rate limiter for API endpoints.
+
+Uses a sliding-window counter. Suitable for single-instance deployments
+(Azure Functions on Container Apps). For multi-instance, swap to a
+Redis/Table Storage backed store.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+
+class RateLimiter:
+    """Thread-safe sliding-window rate limiter keyed by arbitrary string (e.g. IP)."""
+
+    def __init__(self, max_requests: int, window_seconds: int) -> None:
+        self._max = max_requests
+        self._window = window_seconds
+        self._hits: dict[str, list[float]] = {}
+        self._lock = threading.Lock()
+
+    def is_allowed(self, key: str) -> bool:
+        """Return True if the request is within the rate limit, False otherwise."""
+        now = time.monotonic()
+        cutoff = now - self._window
+        with self._lock:
+            timestamps = self._hits.get(key, [])
+            # Prune expired entries
+            timestamps = [t for t in timestamps if t > cutoff]
+            if len(timestamps) >= self._max:
+                self._hits[key] = timestamps
+                return False
+            timestamps.append(now)
+            self._hits[key] = timestamps
+            return True
+
+    def reset(self) -> None:
+        """Clear all rate limit state (for testing)."""
+        with self._lock:
+            self._hits.clear()
+
+
+# Pre-configured limiters for different endpoint tiers
+# AI endpoints: 10 requests per 60 seconds per IP
+ai_limiter = RateLimiter(max_requests=10, window_seconds=60)
+
+# Form submission endpoints: 5 requests per 60 seconds per IP
+form_limiter = RateLimiter(max_requests=5, window_seconds=60)
+
+# Demo/pipeline endpoints: 3 requests per 60 seconds per IP
+demo_limiter = RateLimiter(max_requests=3, window_seconds=60)
+
+
+def get_client_ip(req) -> str:
+    """Extract client IP from Azure Functions request headers."""
+    # Azure Functions / Container Apps passes the real IP in X-Forwarded-For
+    forwarded = req.headers.get("X-Forwarded-For", "")
+    if forwarded:
+        # First IP in the chain is the client
+        return forwarded.split(",")[0].strip()
+    return req.headers.get("X-Real-IP", "unknown")


### PR DESCRIPTION
## Security Hardening

### Issues Found
1. **CRITICAL: CIAM env vars not deployed** — `auth_enabled()` returned `False` in production because the deploy workflow didn't push CIAM settings (Tofu `ignore_changes = [body]` workaround meant app settings changes were never applied)
2. **HIGH: No rate limiting** — AI, form, and demo endpoints could be called without limit
3. **HIGH: No input size limits on AI payloads** — arbitrarily large context data could cause cost/memory abuse
4. **HIGH: `/api/demo-process` had no auth check** — pipeline could be triggered anonymously

### Fixes
- **Deploy workflow**: Now reads CIAM vars from `dev.tfvars` and pushes them via `az webapp config appsettings set`
- **Rate limiting**: New `treesight/security/rate_limit.py` — per-IP sliding-window counters:
  - AI endpoints: 10 req/min
  - Form endpoints: 5 req/min
  - Demo/pipeline endpoints: 3 req/min
- **Input validation**: AI body max 32KiB, timeseries max 120 entries
- **Auth**: Added `check_auth()` to `demo-process` endpoint

### Testing
- 264 tests passing (4 new rate limiter tests)
- 0 pyright errors, 0 ruff violations