### PR TITLE
feat: per-user pipeline quota replaces IP rate-limiting

### DIFF
--- a/blueprints/analysis.py
+++ b/blueprints/analysis.py
@@ -13,7 +13,6 @@ import azure.functions as func
 
 from blueprints._helpers import check_auth, cors_headers, cors_preflight, error_response
 from treesight.ai import generate_analysis
-from treesight.security.rate_limit import ai_limiter, get_client_ip
 
 bp = func.Blueprint()
 
@@ -70,9 +69,6 @@ def frame_analysis(req: func.HttpRequest) -> func.HttpResponse:
         check_auth(req)
     except ValueError as exc:
         return error_response(401, str(exc), req=req)
-
-    if not ai_limiter.is_allowed(get_client_ip(req)):
-        return error_response(429, "Rate limit exceeded — try again shortly")
 
     raw_body = req.get_body()
     if len(raw_body) > _MAX_AI_BODY_BYTES:
@@ -232,9 +228,6 @@ def timelapse_analysis(req: func.HttpRequest) -> func.HttpResponse:
         check_auth(req)
     except ValueError as exc:
         return error_response(401, str(exc), req=req)
-
-    if not ai_limiter.is_allowed(get_client_ip(req)):
-        return error_response(429, "Rate limit exceeded — try again shortly")
 
     raw_body = req.get_body()
     if len(raw_body) > _MAX_AI_BODY_BYTES:

--- a/blueprints/demo.py
+++ b/blueprints/demo.py
@@ -15,6 +15,7 @@ import requests
 
 from blueprints._helpers import (
     EMAIL_RE,
+    check_auth,
     cors_headers,
     cors_preflight,
     error_response,
@@ -25,7 +26,8 @@ from treesight.constants import (
     DEFAULT_OUTPUT_CONTAINER,
     PIPELINE_PAYLOADS_CONTAINER,
 )
-from treesight.security.rate_limit import demo_limiter, get_client_ip, proxy_limiter
+from treesight.security.quota import consume_quota
+from treesight.security.rate_limit import get_client_ip, proxy_limiter
 from treesight.security.valet import mint_valet_token, verify_valet_token
 from treesight.storage.client import BlobStorageClient
 
@@ -40,8 +42,15 @@ def demo_submit(req: func.HttpRequest) -> func.HttpResponse:
     if req.method == "OPTIONS":
         return func.HttpResponse(status_code=204)
 
-    if not demo_limiter.is_allowed(get_client_ip(req)):
-        return error_response(429, "Rate limit exceeded — try again later")
+    try:
+        _claims, user_id = check_auth(req)
+    except ValueError as exc:
+        return error_response(401, str(exc))
+
+    try:
+        consume_quota(user_id)
+    except ValueError as exc:
+        return error_response(403, str(exc))
 
     try:
         body = req.get_json()

--- a/blueprints/pipeline.py
+++ b/blueprints/pipeline.py
@@ -31,7 +31,8 @@ from treesight.constants import (
 from treesight.errors import ContractError
 from treesight.models.blob_event import BlobEvent
 from treesight.pipeline.orchestrator import build_pipeline_summary, derive_project_context
-from treesight.security.rate_limit import demo_limiter, get_client_ip, pipeline_limiter
+from treesight.security.quota import consume_quota
+from treesight.security.rate_limit import get_client_ip, pipeline_limiter
 
 # At runtime resolves to bare ``dict`` (Azure Functions binding requirement);
 # Pylance sees ``dict[str, Any]`` for full type-checking.
@@ -822,12 +823,14 @@ async def demo_process(
     which can be polled via ``GET /api/orchestrator/{instance_id}``.
     """
     try:
-        check_auth(req)
+        _claims, user_id = check_auth(req)
     except ValueError as exc:
         return _error_response(401, str(exc))
 
-    if not demo_limiter.is_allowed(get_client_ip(req)):
-        return _error_response(429, "Rate limit exceeded — try again later")
+    try:
+        consume_quota(user_id)
+    except ValueError as exc:
+        return _error_response(403, str(exc))
 
     try:
         body = req.get_json()

--- a/tests/test_quota.py
+++ b/tests/test_quota.py
@@ -1,0 +1,64 @@
+"""Tests for treesight.security.quota."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from treesight.security.quota import FREE_TIER_LIMIT, check_quota, consume_quota
+
+
+@pytest.fixture(autouse=True)
+def _mock_storage():
+    """Patch BlobStorageClient so quota tests never hit real storage."""
+    store: dict[str, dict] = {}
+    mock_cls = MagicMock()
+
+    def _download_json(_container, path):
+        if path not in store:
+            raise FileNotFoundError(path)
+        return store[path]
+
+    def _upload_json(_container, path, data):
+        store[path] = data
+
+    mock_cls.return_value.download_json = _download_json
+    mock_cls.return_value.upload_json = _upload_json
+
+    with patch("treesight.storage.client.BlobStorageClient", mock_cls):
+        yield store
+
+
+class TestCheckQuota:
+    def test_new_user_has_full_quota(self):
+        assert check_quota("user-new") == FREE_TIER_LIMIT
+
+    def test_partial_usage(self, _mock_storage):
+        _mock_storage["quotas/user-partial.json"] = {"used": 2, "runs": []}
+        assert check_quota("user-partial") == FREE_TIER_LIMIT - 2
+
+    def test_exhausted_returns_zero(self, _mock_storage):
+        _mock_storage["quotas/user-full.json"] = {"used": FREE_TIER_LIMIT, "runs": []}
+        assert check_quota("user-full") == 0
+
+
+class TestConsumeQuota:
+    def test_first_use(self):
+        remaining = consume_quota("user-first")
+        assert remaining == FREE_TIER_LIMIT - 1
+
+    def test_successive_uses(self):
+        for i in range(FREE_TIER_LIMIT - 1):
+            remaining = consume_quota("user-successive")
+            assert remaining == FREE_TIER_LIMIT - (i + 1)
+
+    def test_exhaustion_raises(self):
+        for _ in range(FREE_TIER_LIMIT):
+            consume_quota("user-exhaust")
+        with pytest.raises(ValueError, match="Free quota exhausted"):
+            consume_quota("user-exhaust")
+
+    def test_different_users_independent(self):
+        consume_quota("alice")
+        consume_quota("alice")
+        remaining_bob = consume_quota("bob")
+        assert remaining_bob == FREE_TIER_LIMIT - 1

--- a/treesight/security/quota.py
+++ b/treesight/security/quota.py
@@ -1,0 +1,68 @@
+"""Per-user pipeline run quota backed by blob storage.
+
+Each user gets a fixed number of free pipeline runs.  Usage is tracked in
+a JSON blob ``quotas/{user_id}.json`` inside the pipeline-payloads container.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from treesight.constants import PIPELINE_PAYLOADS_CONTAINER
+
+logger = logging.getLogger(__name__)
+
+#: Maximum free pipeline runs per user.
+FREE_TIER_LIMIT = 5
+
+_QUOTA_PREFIX = "quotas"
+
+
+def _blob_path(user_id: str) -> str:
+    return f"{_QUOTA_PREFIX}/{user_id}.json"
+
+
+def check_quota(user_id: str) -> int:
+    """Return remaining pipeline runs for *user_id*.
+
+    Returns ``FREE_TIER_LIMIT`` if no usage record exists yet.
+    """
+    from treesight.storage.client import BlobStorageClient
+
+    storage = BlobStorageClient()
+    try:
+        record = storage.download_json(PIPELINE_PAYLOADS_CONTAINER, _blob_path(user_id))
+        used = record.get("used", 0)
+    except Exception:
+        used = 0
+    return max(FREE_TIER_LIMIT - used, 0)
+
+
+def consume_quota(user_id: str) -> int:
+    """Increment usage and return remaining runs (after this one).
+
+    Raises ``ValueError`` if the user has exhausted their free quota.
+    """
+    from treesight.storage.client import BlobStorageClient
+
+    storage = BlobStorageClient()
+    path = _blob_path(user_id)
+
+    try:
+        record: dict[str, Any] = storage.download_json(PIPELINE_PAYLOADS_CONTAINER, path)
+    except Exception:
+        record = {"used": 0, "runs": []}
+
+    used: int = record.get("used", 0)
+    if used >= FREE_TIER_LIMIT:
+        raise ValueError(
+            f"Free quota exhausted ({FREE_TIER_LIMIT} pipeline runs). Please upgrade to continue."
+        )
+
+    record["used"] = used + 1
+    record.setdefault("runs", [])
+    storage.upload_json(PIPELINE_PAYLOADS_CONTAINER, path, record)
+    remaining = FREE_TIER_LIMIT - record["used"]
+    logger.info("Quota consumed user=%s used=%d remaining=%d", user_id, record["used"], remaining)
+    return remaining

--- a/treesight/security/rate_limit.py
+++ b/treesight/security/rate_limit.py
@@ -42,14 +42,8 @@ class RateLimiter:
 
 
 # Pre-configured limiters for different endpoint tiers
-# AI endpoints: 10 requests per 60 seconds per IP
-ai_limiter = RateLimiter(max_requests=10, window_seconds=60)
-
 # Form submission endpoints: 5 requests per 60 seconds per IP
 form_limiter = RateLimiter(max_requests=5, window_seconds=60)
-
-# Demo/pipeline endpoints: 3 requests per 60 seconds per IP
-demo_limiter = RateLimiter(max_requests=3, window_seconds=60)
 
 # Pipeline status polling: 30 requests per 60 seconds per IP
 pipeline_limiter = RateLimiter(max_requests=30, window_seconds=60)


### PR DESCRIPTION
## Summary

Replaces IP-based rate limiting with per-user quota on pipeline endpoints. The AI endpoints (`frame-analysis`, `timelapse-analysis`) are **not browser-facing** — they're called server-side by the pipeline — so IP rate limiting on them was protecting the wrong surface.

## Changes

- **Per-user quota** (`treesight/security/quota.py`): blob-backed, 5 free pipeline runs per user (`FREE_TIER_LIMIT`). Enough to taste, not enough to abuse.
- **`demo-submit`**: now requires CIAM auth + quota check (was unauthenticated)
- **`demo-process`**: replaced IP rate-limiter with per-user quota
- **`frame-analysis` / `timelapse-analysis`**: removed IP rate-limiters (auth-only, not browser-exposed)
- **`contact-form`**: keeps IP rate-limiter (public form, no auth)
- Removed unused `ai_limiter` and `demo_limiter` from rate_limit module
- 7 new quota tests, **271 total passing**

## Security Model

| Endpoint | Auth | Quota | Rate Limit | Notes |
|---|---|---|---|---|
| `frame-analysis` | CIAM | — | — | Server-side only, not browser-facing |
| `timelapse-analysis` | CIAM | — | — | Called after pipeline run completes |
| `demo-process` | CIAM | 5 runs | — | Primary cost surface |
| `demo-submit` | CIAM | 5 runs | — | Alternative KML submission |
| `contact-form` | — | — | 5/60s IP | Public form |
| `health` | — | — | — | Health check |