### PR TITLE
fix: UI overhaul — visible login, nav layout, consistency

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -18,15 +18,17 @@ h3{font-size:1.125rem;font-weight:600}
 
 /* --- Nav --- */
 nav{position:sticky;top:0;z-index:1000;background:rgba(12,17,23,.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--c-border);padding:12px 0}
-nav .container{display:flex;align-items:center;justify-content:space-between}
-nav .logo{font-weight:700;font-size:1.25rem;display:flex;align-items:center;gap:8px}
+nav .container{display:flex;align-items:center;gap:16px}
+nav .logo{font-weight:700;font-size:1.25rem;display:flex;align-items:center;gap:8px;flex-shrink:0}
 nav .logo svg{width:24px;height:24px;fill:var(--c-accent)}
-nav ul{list-style:none;display:flex;gap:24px}
+nav ul{list-style:none;display:flex;gap:20px;margin:0 auto;flex-wrap:wrap;justify-content:center}
 nav ul a{color:var(--c-muted);font-size:.875rem;transition:color .15s}
 nav ul a:hover{color:var(--c-text);text-decoration:none}
 #status-badge{font-size:.75rem;padding:3px 10px;border-radius:12px;font-weight:600;background:var(--c-surface);color:var(--c-muted);border:1px solid var(--c-border);transition:all .3s}
 #status-badge.online{background:rgba(63,185,80,.15);color:var(--c-green);border-color:var(--c-green)}
 #status-badge.offline{background:rgba(248,81,73,.15);color:var(--c-red);border-color:var(--c-red)}
+@media(max-width:860px){nav ul{gap:12px}nav ul a{font-size:.8rem}.auth-area{gap:6px}.auth-btn{padding:5px 10px;font-size:.75rem}}
+@media(max-width:600px){nav .container{flex-wrap:wrap;justify-content:center}nav ul{order:3;width:100%;justify-content:center;gap:10px;padding-top:8px;border-top:1px solid var(--c-border);margin-top:4px}}
 
 /* --- Hero --- */
 .hero{padding:80px 0 60px;text-align:center}
@@ -285,10 +287,12 @@ footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;col
 .drop-divider{text-align:center;color:var(--c-muted);font-size:.75rem;margin:4px 0 12px;text-transform:uppercase;letter-spacing:.08em}
 
 /* --- Auth UI --- */
-.auth-area{display:flex;align-items:center;gap:10px;margin-left:12px}
-.auth-user{font-size:.8rem;color:var(--c-muted);max-width:160px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.auth-btn{padding:5px 14px;border-radius:var(--radius);font-size:.8rem;font-weight:600;cursor:pointer;border:1px solid var(--c-accent);background:transparent;color:var(--c-accent);transition:all .15s}
-.auth-btn:hover{background:rgba(88,166,255,.1)}
+.auth-area{display:flex;align-items:center;gap:10px;flex-shrink:0}
+.auth-user{font-size:.8rem;color:var(--c-muted);max-width:140px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.auth-btn{padding:6px 16px;border-radius:var(--radius);font-size:.8rem;font-weight:600;cursor:pointer;border:1px solid var(--c-accent);background:transparent;color:var(--c-accent);transition:all .15s;white-space:nowrap}
+.auth-btn:hover{background:rgba(88,166,255,.15);text-decoration:none}
+.auth-btn.primary{background:var(--c-accent);color:#fff;border-color:var(--c-accent)}
+.auth-btn.primary:hover{background:#79c0ff}
 .auth-btn.logout{border-color:var(--c-border);color:var(--c-muted)}
 .auth-btn.logout:hover{border-color:var(--c-red);color:var(--c-red)}
 .login-prompt{background:rgba(88,166,255,.08);border:1px solid rgba(88,166,255,.2);border-radius:var(--radius);padding:12px 16px;margin-bottom:12px;font-size:.85rem;color:var(--c-muted);text-align:center;display:none}
@@ -312,11 +316,11 @@ footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;col
       <li><a href="#pricing">Pricing</a></li>
       <li><a href="#faq">FAQ</a></li>
       <li><a href="#early-access">Early Access</a></li>
-      <li><span id="status-badge">Checking…</span></li>
     </ul>
     <div class="auth-area" id="auth-area">
+      <span id="status-badge">Checking…</span>
       <span class="auth-user" id="auth-user" style="display:none"></span>
-      <button class="auth-btn" id="auth-login-btn" style="display:none">Sign In</button>
+      <button class="auth-btn primary" id="auth-login-btn">Sign In</button>
       <button class="auth-btn logout" id="auth-logout-btn" style="display:none">Sign Out</button>
     </div>
   </div>
@@ -396,7 +400,7 @@ footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;col
           <div class="drop-divider">— or paste KML text —</div>
           <label for="demo-kml">KML Content</label>
           <textarea id="demo-kml" placeholder="Paste your KML content here, or use the sample below…"></textarea>
-          <div class="login-prompt" id="login-prompt">🔒 <a id="login-prompt-link">Sign in</a> to process KML files and run satellite analysis.</div>
+          <div class="login-prompt" id="login-prompt">� <a id="login-prompt-link">Sign in</a> to process your KML and get satellite imagery, NDVI analysis, and weather data — free.</div>
           <button class="btn btn-primary" id="demo-submit" style="width:100%">Process KML</button>
           <p style="font-size:.7rem;color:var(--c-muted);text-align:center;margin-top:8px">Your data is automatically deleted after 30 days. <a href="/privacy.html">Privacy Policy</a></p>
           <div id="demo-status" class="demo-status"></div>
@@ -533,7 +537,7 @@ footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;col
           <li>30-day data retention</li>
           <li>Community support</li>
         </ul>
-        <a href="#demo" class="btn btn-secondary">Try Free Demo</a>
+        <a href="#early-access" class="btn btn-primary">Start Free</a>
       </div>
       <div class="pricing-card featured">
         <div class="tier-name">Pro</div>
@@ -548,7 +552,7 @@ footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;col
           <li>90-day data retention</li>
           <li>Email support</li>
         </ul>
-        <a href="#early-access" class="btn btn-primary">Get Started</a>
+        <a href="#early-access" class="btn btn-primary">Get Pro</a>
       </div>
       <div class="pricing-card">
         <div class="tier-name">Team</div>
@@ -563,7 +567,7 @@ footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;col
           <li>1-year data retention</li>
           <li>Priority support</li>
         </ul>
-        <a href="#early-access" class="btn btn-secondary">Contact Us</a>
+        <a href="#early-access" class="btn btn-secondary">Get Team</a>
       </div>
       <div class="pricing-card">
         <div class="tier-name">Enterprise</div>
@@ -651,7 +655,7 @@ footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;col
 <!-- Footer -->
 <footer>
   <div class="container">
-    <p>&copy; 2025 TreeSight. API contract version: <span id="contract-version">—</span>
+    <p>&copy; 2026 TreeSight. API contract version: <span id="contract-version">—</span>
     <br><a href="/terms.html">Terms of Service</a> · <a href="/privacy.html">Privacy Policy</a></p>
   </div>
 </footer>
@@ -751,13 +755,15 @@ footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;col
     var logoutBtn = document.getElementById('auth-logout-btn');
     var userSpan = document.getElementById('auth-user');
     var loginPrompt = document.getElementById('login-prompt');
+    var submitBtn = document.getElementById('demo-submit');
 
     if (!authEnabled()) {
-      /* Auth not configured — hide everything, anonymous access */
+      /* Auth not configured — hide auth controls, anonymous access */
       loginBtn.style.display = 'none';
       logoutBtn.style.display = 'none';
       userSpan.style.display = 'none';
       loginPrompt.style.display = 'none';
+      if (submitBtn) submitBtn.textContent = 'Process KML';
       return;
     }
 
@@ -768,11 +774,13 @@ footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;col
       loginBtn.style.display = 'none';
       logoutBtn.style.display = 'inline';
       loginPrompt.style.display = 'none';
+      if (submitBtn) submitBtn.textContent = 'Process KML';
     } else {
       userSpan.style.display = 'none';
       loginBtn.style.display = 'inline';
       logoutBtn.style.display = 'none';
       loginPrompt.style.display = 'block';
+      if (submitBtn) submitBtn.textContent = 'Sign In to Process KML';
     }
   }
 


### PR DESCRIPTION
## UI Overhaul — Login Visibility, Navigation, Consistency

Thorough audit of the website UI identified several issues with discoverability, consistency, and usability. This PR fixes them all.

### Login Button (Critical)
**Before:** The Sign In button had `style="display:none"` inline and only became visible after MSAL loaded and `handleRedirectPromise()` resolved. Users saw no login option on page load — it could take 1-2 seconds to appear, or never if MSAL failed to load.

**After:** Sign In button is visible immediately. It uses a solid accent-coloured `.primary` style so it's clearly a call-to-action, not just a nav link. JS hides it only when auth is confirmed disabled or user is already logged in.

### Navigation Layout
- **Fixed flex layout:** Logo left, links centered (`margin: 0 auto`), auth area right — proper 3-zone layout
- **Status badge relocated:** Moved from nav `<ul>` (where it was a list item among links) to the auth-area group, where it belongs visually
- **Responsive breakpoints:** Nav wraps gracefully at 860px (smaller gaps/font) and 600px (links wrap to second row)

### Demo Form UX
- **Submit button text changes with auth state:** Shows "Sign In to Process KML" when unauthenticated, "Process KML" when signed in — no more ambiguity about what clicking it does
- **Login prompt updated:** Now describes what signing in unlocks: "satellite imagery, NDVI analysis, and weather data — free"

### Pricing CTAs
**Before:** Inconsistent labels — "Try Free Demo" / "Get Started" / "Contact Us" / "Talk to Sales" — with mixed button styles and link targets.

**After:** Tier-appropriate labels that match user intent:
| Tier | Label | Style | Links to |
|------|-------|-------|----------|
| Free | Start Free | Primary (solid) | #early-access |
| Pro | Get Pro | Primary (solid) | #early-access |
| Team | Get Team | Secondary (outline) | #early-access |
| Enterprise | Talk to Sales | Secondary (outline) | #early-access |

### Footer
- Updated copyright year: 2025 → 2026

### No backend changes. 328 tests still pass.