### PR TITLE
fix: security hardening — auth on orchestrator, rate-limit proxy, body cap on save

### DIFF
--- a/blueprints/demo.py
+++ b/blueprints/demo.py
@@ -25,7 +25,7 @@ from treesight.constants import (
     DEFAULT_OUTPUT_CONTAINER,
     PIPELINE_PAYLOADS_CONTAINER,
 )
-from treesight.security.rate_limit import demo_limiter, get_client_ip
+from treesight.security.rate_limit import demo_limiter, get_client_ip, proxy_limiter
 from treesight.security.valet import mint_valet_token, verify_valet_token
 from treesight.storage.client import BlobStorageClient
 
@@ -209,6 +209,9 @@ def cors_proxy(req: func.HttpRequest) -> func.HttpResponse:
     """
     if req.method == "OPTIONS":
         return cors_preflight(req)
+
+    if not proxy_limiter.is_allowed(get_client_ip(req)):
+        return error_response(429, "Rate limit exceeded — try again later", req=req)
 
     target_url = req.params.get("url")
 

--- a/blueprints/pipeline.py
+++ b/blueprints/pipeline.py
@@ -31,7 +31,7 @@ from treesight.constants import (
 from treesight.errors import ContractError
 from treesight.models.blob_event import BlobEvent
 from treesight.pipeline.orchestrator import build_pipeline_summary, derive_project_context
-from treesight.security.rate_limit import demo_limiter, get_client_ip
+from treesight.security.rate_limit import demo_limiter, get_client_ip, pipeline_limiter
 
 # At runtime resolves to bare ``dict`` (Azure Functions binding requirement);
 # Pylance sees ``dict[str, Any]`` for full type-checking.
@@ -42,19 +42,37 @@ else:
 
 bp = df.Blueprint()
 
+# Maximum body size for analysis save endpoint (128 KiB)
+_MAX_ANALYSIS_BODY_BYTES = 131_072
+
 
 # ---------------------------------------------------------------------------
 # Blob trigger → start orchestration (§4.2)
 # ---------------------------------------------------------------------------
 
 
-@bp.route(route="orchestrator/{instance_id}", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
+@bp.route(
+    route="orchestrator/{instance_id}",
+    methods=["GET", "OPTIONS"],
+    auth_level=func.AuthLevel.ANONYMOUS,
+)
 @bp.durable_client_input(client_name="client")
 async def orchestrator_status(
     req: func.HttpRequest,
     client: df.DurableOrchestrationClient,
 ) -> func.HttpResponse:
     """GET /api/orchestrator/{instance_id} — direct JSON diagnostics (§4.3)."""
+    if req.method == "OPTIONS":
+        return cors_preflight(req)
+
+    try:
+        check_auth(req)
+    except ValueError as exc:
+        return _error_response(401, str(exc))
+
+    if not pipeline_limiter.is_allowed(get_client_ip(req)):
+        return _error_response(429, "Rate limit exceeded — try again later")
+
     instance_id = req.route_params.get("instance_id", "")
     if not instance_id:
         return func.HttpResponse(
@@ -82,6 +100,7 @@ async def orchestrator_status(
         json.dumps(result, default=str),
         status_code=200,
         mimetype="application/json",
+        headers=cors_headers(req),
     )
 
 
@@ -717,6 +736,12 @@ def timelapse_analysis_save(req: func.HttpRequest) -> func.HttpResponse:
         check_auth(req)
     except ValueError as exc:
         return _error_response(401, str(exc))
+
+    raw_body = req.get_body()
+    if len(raw_body) > _MAX_ANALYSIS_BODY_BYTES:
+        return _error_response(
+            413, f"Request body too large (max {_MAX_ANALYSIS_BODY_BYTES} bytes)"
+        )
 
     try:
         body = req.get_json()

--- a/treesight/security/rate_limit.py
+++ b/treesight/security/rate_limit.py
@@ -51,6 +51,12 @@ form_limiter = RateLimiter(max_requests=5, window_seconds=60)
 # Demo/pipeline endpoints: 3 requests per 60 seconds per IP
 demo_limiter = RateLimiter(max_requests=3, window_seconds=60)
 
+# Pipeline status polling: 30 requests per 60 seconds per IP
+pipeline_limiter = RateLimiter(max_requests=30, window_seconds=60)
+
+# CORS proxy: 60 requests per 60 seconds per IP
+proxy_limiter = RateLimiter(max_requests=60, window_seconds=60)
+
 
 def get_client_ip(req) -> str:
     """Extract client IP from Azure Functions request headers."""


### PR DESCRIPTION
## Security Hardening

Addresses three findings from the security audit:

### Critical: Orchestrator endpoint auth (#233)
- **`GET /api/orchestrator/{instance_id}`** was completely unauthenticated with no rate limiting
- Added CIAM JWT authentication via `check_auth()`
- Added rate limiting (30 requests/60s per IP) via new `pipeline_limiter`
- Added OPTIONS/CORS preflight support

### High: Proxy rate limiting (#236)
- **`GET /api/proxy`** had no rate limiting — could be used as an open relay to flood upstream APIs
- Added rate limiting (60 requests/60s per IP) via new `proxy_limiter`

### Medium: Analysis save body cap (#247)
- **`POST /api/timelapse-analysis-save`** had no body size validation
- Added 128 KiB body size cap (returns 413 if exceeded)

### Changes
| File | Change |
|------|--------|
| `treesight/security/rate_limit.py` | Added `pipeline_limiter` (30/60s) and `proxy_limiter` (60/60s) |
| `blueprints/pipeline.py` | Auth + rate limit on orchestrator; body cap on save; CORS on orchestrator |
| `blueprints/demo.py` | Rate limit on proxy endpoint |

### Testing
- 328 tests pass
- `ruff check` clean

Closes #233, closes #236, closes #247