### PR TITLE
fix: cache tofu providers + bounded retry on init

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,6 +106,13 @@ jobs:
         with:
           tofu_version: ${{ env.TOFU_VERSION }}
 
+      - name: Cache OpenTofu providers
+        uses: actions/cache@v4
+        with:
+          path: infra/tofu/.terraform/providers
+          key: tofu-providers-${{ hashFiles('infra/tofu/.terraform.lock.hcl') }}
+          restore-keys: tofu-providers-
+
       - name: Tofu Init
         working-directory: infra/tofu
         env:
@@ -114,11 +121,24 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           ARM_USE_OIDC: "true"
         run: |
-          tofu init \
-            -backend-config="resource_group_name=${{ secrets.TF_STATE_RESOURCE_GROUP }}" \
-            -backend-config="storage_account_name=${{ secrets.TF_STATE_STORAGE_ACCOUNT }}" \
-            -backend-config="container_name=${{ secrets.TF_STATE_CONTAINER_DEV }}" \
-            -backend-config="key=${{ secrets.TF_STATE_KEY_DEV }}"
+          MAX_RETRIES=3
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            echo "tofu init attempt ${attempt}/${MAX_RETRIES}"
+            if tofu init \
+              -backend-config="resource_group_name=${{ secrets.TF_STATE_RESOURCE_GROUP }}" \
+              -backend-config="storage_account_name=${{ secrets.TF_STATE_STORAGE_ACCOUNT }}" \
+              -backend-config="container_name=${{ secrets.TF_STATE_CONTAINER_DEV }}" \
+              -backend-config="key=${{ secrets.TF_STATE_KEY_DEV }}"; then
+              echo "✅ tofu init succeeded on attempt ${attempt}"
+              exit 0
+            fi
+            if [ "$attempt" -lt "$MAX_RETRIES" ]; then
+              echo "⚠️ tofu init failed, retrying in 10s..."
+              sleep 10
+            fi
+          done
+          echo "❌ tofu init failed after ${MAX_RETRIES} attempts"
+          exit 1
 
       - name: Tofu Plan
         working-directory: infra/tofu


### PR DESCRIPTION
## Problem

Deploy run `23389599612` failed because `tofu init` got a transient `502 Bad Gateway` from the OpenTofu registry when downloading `hashicorp/random`. Providers are re-downloaded from scratch on every deploy, making every run vulnerable to upstream flakes.

## Changes

1. **Provider caching** — `actions/cache@v4` caches `.terraform/providers` keyed on `.terraform.lock.hcl`. Providers only re-download when the lock file changes (i.e. version bumps), removing the external dependency from most runs.

2. **Bounded retry** — `tofu init` retries up to 3 times with 10s backoff. Covers transient registry errors without looping indefinitely.

## Impact

- Faster `tofu init` on cache hit (~10s saved)
- Resilient to transient registry 502/503 errors
- No change to infra behaviour — same providers, same lock file