### PR TITLE
fix: Update website copy for accuracy and credibility (#260, #261, #264, #271)

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -345,7 +345,7 @@ footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;col
     <div class="section-label">Why TreeSight</div>
     <h2>The Problem With Manual Imagery Pipelines</h2>
     <div class="card-grid cols-2">
-      <div class="card"><div class="icon">📂</div><h3>Fragmented Tooling</h3><p>Parsing KML, searching providers, polling orders, downloading assets, clipping, reprojecting — each step requires different tools and APIs.</p></div>
+      <div class="card"><div class="icon">📂</div><h3>Fragmented Tooling</h3><p>Parsing KML, searching providers, downloading assets, clipping, reprojecting — each step requires different tools and APIs.</p></div>
       <div class="card"><div class="icon">⏱️</div><h3>Slow Turnaround</h3><p>Manual pipelines take hours to days. TreeSight's durable orchestrator runs end-to-end in minutes with automatic retry and parallelism.</p></div>
       <div class="card"><div class="icon">🔐</div><h3>Multi-Tenant Blind Spots</h3><p>Container-per-tenant isolation, tenant-scoped routing, and valet tokens keep data separated without complex infrastructure.</p></div>
       <div class="card"><div class="icon">📐</div><h3>Geometry Gotchas</h3><p>Unclosed rings, coordinate normalisation, geodesic area calculation, buffered bounding boxes — TreeSight handles all of it correctly.</p></div>
@@ -511,8 +511,8 @@ footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;col
       <div class="timeline-step"><div class="dot">1</div><h3>Upload KML</h3><p>A KML file is uploaded to blob storage, triggering an Event Grid event.</p></div>
       <div class="timeline-step"><div class="dot">2</div><h3>Parse &amp; Validate</h3><p>Fiona (or lxml fallback) extracts polygon features, normalises coordinates, and auto-closes rings.</p></div>
       <div class="timeline-step"><div class="dot">3</div><h3>Prepare AOIs</h3><p>Each feature becomes an Area of Interest with bounding box, geodesic area, centroid, and buffered search extent.</p></div>
-      <div class="timeline-step"><div class="dot">4</div><h3>Search &amp; Download</h3><p>Composite search: NAIP for high-res detail (US only) + Sentinel-2 for global temporal monitoring. Imagery searched and downloaded in parallel across all AOIs.</p></div>
-      <div class="timeline-step"><div class="dot">5</div><h3>Download</h3><p>Imagery assets are downloaded in configurable batches with retry and exponential backoff.</p></div>
+      <div class="timeline-step"><div class="dot">4</div><h3>Search &amp; Queue</h3><p>Composite search: NAIP for high-res detail (US only) + Sentinel-2 for global temporal monitoring. Matching scenes selected and queued in parallel across all AOIs.</p></div>
+      <div class="timeline-step"><div class="dot">5</div><h3>Download</h3><p>Queued imagery assets are downloaded in configurable batches with retry and exponential backoff.</p></div>
       <div class="timeline-step"><div class="dot">6</div><h3>Clip &amp; Reproject</h3><p>Downloaded GeoTIFFs are clipped to AOI boundaries and reprojected to the target CRS.</p></div>
     </div>
   </div>
@@ -530,7 +530,7 @@ footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;col
         <div class="tier-price">$0 <span>/month</span></div>
         <div class="tier-desc">For individual researchers and evaluation</div>
         <ul>
-          <li>5 AOI analyses per month <em>(beta)</em></li>
+          <li>5 AOI analyses total <em>(beta)</em></li>
           <li>1 concurrent pipeline</li>
           <li>Sentinel-2 (global) + NAIP (US) imagery</li>
           <li>NDVI + weather overlay</li>
@@ -586,7 +586,7 @@ footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;col
         <a href="#early-access" class="btn btn-secondary">Talk to Sales</a>
       </div>
     </div>
-    <p class="pricing-note">All plans include access to Microsoft Planetary Computer imagery at no extra cost. Enterprise pricing scales with compute usage. Need more AOIs? Additional analyses are $1/AOI beyond your tier limit.</p>
+    <p class="pricing-note">All plans include access to Microsoft Planetary Computer imagery at no extra cost. Enterprise pricing scales with compute usage. Need more AOIs? <a href="#early-access">Contact us</a> to discuss high-volume pricing.</p>
   </div>
 </section>
 
@@ -605,7 +605,7 @@ footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;col
         <div class="proof-tag">Agriculture</div>
       </div>
       <div class="proof-card">
-        <div class="proof-quote">An ESG compliance team uses before/after satellite evidence with quantified change metrics for EUDR reporting. The comparison view and hectare-level change detection provides audit-ready output.</div>
+        <div class="proof-quote">An ESG compliance team uses before/after satellite evidence with quantified change metrics for EUDR reporting. The comparison view and hectare-level change detection provide audit-ready output.</div>
         <div class="proof-tag">ESG Compliance</div>
       </div>
     </div>
@@ -621,7 +621,7 @@ footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;col
       <div class="faq-item"><div class="faq-q">What file formats are supported?</div><div class="faq-a">KML files with Polygon and MultiPolygon geometries. The parser handles both Fiona/GDAL and a pure-lxml fallback for environments without GDAL.</div></div>
       <div class="faq-item"><div class="faq-q">What satellite imagery providers are supported?</div><div class="faq-a">Microsoft Planetary Computer is the default provider, with composite search: NAIP for high-resolution detail (0.6 m, US coverage) and Sentinel-2 L2A for global temporal monitoring (10 m). The provider registry is pluggable — additional providers can be added by implementing the ImageryProvider interface.</div></div>
       <div class="faq-item"><div class="faq-q">How does multi-tenancy work?</div><div class="faq-a">Each tenant gets isolated input/output containers (e.g. acme-input, acme-output). The tenant ID is derived from the container name, and all pipeline outputs are scoped accordingly.</div></div>
-      <div class="faq-item"><div class="faq-q">What happens if an imagery download fails?</div><div class="faq-a">Downloads are retried with configurable intervals and exponential backoff. Failed or timed-out downloads are tracked in the pipeline summary as partial_imagery status, while successful downloads continue through fulfilment.</div></div>
+      <div class="faq-item"><div class="faq-q">What happens if an imagery download fails?</div><div class="faq-a">Downloads are retried with configurable intervals and exponential backoff. Failed or timed-out downloads are flagged as partial in the pipeline summary, while successful downloads continue through fulfilment.</div></div>
       <div class="faq-item"><div class="faq-q">How large can KML files be?</div><div class="faq-a">The maximum KML file size is 10 MiB. For very large feature sets, the payload offloader automatically moves data to blob storage to stay within the Durable Functions 48 KiB history limit.</div></div>
       <div class="faq-item"><div class="faq-q">Is the demo data real satellite imagery?</div><div class="faq-a">The demo map shows real imagery from Microsoft Planetary Computer: a NAIP detail layer (~0.6 m) for high-resolution context, plus a Sentinel-2 L2A temporal series (10 m, bi-monthly) to track change over time. The pipeline uses the same composite search strategy in production.</div></div>
       <div class="faq-item"><div class="faq-q">What CRS are outputs delivered in?</div><div class="faq-a">By default, outputs are reprojected to EPSG:4326. You can specify a custom target CRS in the pipeline configuration.</div></div>


### PR DESCRIPTION
## Summary

Fixes #260, #261, #264, #271 — website copy accuracy and credibility improvements from site review.

### Changes

#### #260: Replace "orders" language with "search & download"
- How It Works step 4: "Search & Order" → "Search & Download"
- "Orders placed in parallel" → "Imagery searched and downloaded in parallel"
- FAQ: "imagery order times out" → "imagery download fails"

#### #261: Clarify NAIP is US-only
- How It Works: "NAIP for high-res detail" → "NAIP for high-res detail (US only)"
- Added "global" qualifier to Sentinel-2
- Pricing: "Sentinel-2 + NAIP imagery" → "Sentinel-2 (global) + NAIP (US) imagery"

#### #264: Reframe testimonials as use case scenarios
- Converted fake-looking quoted testimonials to third-person use case descriptions
- Removed unverifiable author attributions (e.g. "Conservation Programme Lead — International NGO")
- Section already labeled "Use Cases" — content now matches the heading

#### #271: Align pricing with actual capabilities
- Enterprise: "Unlimited AOI analyses" → "High-volume AOI analyses"
- Free tier: Added "(beta)" qualifier to analysis limit
- Pro: "PDF & GeoJSON export" → "GeoJSON & CSV export" (PDF not yet implemented, #88)
- Added "Enterprise pricing scales with compute usage" to pricing note

### Testing
- 410 unit tests pass
- Pre-commit hooks clean

Part of #259 (Site Review Remediation)