### PR TITLE
fix: remove broken SWA linked backend; use direct API calls

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,6 +91,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-image
     environment: dev
+    outputs:
+      function_app_hostname: ${{ steps.hostname.outputs.hostname }}
     steps:
       - uses: actions/checkout@v4
 
@@ -193,6 +195,18 @@ jobs:
               CIAM_CLIENT_ID="$CIAM_CLIENT" \
               CIAM_AUDIENCE="$CIAM_CLIENT"
 
+      - name: Export Function App hostname
+        id: hostname
+        working-directory: infra/tofu
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_USE_OIDC: "true"
+        run: |
+          HOSTNAME=$(tofu output -raw function_app_default_hostname)
+          echo "hostname=${HOSTNAME}" >> "$GITHUB_OUTPUT"
+
       - name: Verify runtime readiness
         working-directory: infra/tofu
         env:
@@ -256,6 +270,12 @@ jobs:
     environment: dev
     steps:
       - uses: actions/checkout@v4
+
+      - name: Inject API config
+        run: |
+          cat > website/api-config.json <<EOF
+          {"apiBase": "https://${{ needs.deploy-infra.outputs.function_app_hostname }}"}
+          EOF
 
       - name: Deploy to Azure Static Web Apps
         uses: Azure/static-web-apps-deploy@v1

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -369,25 +369,11 @@ resource "azurerm_static_web_app" "main" {
   tags                = local.tags
 }
 
-# --- Linked backend: route /api/* through SWA to the Function App (#234) ---
-resource "azapi_resource" "swa_backend_link" {
-  type      = "Microsoft.Web/staticSites/linkedBackends@2024-04-01"
-  parent_id = azurerm_static_web_app.main.id
-  name      = "backend"
-
-  body = {
-    properties = {
-      backendResourceId = azapi_resource.function_app.id
-      region            = azurerm_resource_group.main.location
-    }
-  }
-
-  timeouts {
-    create = "60m"
-    update = "60m"
-    delete = "30m"
-  }
-}
+# --- Linked backend (disabled): the linkedBackends ARM API returns 500
+# for Function Apps on Container Apps (kind: azurecontainerapps).
+# See #282 — the frontend falls back to calling the Function App directly
+# via the hostname injected at deploy time in /api-config.json.
+# Re-enable if Azure adds Container Apps Function App support. ---
 
 # --- Custom domain (M1.5) ---
 # Prerequisites (manual, one-time):

--- a/website/api-config.json
+++ b/website/api-config.json
@@ -1,0 +1,1 @@
+{"apiBase": "http://localhost:7071"}

--- a/website/index.html
+++ b/website/index.html
@@ -856,11 +856,25 @@ footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;col
 
   /* --- API discovery: verify backend is reachable via SWA proxy --- */
   async function discoverApiBase() {
+    /* 1. Try SWA linked backend proxy (ideal — no CORS needed) */
     try {
       var res = await fetch('/api/health');
       if (res.ok) { apiBase = ''; return; }
     } catch { /* network error */ }
-    console.warn('Backend not reachable via /api — check SWA linked backend configuration');
+
+    /* 2. Load deploy-time config for direct Function App hostname (#282) */
+    try {
+      var cfgRes = await fetch('/api-config.json');
+      if (cfgRes.ok) {
+        var cfg = await cfgRes.json();
+        if (cfg.apiBase) {
+          var probe = await fetch(cfg.apiBase + '/api/health');
+          if (probe.ok) { apiBase = cfg.apiBase; return; }
+        }
+      }
+    } catch { /* config not available or backend unreachable */ }
+
+    console.warn('Backend not reachable — check SWA backend configuration or api-config.json');
   }
 
   /* --- Contract check (§12.3) --- */

--- a/website/staticwebapp.config.json
+++ b/website/staticwebapp.config.json
@@ -1,7 +1,7 @@
 {
   "navigationFallback": {
     "rewrite": "/index.html",
-    "exclude": ["/api/*", "/css/*", "/js/*", "/images/*", "/kml-guide.html", "/terms.html", "/privacy.html"]
+    "exclude": ["/api/*", "/api-config.json", "/css/*", "/js/*", "/images/*", "/kml-guide.html", "/terms.html", "/privacy.html"]
   },
   "routes": [
     {
@@ -20,6 +20,6 @@
     "Referrer-Policy": "strict-origin-when-cross-origin",
     "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
     "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
-    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://alcdn.msauth.net; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.basemaps.cartocdn.com https://planetarycomputer.microsoft.com https://server.arcgisonline.com; connect-src 'self' https://treesightauth.ciamlogin.com https://login.microsoftonline.com https://planetarycomputer.microsoft.com https://archive-api.open-meteo.com https://firms.modaps.eosdis.nasa.gov https://environment.data.gov.uk https://waterdata.usgs.gov https://api.open-meteo.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'"
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://alcdn.msauth.net; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://*.basemaps.cartocdn.com https://planetarycomputer.microsoft.com https://server.arcgisonline.com; connect-src 'self' https://*.azurecontainerapps.io https://treesightauth.ciamlogin.com https://login.microsoftonline.com https://planetarycomputer.microsoft.com https://archive-api.open-meteo.com https://firms.modaps.eosdis.nasa.gov https://environment.data.gov.uk https://waterdata.usgs.gov https://api.open-meteo.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'"
   }
 }


### PR DESCRIPTION
## Problem

The `linkedBackends` ARM API returns **HTTP 500** immediately for Function Apps hosted on Container Apps (`kind: functionapp,linux,container,azurecontainerapps`). The `azapi` provider masks this as a timeout — every deploy has failed for the last 3 runs, blocking all releases.

**Root cause**: Azure's SWA linked backend API doesn't support the hybrid `Microsoft.Web/sites` resource type used by Function Apps on Container Apps. Manual `az rest PUT` confirmed the 500 is instant, not a timeout.

## Solution

Replace the broken linked backend with deploy-time config injection:

1. **Remove `azapi_resource.swa_backend_link`** from Tofu (keeps SWA Standard for CIAM auth)
2. **Pipeline injects `api-config.json`** with the Function App hostname before SWA upload
3. **Frontend two-step discovery**: tries `/api/health` (SWA proxy) first, then falls back to reading `/api-config.json` for the direct Function App URL
4. **CSP updated** to allow `connect-src https://*.azurecontainerapps.io`

## Changes

| File | Change |
|------|--------|
| `infra/tofu/main.tf` | Removed `swa_backend_link` resource |
| `.github/workflows/deploy.yml` | Added hostname output, API config injection step |
| `website/index.html` | Two-step `discoverApiBase()` with fallback |
| `website/staticwebapp.config.json` | CSP + navigation exclude update |
| `website/api-config.json` | Local dev placeholder |

## Verification

- CORS already configured on Function App to allow SWA origin
- 445 tests passing
- Deploy should now complete in ~5 minutes (no 60m linked backend wait)

Fixes #282