### PR TITLE
security: SHA-pin all GitHub Actions + update setup-uv v4→v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
       - run: uv sync --all-extras
       - run: uv run ruff check .
       - run: uv run ruff format --check .
@@ -34,11 +34,11 @@ jobs:
       AzureWebJobsStorage: "UseDevelopmentStorage=true"
       DEMO_VALET_TOKEN_SECRET: "ci-test-secret"  # pragma: allowlist secret
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
       - run: uv sync --all-extras
       - run: uv run pytest tests/ -v -m "not integration" --tb=short --cov=treesight --cov-report=xml
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         if: always()
         with:
           name: coverage
@@ -50,6 +50,6 @@ jobs:
     needs: [lint, test]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Build image (smoke test)
         run: docker build -t treesight:ci-check .

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,18 +26,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@480db559a14342288b67e54bd959dd52dc3ee68f # v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@480db559a14342288b67e54bd959dd52dc3ee68f # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@480db559a14342288b67e54bd959dd52dc3ee68f # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,10 +44,10 @@ jobs:
     outputs:
       image_uri: ${{ steps.meta.outputs.image_uri }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -70,7 +70,7 @@ jobs:
           docker push "${IMAGE_NAME}:latest"
 
       - name: Trivy container scan
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ steps.meta.outputs.image_uri }}
           format: sarif
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload Trivy image SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@480db559a14342288b67e54bd959dd52dc3ee68f # v3
         with:
           sarif_file: trivy-image.sarif
           category: trivy-image
@@ -94,22 +94,22 @@ jobs:
     outputs:
       function_app_hostname: ${{ steps.hostname.outputs.hostname }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Azure Login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Setup OpenTofu
-        uses: opentofu/setup-opentofu@v1
+        uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
         with:
           tofu_version: ${{ env.TOFU_VERSION }}
 
       - name: Cache OpenTofu providers
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: infra/tofu/.terraform/providers
           key: tofu-providers-${{ hashFiles('infra/tofu/.terraform.lock.hcl') }}
@@ -269,7 +269,7 @@ jobs:
     needs: deploy-infra
     environment: dev
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Inject API config
         run: |
@@ -278,7 +278,7 @@ jobs:
           EOF
 
       - name: Deploy to Azure Static Web Apps
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.SWA_DEPLOYMENT_TOKEN }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,7 +30,7 @@ jobs:
     container:
       image: semgrep/semgrep
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Semgrep
         run: |
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload Semgrep SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@480db559a14342288b67e54bd959dd52dc3ee68f # v3
         with:
           sarif_file: semgrep.sarif
           category: semgrep
@@ -62,8 +62,8 @@ jobs:
     name: Dependency Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
       - name: Install dependencies
         run: uv sync --all-extras
@@ -126,7 +126,7 @@ jobs:
 
       - name: Upload pip-audit SARIF
         if: always() && hashFiles('pip-audit.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@480db559a14342288b67e54bd959dd52dc3ee68f # v3
         with:
           sarif_file: pip-audit.sarif
           category: pip-audit
@@ -136,10 +136,10 @@ jobs:
     name: Trivy IaC Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Trivy (IaC)
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: config
           scan-ref: infra/tofu
@@ -150,7 +150,7 @@ jobs:
 
       - name: Upload Trivy IaC SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@480db559a14342288b67e54bd959dd52dc3ee68f # v3
         with:
           sarif_file: trivy-iac.sarif
           category: trivy-iac
@@ -160,10 +160,10 @@ jobs:
     name: Trivy Filesystem Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Trivy (filesystem)
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs
           scan-ref: .
@@ -174,7 +174,7 @@ jobs:
 
       - name: Upload Trivy FS SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@480db559a14342288b67e54bd959dd52dc3ee68f # v3
         with:
           sarif_file: trivy-fs.sarif
           category: trivy-fs


### PR DESCRIPTION
## Summary

Pin every third-party GitHub Action reference to its verified commit SHA, hardening the CI/CD supply chain against tag-hijacking attacks like CVE-2026-33634.

## Changes

### SHA-pinning (all workflows)
Every `uses:` line now references the immutable commit SHA with the version tag retained as a comment:
```yaml
- uses: actions/checkout@de0fac2e...ce83dd # v6
```

### Version updates
- **`astral-sh/setup-uv`**: v4 → **v7**
  - v5: free caching on GitHub-hosted runners by default
  - v6: `activate-environment` / `working-directory` inputs (we don't use these)
  - v7: node24 runtime, bug fixes
  - Breaking changes reviewed — none affect our zero-input usage
- **`aquasecurity/trivy-action`**: stays at v0.35.0 (latest release, known-safe immutable tag per CVE-2026-33634 analysis)
- All other actions: already on latest major, pinned to current SHA

### SHA mapping (verified via `git ls-remote`)

| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v6 | `de0fac2e` |
| `astral-sh/setup-uv` | **v7** | `94527f2e` |
| `actions/upload-artifact` | v5 | `330a01c4` |
| `actions/cache` | v5 | `66822842` |
| `github/codeql-action/*` | v3 | `480db559` |
| `aquasecurity/trivy-action` | v0.35.0 | `57a97c7e` |
| `docker/login-action` | v3 | `c94ce9fb` |
| `azure/login` | v2 | `1384c340` |
| `opentofu/setup-opentofu` | v1 | `9d84900f` |
| `Azure/static-web-apps-deploy` | v1 | `1a947af9` |

## Files changed
- `.github/workflows/ci.yml`
- `.github/workflows/deploy.yml`
- `.github/workflows/security.yml`
- `.github/workflows/codeql.yml`

## Testing
- actionlint: passed
- All pre-commit hooks: passed
- CI will validate workflows execute correctly with pinned refs

Fixes #286