### PR TITLE
fix: add CORS headers to health/readiness/contract endpoints

### DIFF
--- a/blueprints/health.py
+++ b/blueprints/health.py
@@ -10,31 +10,42 @@ import azure.functions as func
 
 from treesight.constants import API_CONTRACT_VERSION
 
+from ._helpers import cors_headers, cors_preflight
+
 bp = func.Blueprint()
 
 
-@bp.route(route="health", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
+@bp.route(route="health", methods=["GET", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
 def health(req: func.HttpRequest) -> func.HttpResponse:
+    if req.method == "OPTIONS":
+        return cors_preflight(req)
     return func.HttpResponse(
         json.dumps({"status": "healthy"}),
         status_code=200,
         mimetype="application/json",
+        headers=cors_headers(req),
     )
 
 
-@bp.route(route="readiness", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
+@bp.route(route="readiness", methods=["GET", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
 def readiness(req: func.HttpRequest) -> func.HttpResponse:
+    if req.method == "OPTIONS":
+        return cors_preflight(req)
     return func.HttpResponse(
         json.dumps({"status": "ready", "api_version": API_CONTRACT_VERSION}),
         status_code=200,
         mimetype="application/json",
+        headers=cors_headers(req),
     )
 
 
-@bp.route(route="contract", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
+@bp.route(route="contract", methods=["GET", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
 def contract(req: func.HttpRequest) -> func.HttpResponse:
+    if req.method == "OPTIONS":
+        return cors_preflight(req)
     return func.HttpResponse(
         json.dumps({"api_version": API_CONTRACT_VERSION}),
         status_code=200,
         mimetype="application/json",
+        headers=cors_headers(req),
     )


### PR DESCRIPTION
## Problem

The health, readiness, and contract endpoints return no CORS headers. When the frontend falls back to cross-origin API calls (via `api-config.json`), the browser blocks reading the response → `discoverApiBase()` fails → `apiBase` stays empty → status badge shows **"Offline"**.

This happens because the SWA backend proxy (`/api/*`) isn't linked, so the frontend's `discoverApiBase()` tries to directly reach the Function App cross-origin.

## Fix

Add `cors_headers()` and `OPTIONS` preflight handling to health, readiness, and contract endpoints — consistent with all other API endpoints that already use these helpers.

Fixes #291