### PR TITLE
fix: security hardening for authenticated surface

### DIFF
--- a/blueprints/_helpers.py
+++ b/blueprints/_helpers.py
@@ -62,6 +62,7 @@ def cors_headers(req: func.HttpRequest) -> dict[str, str]:
         "Access-Control-Allow-Origin": origin,
         "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
         "Access-Control-Allow-Headers": "Content-Type, Authorization",
+        "Access-Control-Max-Age": "7200",
     }
 
 

--- a/blueprints/contact.py
+++ b/blueprints/contact.py
@@ -49,7 +49,7 @@ def contact_form(req: func.HttpRequest) -> func.HttpResponse:
         "use_case": use_case,
         "submitted_at": datetime.now(UTC).isoformat(),
         "source": "marketing_website",
-        "ip_forwarded_for": req.headers.get("X-Forwarded-For", ""),
+        "ip_forwarded_for": get_client_ip(req),
     }
 
     storage = BlobStorageClient()

--- a/blueprints/demo.py
+++ b/blueprints/demo.py
@@ -41,7 +41,7 @@ bp = func.Blueprint()
 @bp.route(route="demo-submit", methods=["POST", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
 def demo_submit(req: func.HttpRequest) -> func.HttpResponse:
     if req.method == "OPTIONS":
-        return func.HttpResponse(status_code=204)
+        return cors_preflight(req)
 
     try:
         _claims, user_id = check_auth(req)
@@ -105,6 +105,7 @@ def demo_submit(req: func.HttpRequest) -> func.HttpResponse:
         json.dumps({"status": "submitted", "submission_id": submission_id}),
         status_code=200,
         mimetype="application/json",
+        headers=cors_headers(req),
     )
 
 
@@ -256,10 +257,19 @@ def cors_proxy(req: func.HttpRequest) -> func.HttpResponse:
             return error_response(502, "Upstream response too large", req=req)
         hdrs = cors_headers(req)
         hdrs["Cache-Control"] = "max-age=3600"
+        # Force safe content-type — never reflect upstream HTML/JS directly
+        upstream_ct = resp.headers.get("Content-Type", "application/json")
+        safe_ct = (
+            upstream_ct
+            if upstream_ct.startswith(
+                ("application/json", "text/plain", "text/csv", "application/geo")
+            )
+            else "application/octet-stream"
+        )
         return func.HttpResponse(
             body,
             status_code=resp.status_code,
-            mimetype=resp.headers.get("Content-Type", "application/json"),
+            mimetype=safe_ct,
             headers=hdrs,
         )
     except requests.Timeout:

--- a/blueprints/export.py
+++ b/blueprints/export.py
@@ -33,7 +33,7 @@ async def _fetch_manifest(
 ) -> tuple[dict[str, Any] | None, func.HttpResponse | None]:
     """Return (manifest_dict, None) on success or (None, error_response) on failure."""
     try:
-        check_auth(req)
+        _claims, user_id = check_auth(req)
     except ValueError as exc:
         return None, error_response(401, str(exc), req=req)
 
@@ -43,6 +43,12 @@ async def _fetch_manifest(
 
     status = await client.get_status(instance_id)
     if not status or not status.output:
+        return None, error_response(404, "Pipeline not found or not complete", req=req)
+
+    # Ownership check: verify calling user owns this pipeline instance
+    input_data = status.input if isinstance(status.input, dict) else {}
+    owner = input_data.get("user_id", "")
+    if owner and user_id != "anonymous" and owner != user_id:
         return None, error_response(404, "Pipeline not found or not complete", req=req)
 
     output = status.output if isinstance(status.output, dict) else {}

--- a/blueprints/pipeline.py
+++ b/blueprints/pipeline.py
@@ -67,7 +67,7 @@ async def orchestrator_status(
         return cors_preflight(req)
 
     try:
-        check_auth(req)
+        _claims, user_id = check_auth(req)
     except ValueError as exc:
         return _error_response(401, str(exc))
 
@@ -84,6 +84,14 @@ async def orchestrator_status(
 
     status = await client.get_status(instance_id)
     if not status:
+        return func.HttpResponse(
+            json.dumps({"error": "not found"}), status_code=404, mimetype="application/json"
+        )
+
+    # Ownership check: verify calling user owns this pipeline instance
+    input_data = status.input if isinstance(status.input, dict) else {}
+    owner = input_data.get("user_id", "")
+    if owner and user_id != "anonymous" and owner != user_id:
         return func.HttpResponse(
             json.dumps({"error": "not found"}), status_code=404, mimetype="application/json"
         )
@@ -868,6 +876,7 @@ async def demo_process(
         "correlation_id": submission_id,
         "composite_search": True,
         "provider_name": "planetary_computer",
+        "user_id": user_id,
     }
 
     await client.start_new(
@@ -881,6 +890,7 @@ async def demo_process(
         json.dumps({"instance_id": submission_id}),
         status_code=202,
         mimetype="application/json",
+        headers=cors_headers(req),
     )
 
 

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -325,6 +325,14 @@ resource "azapi_resource" "function_app" {
           {
             name  = "IMAGERY_PROVIDER"
             value = "planetary_computer"
+          },
+          {
+            name  = "REQUIRE_AUTH"
+            value = "true"
+          },
+          {
+            name  = "DEMO_VALET_TOKEN_SECRET"
+            value = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault.main.vault_uri}secrets/demo-valet-token-secret)"
           }
         ], var.enable_azure_ai ? [
           {

--- a/tests/test_quota.py
+++ b/tests/test_quota.py
@@ -11,18 +11,41 @@ from treesight.security.quota import FREE_TIER_LIMIT, check_quota, consume_quota
 def _mock_storage():
     """Patch BlobStorageClient so quota tests never hit real storage."""
     store: dict[str, dict] = {}
+    etags: dict[str, str] = {}
+    _etag_counter = [0]
     mock_cls = MagicMock()
+
+    def _next_etag() -> str:
+        _etag_counter[0] += 1
+        return f"etag-{_etag_counter[0]}"
 
     def _download_json(_container, path):
         if path not in store:
             raise FileNotFoundError(path)
         return store[path]
 
+    def _download_json_with_etag(_container, path):
+        if path not in store:
+            raise FileNotFoundError(path)
+        return store[path], etags.get(path, "etag-0")
+
     def _upload_json(_container, path, data):
         store[path] = data
+        etags[path] = _next_etag()
+
+    def _upload_json_if_match(_container, path, data, etag):
+        current_etag = etags.get(path)
+        if current_etag and current_etag != etag:
+            from azure.core.exceptions import ResourceModifiedError
+
+            raise ResourceModifiedError("ETag mismatch")
+        store[path] = data
+        etags[path] = _next_etag()
 
     mock_cls.return_value.download_json = _download_json
+    mock_cls.return_value.download_json_with_etag = _download_json_with_etag
     mock_cls.return_value.upload_json = _upload_json
+    mock_cls.return_value.upload_json_if_match = _upload_json_if_match
 
     with patch("treesight.storage.client.BlobStorageClient", mock_cls):
         yield store

--- a/treesight/security/auth.py
+++ b/treesight/security/auth.py
@@ -1,6 +1,7 @@
 """Entra External ID (CIAM) JWT validation for API endpoints."""
 
 import logging
+import re
 import threading
 import time
 from typing import Any
@@ -15,7 +16,7 @@ logger = logging.getLogger(__name__)
 # JWKS cache: thread-safe, refreshes every 24 hours
 _jwks_cache: dict[str, Any] = {}
 _jwks_lock = threading.Lock()
-_JWKS_TTL = 86400  # 24 hours
+_JWKS_TTL = 21600  # 6 hours
 
 
 def _oidc_config_url() -> str:
@@ -149,6 +150,16 @@ def validate_token(auth_header: str) -> dict[str, Any]:
     return claims
 
 
+#: Safe pattern for user identifiers (CIAM sub / oid values).
+_USER_ID_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
+
+
 def get_user_id(claims: dict[str, Any]) -> str:
-    """Extract the user identifier (subject) from validated claims."""
-    return claims.get("sub", claims.get("oid", ""))
+    """Extract and validate the user identifier from claims.
+
+    Raises ``ValueError`` if the identifier contains unexpected characters.
+    """
+    uid = claims.get("sub", claims.get("oid", ""))
+    if uid and not _USER_ID_RE.match(uid):
+        raise ValueError("Invalid user identifier format")
+    return uid

--- a/treesight/security/quota.py
+++ b/treesight/security/quota.py
@@ -7,7 +7,6 @@ a JSON blob ``quotas/{user_id}.json`` inside the pipeline-payloads container.
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from treesight.constants import PIPELINE_PAYLOADS_CONTAINER
 
@@ -42,27 +41,49 @@ def check_quota(user_id: str) -> int:
 def consume_quota(user_id: str) -> int:
     """Increment usage and return remaining runs (after this one).
 
+    Uses ETag-based optimistic concurrency to prevent TOCTOU races.
     Raises ``ValueError`` if the user has exhausted their free quota.
     """
+    from azure.core.exceptions import ResourceModifiedError
+
     from treesight.storage.client import BlobStorageClient
 
     storage = BlobStorageClient()
     path = _blob_path(user_id)
 
-    try:
-        record: dict[str, Any] = storage.download_json(PIPELINE_PAYLOADS_CONTAINER, path)
-    except Exception:
-        record = {"used": 0, "runs": []}
+    max_retries = 3
+    for attempt in range(max_retries):
+        etag: str | None = None
+        try:
+            record, etag = storage.download_json_with_etag(PIPELINE_PAYLOADS_CONTAINER, path)
+        except Exception:
+            record = {"used": 0, "runs": []}
 
-    used: int = record.get("used", 0)
-    if used >= FREE_TIER_LIMIT:
-        raise ValueError(
-            f"Free quota exhausted ({FREE_TIER_LIMIT} pipeline runs). Please upgrade to continue."
+        used: int = record.get("used", 0)
+        if used >= FREE_TIER_LIMIT:
+            raise ValueError(
+                f"Free quota exhausted ({FREE_TIER_LIMIT} runs). Please upgrade to continue."
+            )
+
+        record["used"] = used + 1
+        record.setdefault("runs", [])
+
+        if etag:
+            try:
+                storage.upload_json_if_match(PIPELINE_PAYLOADS_CONTAINER, path, record, etag)
+            except ResourceModifiedError:
+                if attempt < max_retries - 1:
+                    logger.warning("Quota update conflict for user=%s, retrying", user_id)
+                    continue
+                raise ValueError("Quota update conflict — please retry") from None
+        else:
+            # New record — no ETag to match
+            storage.upload_json(PIPELINE_PAYLOADS_CONTAINER, path, record)
+
+        remaining = FREE_TIER_LIMIT - record["used"]
+        logger.info(
+            "Quota consumed user=%s used=%d remaining=%d", user_id, record["used"], remaining
         )
+        return remaining
 
-    record["used"] = used + 1
-    record.setdefault("runs", [])
-    storage.upload_json(PIPELINE_PAYLOADS_CONTAINER, path, record)
-    remaining = FREE_TIER_LIMIT - record["used"]
-    logger.info("Quota consumed user=%s used=%d remaining=%d", user_id, record["used"], remaining)
-    return remaining
+    raise ValueError("Quota update failed — please retry")

--- a/treesight/storage/client.py
+++ b/treesight/storage/client.py
@@ -106,3 +106,45 @@ class BlobStorageClient:
         """Return a ``StorageStreamDownloader`` for streaming responses."""
         blob = self._client.get_blob_client(container, blob_path)
         return blob.download_blob()
+
+    # --- ETag-aware operations for optimistic concurrency ---
+
+    def download_json_with_etag(self, container: str, blob_path: str) -> tuple[dict[str, Any], str]:
+        """Download a JSON blob and return ``(data, etag)``."""
+        import json
+
+        blob = self._client.get_blob_client(container, blob_path)
+        dl = blob.download_blob()
+        raw = json.loads(dl.readall())
+        etag = dl.properties.etag
+        if not isinstance(raw, dict):
+            msg = f"Expected JSON object in {container}/{blob_path}, got {type(raw).__name__}"
+            raise TypeError(msg)
+        return cast(dict[str, Any], raw), etag
+
+    def upload_json_if_match(
+        self, container: str, blob_path: str, data: dict[str, Any], etag: str
+    ) -> None:
+        """Upload JSON only if the blob's current ETag matches *etag*.
+
+        Raises ``azure.core.exceptions.ResourceModifiedError`` on conflict.
+        """
+        import json
+
+        from azure.core import MatchConditions
+        from azure.core.exceptions import ResourceModifiedError
+        from azure.storage.blob import BlobClient
+
+        payload = json.dumps(data, indent=2, default=str).encode("utf-8")
+        self.ensure_container(container)
+        blob: BlobClient = self._client.get_blob_client(container, blob_path)
+        try:
+            blob.upload_blob(
+                payload,
+                overwrite=True,
+                etag=etag,
+                match_condition=MatchConditions.IfNotModified,
+                content_settings=ContentSettings(content_type="application/json"),
+            )
+        except ResourceModifiedError:
+            raise


### PR DESCRIPTION
## Closing — rebase needed after #309\n\nThe 4-file overlap with #309 (contact.py, export.py, pipeline.py, main.tf) makes this unmergeable without a rebase. The unique security fixes here (quota TOCTOU race, user_id format validation, CORS on demo endpoints) should be re-applied in a fresh PR after #309 merges to main.\n\nTracking fixes:\n- Quota TOCTOU race condition (ETag optimistic concurrency)\n- user_id format validation (`^[a-zA-Z0-9._-]+$`)\n- CORS proxy content-type forcing\n- Contact form log injection fix\n- JWKS cache TTL reduction\n- Demo endpoint CORS headers