### PR TITLE
feat(ux): first-run empty state, evidence export bar, demo conversion prompt

### DIFF
--- a/tests/test_frontend_config.py
+++ b/tests/test_frontend_config.py
@@ -16,7 +16,9 @@ import pytest
 
 WEBSITE = Path(__file__).resolve().parent.parent / "website"
 INDEX_HTML = WEBSITE / "index.html"
+APP_SHELL_HTML = WEBSITE / "app" / "index.html"
 APP_JS = WEBSITE / "js" / "app.js"
+APP_SHELL_JS = WEBSITE / "js" / "app-shell.js"
 MSAL_BUNDLE = WEBSITE / "js" / "msal-browser.min.js"
 SWA_CONFIG = WEBSITE / "staticwebapp.config.json"
 API_CONFIG = WEBSITE / "api-config.json"
@@ -31,6 +33,16 @@ def index_html():
 @pytest.fixture()
 def app_js():
     return APP_JS.read_text()
+
+
+@pytest.fixture()
+def app_shell_html():
+    return APP_SHELL_HTML.read_text()
+
+
+@pytest.fixture()
+def app_shell_js():
+    return APP_SHELL_JS.read_text()
 
 
 @pytest.fixture()
@@ -136,6 +148,195 @@ class TestAuthConfig:
         assert match, "CIAM_CLIENT_ID not found in app.js"
         assert len(match.group(1)) > 10, "CIAM_CLIENT_ID looks too short"
 
+    def test_ciam_authority_includes_tenant_path(self, app_js):
+        """MSAL authority must point at the tenant-qualified CIAM path.
+
+        Pointing MSAL at the bare ciamlogin.com root breaks OIDC discovery and
+        can produce tokens that do not align with backend issuer validation.
+        """
+        assert ".ciamlogin.com/' + CIAM_TENANT_DOMAIN + '/'" in app_js, (
+            "CIAM authority must include the tenant .onmicrosoft.com path"
+        )
+
+    def test_known_authority_uses_hostname_only(self, app_js):
+        """MSAL knownAuthorities must list the CIAM hostname, not the full authority URL."""
+        assert "const CIAM_KNOWN_AUTHORITY = CIAM_TENANT_NAME" in app_js
+        assert "? CIAM_TENANT_NAME + '.ciamlogin.com'" in app_js, (
+            "knownAuthorities must use the CIAM host name only"
+        )
+
+
+class TestSignInPrompt:
+    def test_login_prompt_has_no_replacement_character(self, index_html):
+        """The homepage sign-in CTA should not render with a broken replacement glyph."""
+        assert "�" not in index_html, (
+            "index.html still contains a broken replacement glyph in the sign-in prompt"
+        )
+
+    def test_login_prompt_uses_button_control(self, index_html):
+        """The inline sign-in CTA should be a real button so it is keyboard accessible."""
+        assert (
+            '<button type="button" class="login-prompt-link" id="login-prompt-link">' in index_html
+        )
+
+    def test_public_demo_limits_are_explicit(self, index_html):
+        assert "Public Demo Limits" in index_html
+        assert "Max 3 AOIs per run" in index_html
+        assert "Max 10,000 hectares per AOI" in index_html
+
+    def test_demo_ai_button_starts_disabled(self, index_html):
+        assert 'id="btn-get-ai-insights"' in index_html
+        assert "AI Analysis Available on Paid Plans" in index_html
+        assert 'disabled aria-disabled="true"' in index_html
+
+
+class TestSignedInAppShell:
+    def test_app_shell_exists(self):
+        assert APP_SHELL_HTML.exists(), "website/app/index.html is missing"
+        assert APP_SHELL_JS.exists(), "website/js/app-shell.js is missing"
+
+    def test_app_shell_loads_local_msal(self, app_shell_html):
+        assert "/js/msal-browser.min.js" in app_shell_html
+
+    def test_root_login_sets_post_login_app_redirect(self, app_js):
+        assert "const APP_HOME_PATH = '/app/';" in app_js
+        assert "const POST_LOGIN_DESTINATION_KEY = 'treesight-post-login';" in app_js
+        assert "window.location.replace(APP_HOME_PATH);" in app_js
+        assert "function ciamRedirectOrigin()" in app_js
+        assert "function localLoginTransitionUrl()" in app_js
+        assert "function consumeLocalLoginRequest()" in app_js
+        assert (
+            "return runningOnLocalDevOrigin() ? 'http://localhost:4280' : window.location.origin;"
+            in app_js
+        )
+        assert "window.location.replace(localLoginTransitionUrl());" in app_js
+
+    def test_frontend_prefers_id_token_for_identity_only_api_calls(self, app_js, app_shell_js):
+        assert (
+            "const IDENTITY_ONLY_SCOPES = ['openid', 'profile', 'email', 'offline_access'];"
+            in app_js
+        )
+        assert (
+            "const IDENTITY_ONLY_SCOPES = ['openid', 'profile', 'email', 'offline_access'];"
+            in app_shell_js
+        )
+        assert "function selectApiBearerToken(resp)" in app_js
+        assert "function selectApiBearerToken(resp)" in app_shell_js
+        assert "00000003-0000-0000-c000-000000000000" in app_js
+        assert "00000003-0000-0000-c000-000000000000" in app_shell_js
+
+    def test_app_shell_uses_same_post_login_redirect_contract(self, app_shell_js):
+        assert "const POST_LOGIN_DESTINATION_KEY = 'treesight-post-login';" in app_shell_js
+        assert "sessionStorage.setItem(POST_LOGIN_DESTINATION_KEY, 'app')" in app_shell_js
+        assert "function ciamRedirectOrigin()" in app_shell_js
+        assert "function localLoginTransitionUrl()" in app_shell_js
+        assert "function consumeLocalLoginRequest()" in app_shell_js
+        assert (
+            "return runningOnLocalDevOrigin() ? 'http://localhost:4280' : window.location.origin;"
+            in app_shell_js
+        )
+        assert "window.location.replace(localLoginTransitionUrl());" in app_shell_js
+
+    def test_app_shell_contains_tier_emulation_controls(self, app_shell_html):
+        assert 'id="app-tier-emulation-card"' in app_shell_html
+        assert 'id="app-tier-emulation-select"' in app_shell_html
+        assert 'id="app-apply-tier-emulation-btn"' in app_shell_html
+
+    def test_app_shell_contains_signed_in_analysis_launcher(self, app_shell_html):
+        assert 'id="app-workflow-stage"' in app_shell_html
+        assert 'data-focus="run"' in app_shell_html
+        assert 'id="app-role-switcher"' in app_shell_html
+        assert 'data-role-choice="conservation"' in app_shell_html
+        assert 'data-role-choice="eudr"' in app_shell_html
+        assert 'data-role-choice="portfolio"' in app_shell_html
+        assert 'id="app-preference-switcher"' in app_shell_html
+        assert 'data-preference-choice="investigate"' in app_shell_html
+        assert 'data-preference-choice="monitor"' in app_shell_html
+        assert 'data-preference-choice="report"' in app_shell_html
+        assert 'id="app-guided-primary-btn"' in app_shell_html
+        assert 'id="app-guided-secondary-btn"' in app_shell_html
+        assert 'data-focus-target="history"' in app_shell_html
+        assert 'data-focus-target="content"' in app_shell_html
+        assert 'id="app-history-card"' in app_shell_html
+        assert 'id="app-analysis-card"' in app_shell_html
+        assert 'id="app-content-card"' in app_shell_html
+        assert 'id="app-history-list"' in app_shell_html
+        assert 'id="app-analysis-file"' in app_shell_html
+        assert 'id="app-analysis-kml"' in app_shell_html
+        assert 'id="app-analysis-lens-title"' in app_shell_html
+        assert 'id="app-analysis-preflight"' in app_shell_html
+        assert 'id="app-preflight-headline"' in app_shell_html
+        assert 'id="app-preflight-features"' in app_shell_html
+        assert 'id="app-preflight-aois"' in app_shell_html
+        assert 'id="app-preflight-spread"' in app_shell_html
+        assert 'id="app-preflight-quota"' in app_shell_html
+        assert 'id="app-analysis-submit-btn"' in app_shell_html
+        assert 'id="app-analysis-status"' in app_shell_html
+        assert 'id="app-analysis-progress"' in app_shell_html
+        assert 'id="app-run-detail-grid"' in app_shell_html
+        assert 'id="app-run-submitted"' in app_shell_html
+        assert 'id="app-run-scope"' in app_shell_html
+        assert 'id="app-run-delivery"' in app_shell_html
+        assert 'id="app-run-link"' in app_shell_html
+        assert 'id="app-run-export-geojson"' in app_shell_html
+        assert 'id="app-run-export-csv"' in app_shell_html
+        assert 'id="app-run-export-pdf"' in app_shell_html
+        assert 'id="app-hero-plan"' in app_shell_html
+        assert 'id="app-hero-active-run"' in app_shell_html
+        assert 'id="app-history-latest-status"' in app_shell_html
+        assert 'id="app-content-imagery"' in app_shell_html
+        assert 'id="app-evidence-surface"' in app_shell_html
+        assert 'id="app-evidence-map"' in app_shell_html
+        assert 'id="app-evidence-ndvi-grid"' in app_shell_html
+        assert 'id="app-evidence-weather-grid"' in app_shell_html
+        assert 'id="app-evidence-ai-btn"' in app_shell_html
+        assert 'id="app-evidence-eudr-btn"' in app_shell_html
+        assert 'data-phase="acquisition"' in app_shell_html
+        assert 'data-phase="enrichment"' in app_shell_html
+
+    def test_app_shell_calls_billing_emulation_endpoint(self, app_shell_js):
+        assert "/api/billing/emulation" in app_shell_js
+
+    def test_app_shell_calls_production_named_analysis_endpoint(self, app_shell_js):
+        assert "/api/analysis/submit" in app_shell_js
+        assert "/api/analysis/history" in app_shell_js
+        assert "/api/export/" in app_shell_js
+        assert "function runningOnLocalDevOrigin()" in app_shell_js
+        assert "window.location.hostname === '127.0.0.1'" in app_shell_js
+        assert "pollAnalysisRun" in app_shell_js
+        assert "loadAnalysisHistory" in app_shell_js
+        assert "selectAnalysisRun" in app_shell_js
+        assert "selectedRunPermalink" in app_shell_js
+        assert "downloadRunExport" in app_shell_js
+        assert "updateRunDetail" in app_shell_js
+        assert "renderAnalysisHistoryList" in app_shell_js
+        assert "ANALYSIS_PHASE_DETAILS" in app_shell_js
+        assert "const WORKSPACE_ROLES = {" in app_shell_js
+        assert "const WORKSPACE_PREFERENCES = {" in app_shell_js
+        assert "setAnalysisStep" in app_shell_js
+        assert "updateHeroSummary" in app_shell_js
+        assert "setHeroRunSummary" in app_shell_js
+        assert "setWorkflowFocus" in app_shell_js
+        assert "function setWorkspaceRole" in app_shell_js
+        assert "function setWorkspacePreference" in app_shell_js
+        assert "function buildAnalysisPreflight" in app_shell_js
+        assert "function updateAnalysisPreflight" in app_shell_js
+        assert "updateHistorySummary" in app_shell_js
+        assert "updateContentSummary" in app_shell_js
+        assert "loadRunEvidence" in app_shell_js
+        assert "/api/timelapse-data/" in app_shell_js
+        assert "/api/timelapse-analysis-load/" in app_shell_js
+        assert "/api/timelapse-analysis" in app_shell_js
+        assert "/api/eudr-assessment" in app_shell_js
+        assert "renderEvidenceAnalysis" in app_shell_js
+        assert "initEvidenceMap" in app_shell_js
+
+    def test_swa_rewrites_app_route(self, swa_config):
+        assert any(
+            route.get("route") == "/app" and route.get("rewrite") == "/app/index.html"
+            for route in swa_config["routes"]
+        ), "staticwebapp.config.json must rewrite /app to the app shell"
+
 
 # ---------------------------------------------------------------------------
 # CORS — backend must include all frontend origins
@@ -152,3 +353,98 @@ class TestCorsConfig:
         """The custom domain must be in _ALLOWED_ORIGINS."""
         src = HELPERS_PY.read_text()
         assert "treesight.hrdcrprwn.com" in src
+
+
+class TestFirstRunEmptyState:
+    """#323 — First-time empty state must surface onboarding instead of a
+    blank evidence hero and empty history list."""
+
+    def test_first_run_hero_exists_in_html(self, app_shell_html):
+        assert 'id="app-first-run-hero"' in app_shell_html
+
+    def test_first_run_hero_hidden_by_default(self, app_shell_html):
+        assert 'id="app-first-run-hero"' in app_shell_html
+        # It should be hidden initially (shown only when history is empty)
+        assert (
+            "hidden" in app_shell_html.split('id="app-first-run-hero"')[0].rsplit("<", 1)[-1]
+            or "hidden" in app_shell_html.split('id="app-first-run-hero"')[1].split(">")[0]
+        )
+
+    def test_first_run_hero_contains_kml_guide_link(self, app_shell_html):
+        # The first-run hero should link to the KML guide for onboarding
+        idx = app_shell_html.index('id="app-first-run-hero"')
+        # Find the closing tag of this section
+        section = app_shell_html[idx : idx + 2000]
+        assert "/kml-guide.html" in section
+
+    def test_first_run_hero_contains_cta_button(self, app_shell_html):
+        idx = app_shell_html.index('id="app-first-run-hero"')
+        section = app_shell_html[idx : idx + 2000]
+        assert 'id="app-first-run-cta"' in section
+
+    def test_js_toggles_first_run_layout(self, app_shell_js):
+        assert "applyFirstRunLayout" in app_shell_js
+
+
+class TestEvidenceExportBar:
+    """#324 — Export bar promoted into the evidence hero so completed-run
+    exports are always one click away."""
+
+    def test_evidence_export_bar_exists(self, app_shell_html):
+        assert 'id="app-evidence-export-bar"' in app_shell_html
+
+    def test_evidence_export_bar_inside_evidence_surface(self, app_shell_html):
+        surface_idx = app_shell_html.index('id="app-evidence-surface"')
+        bar_idx = app_shell_html.index('id="app-evidence-export-bar"')
+        assert bar_idx > surface_idx, "Export bar must be inside the evidence surface"
+
+    def test_evidence_export_bar_has_format_buttons(self, app_shell_html):
+        idx = app_shell_html.index('id="app-evidence-export-bar"')
+        section = app_shell_html[idx : idx + 1000]
+        assert 'data-export-format="geojson"' in section
+        assert 'data-export-format="csv"' in section
+        assert 'data-export-format="pdf"' in section
+
+
+class TestDemoConversionPrompt:
+    """#325 — Post-demo conversion prompt shown after demo timelapse finishes."""
+
+    def test_demo_upsell_exists(self, index_html):
+        assert 'id="demo-conversion-prompt"' in index_html
+
+    def test_demo_upsell_hidden_by_default(self, index_html):
+        idx = index_html.index('id="demo-conversion-prompt"')
+        tag = index_html[:idx].rsplit("<", 1)[-1] + index_html[idx : idx + 200].split(">")[0]
+        assert "hidden" in tag
+
+    def test_demo_upsell_links_to_pricing(self, index_html):
+        idx = index_html.index('id="demo-conversion-prompt"')
+        section = index_html[idx : idx + 1500]
+        assert "#pricing" in section
+
+    def test_demo_upsell_has_dismiss(self, index_html):
+        idx = index_html.index('id="demo-conversion-prompt"')
+        section = index_html[idx : idx + 1500]
+        assert 'id="demo-conversion-dismiss"' in section
+
+    def test_js_shows_conversion_prompt_after_timelapse(self, app_js):
+        assert "demo-conversion-prompt" in app_js
+
+
+class TestDemoBoundaries:
+    def test_demo_js_has_explicit_polygon_cap(self, app_js):
+        assert "const DEMO_MAX_POLYGONS = 3;" in app_js
+        assert "checkDemoBounds(polygons)" in app_js
+
+    def test_demo_js_has_explicit_area_cap(self, app_js):
+        assert "const DEMO_MAX_AREA_HA = 10000;" in app_js
+        assert "function polygonAreaHa(coords)" in app_js
+
+    def test_demo_js_gates_ai_by_plan_capabilities(self, app_js):
+        assert "function updateDemoAiControls(data)" in app_js
+        assert "data.capabilities.ai_insights" in app_js
+
+    def test_demo_js_prefers_same_origin_proxy_for_local_dev(self, app_js):
+        assert "function runningOnLocalDevOrigin()" in app_js
+        assert "window.location.hostname === '127.0.0.1'" in app_js
+        assert "var localRes = await fetch('/api/health');" in app_js

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -1,0 +1,452 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TreeSight App — Dashboard</title>
+<meta name="description" content="TreeSight signed-in workspace for analyses, usage, and billing.">
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha384-sHL9NAb7lN7rfvG5lfHpm643Xkcjzp4jFvuavGOndn6pjVqS6ny56CAt3nsEVT4H" crossorigin="anonymous"> <!-- pragma: allowlist secret -->
+<link rel="stylesheet" href="/css/shared.css">
+<link rel="stylesheet" href="/css/app.css">
+<meta name="ai-connection-string" content="">
+<script src="/js/analytics.js" defer></script>
+<script src="/js/msal-browser.min.js" defer></script>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha384-cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HTH" crossorigin="anonymous"></script> <!-- pragma: allowlist secret -->
+<script src="/js/app-shell.js" defer></script>
+</head>
+<body>
+<noscript><div class="noscript-banner">TreeSight requires JavaScript to function. Please enable JavaScript in your browser.</div></noscript>
+
+<nav>
+  <div class="container">
+    <a href="/app/" class="logo">
+      <svg viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/></svg>
+      TreeSight App
+    </a>
+    <ul>
+      <li><a href="/app/" aria-current="page">Dashboard</a></li>
+      <li><a href="/#pricing">Pricing</a></li>
+      <li><a href="/kml-guide.html">KML Guide</a></li>
+      <li><a href="/">Marketing Site</a></li>
+    </ul>
+    <div class="auth-area" id="auth-area">
+      <span id="status-badge">Checking…</span>
+      <span class="auth-user" id="auth-user" style="display:none"></span>
+      <button class="auth-btn primary" id="auth-login-btn">Sign In</button>
+      <button class="auth-btn logout" id="auth-logout-btn" style="display:none">Sign Out</button>
+    </div>
+  </div>
+</nav>
+
+<main class="app-main">
+  <section id="app-unauthenticated" class="app-gate">
+    <div class="container">
+      <div class="app-panel">
+        <h2>Sign in to access your workspace</h2>
+        <p>Use your TreeSight identity to view usage, billing, and run history as the dashboard rolls out.</p>
+        <div class="app-gate-actions">
+          <button class="btn btn-primary" id="app-sign-in-btn" type="button">Sign In</button>
+          <a class="btn btn-secondary" href="/">Back to site</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="app-dashboard" class="app-dashboard" hidden>
+    <div class="container">
+
+      <!-- ── Compact welcome bar ── -->
+      <div class="app-welcome-bar">
+        <div class="app-welcome-identity">
+          <h2>Welcome back, <span id="app-user-name">there</span></h2>
+          <p id="app-account-note" class="app-welcome-note">Signed-in workspace</p>
+        </div>
+        <div class="app-welcome-stats">
+          <div class="app-stat-pill"><span class="app-utility-label">Plan</span><strong id="app-hero-plan">Loading…</strong><span class="app-utility-note" id="app-hero-plan-note">Checking entitlement…</span></div>
+          <div class="app-stat-pill"><span class="app-utility-label">Runs Left</span><strong id="app-hero-runs">—</strong><span class="app-utility-note" id="app-hero-runs-note">Quota refreshes with your plan.</span></div>
+          <div class="app-stat-pill"><span class="app-utility-label">Mode</span><strong id="app-hero-mode">Analysis workspace</strong><span class="app-utility-note" id="app-hero-mode-note">Capability summary loading…</span></div>
+          <div class="app-stat-pill"><span class="app-utility-label">Active Run</span><strong id="app-hero-active-run">Checking recent runs</strong><span class="app-utility-note" id="app-hero-active-run-note">Restoring signed-in history and active run state.</span></div>
+        </div>
+        <div class="app-welcome-actions">
+          <a class="btn btn-primary" id="app-new-analysis-btn" href="#app-analysis-card">New Analysis</a>
+          <button class="btn btn-secondary" id="app-manage-billing-btn" type="button">Billing</button>
+        </div>
+      </div>
+
+      <!-- ── First-run hero (shown when analysis history is empty) ── -->
+      <div class="app-first-run-hero" id="app-first-run-hero" hidden>
+        <article class="app-card app-first-run-card">
+          <div class="app-first-run-content">
+            <div class="section-label">Get Started</div>
+            <h3>Welcome to Your Workspace</h3>
+            <p class="app-first-run-note">You have no analysis runs yet. Upload a KML file describing your area of interest, and TreeSight will search satellite imagery, compute vegetation health, and assemble a time-series evidence pack.</p>
+            <div class="app-first-run-actions">
+              <a class="btn btn-primary" id="app-first-run-cta" href="#app-analysis-card">Start Your First Analysis</a>
+              <a class="btn btn-secondary" href="/kml-guide.html">KML Guide</a>
+              <a class="btn btn-secondary" href="/#demo">Try the Public Demo</a>
+            </div>
+          </div>
+          <div class="app-first-run-checklist">
+            <div class="section-label">Quick Checklist</div>
+            <ol>
+              <li>Prepare a KML or KMZ file with polygon boundaries</li>
+              <li>Upload it in the New Analysis panel below</li>
+              <li>Queue the pipeline and watch each phase complete</li>
+              <li>Review satellite imagery, NDVI, and AI findings on this dashboard</li>
+            </ol>
+          </div>
+        </article>
+      </div>
+
+      <!-- ── Evidence hero (full-width, prominent) ── -->
+      <div class="app-evidence-hero" id="app-evidence-hero">
+        <article class="app-card app-evidence-hero-card" id="app-content-card" data-focus-target="content">
+          <div class="app-evidence-hero-header">
+            <div>
+              <div class="section-label">Evidence</div>
+              <h3 id="app-content-title">Satellite Imagery &amp; Analysis</h3>
+            </div>
+            <p class="app-evidence-hero-note" id="app-content-copy">Select a completed run to review satellite imagery, vegetation health, weather context, and AI-powered findings.</p>
+          </div>
+
+          <!-- Phase status (shown during active runs) -->
+          <div class="app-content-stack" id="app-content-phase-status">
+            <div class="app-evidence-status-row">
+              <div class="app-content-block">
+                <span class="app-content-label">Imagery stack</span>
+                <strong id="app-content-imagery">Waiting for a run</strong>
+                <p id="app-content-imagery-note">Before/after imagery and NDVI layers will appear here as the evidence stack forms.</p>
+              </div>
+              <div class="app-content-block">
+                <span class="app-content-label">Enrichment</span>
+                <strong id="app-content-enrichment">Context pending</strong>
+                <p id="app-content-enrichment-note">Weather and narrative context will follow once the imagery pipeline is stable.</p>
+              </div>
+              <div class="app-content-block">
+                <span class="app-content-label">Exports</span>
+                <strong id="app-content-exports">Evidence pack next</strong>
+                <p id="app-content-exports-note">Saved maps, narrative, and donor-ready exports will land here once run detail is wired.</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Evidence surface (shown for completed runs) -->
+          <div class="app-evidence-surface" id="app-evidence-surface" hidden>
+            <div class="app-evidence-two-col">
+              <!-- Left: large map -->
+              <div class="app-evidence-primary">
+                <div class="app-evidence-block app-evidence-map-block">
+                  <div class="app-evidence-map-header">
+                    <span class="app-content-label">Satellite imagery</span>
+                    <div class="app-evidence-map-controls">
+                      <button class="app-evidence-layer-btn active" id="app-map-btn-rgb" type="button">RGB</button>
+                      <button class="app-evidence-layer-btn" id="app-map-btn-ndvi" type="button">NDVI</button>
+                      <button class="app-evidence-layer-btn" id="app-map-expand-btn" type="button" title="Expand viewer">&#x26F6;</button>
+                    </div>
+                  </div>
+                  <div class="app-evidence-map-wrap" id="app-evidence-map-wrap">
+                    <div id="app-evidence-map"></div>
+                    <div class="app-evidence-map-overlay" id="app-evidence-map-overlay">Loading map&hellip;</div>
+                  </div>
+                  <div class="app-evidence-frame-controls" id="app-evidence-frame-controls" hidden>
+                    <button class="btn btn-secondary app-evidence-play-btn" id="app-map-play-btn" type="button">&#9654; Play</button>
+                    <input type="range" id="app-map-frame-slider" min="0" max="0" value="0">
+                    <span id="app-map-frame-counter">0/0</span>
+                  </div>
+                  <div class="app-evidence-frame-label" id="app-map-frame-label"></div>
+                </div>
+              </div>
+
+              <!-- Right: data panels -->
+              <div class="app-evidence-sidebar">
+                <!-- NDVI summary -->
+                <div class="app-evidence-block" id="app-evidence-ndvi-block">
+                  <span class="app-content-label">Vegetation health</span>
+                  <div class="app-evidence-ndvi-grid" id="app-evidence-ndvi-grid"></div>
+                  <canvas id="app-evidence-ndvi-canvas" width="320" height="80"></canvas>
+                  <p class="app-evidence-note" id="app-evidence-ndvi-note"></p>
+                </div>
+
+                <!-- Weather summary -->
+                <div class="app-evidence-block" id="app-evidence-weather-block">
+                  <span class="app-content-label">Climate context</span>
+                  <div class="app-evidence-weather-grid" id="app-evidence-weather-grid"></div>
+                  <canvas id="app-evidence-weather-canvas" width="320" height="80"></canvas>
+                </div>
+
+                <!-- Change detection -->
+                <div class="app-evidence-block" id="app-evidence-change-block" hidden>
+                  <span class="app-content-label">Change detection</span>
+                  <div id="app-evidence-change-list"></div>
+                </div>
+              </div>
+            </div>
+
+            <!-- AI & EUDR — full-width action row below the two-col layout -->
+            <div class="app-evidence-actions-row">
+              <!-- AI observations -->
+              <div class="app-evidence-block app-evidence-action-card" id="app-evidence-ai-block" hidden>
+                <div class="app-evidence-ai-header">
+                  <div>
+                    <span class="app-content-label">AI analysis</span>
+                    <p class="app-evidence-action-hint">Get AI-powered observations about vegetation change, land use, and risk signals from the imagery stack.</p>
+                  </div>
+                  <button class="btn btn-primary" id="app-evidence-ai-btn" type="button">Analyze with AI</button>
+                </div>
+                <div id="app-evidence-ai-content"></div>
+                <div class="app-evidence-ai-loading" id="app-evidence-ai-loading" hidden>Analyzing with AI&hellip;</div>
+              </div>
+
+              <!-- EUDR compliance (role-dependent) -->
+              <div class="app-evidence-block app-evidence-action-card" id="app-evidence-eudr-block" hidden>
+                <div class="app-evidence-ai-header">
+                  <div>
+                    <span class="app-content-label">EUDR compliance</span>
+                    <p class="app-evidence-action-hint">Run a deforestation-risk assessment against EU Deforestation Regulation thresholds.</p>
+                  </div>
+                  <button class="btn btn-primary" id="app-evidence-eudr-btn" type="button">Assess EUDR</button>
+                </div>
+                <div id="app-evidence-eudr-content"></div>
+                <div class="app-evidence-ai-loading" id="app-evidence-eudr-loading" hidden>Running EUDR assessment&hellip;</div>
+              </div>
+            </div>
+
+            <!-- Export bar — always-visible download row for completed runs -->
+            <div class="app-evidence-export-bar" id="app-evidence-export-bar">
+              <span class="app-content-label">Exports</span>
+              <div class="app-evidence-export-actions">
+                <button class="btn btn-secondary app-evidence-export-btn" type="button" data-export-format="geojson" disabled>GeoJSON</button>
+                <button class="btn btn-secondary app-evidence-export-btn" type="button" data-export-format="csv" disabled>CSV</button>
+                <button class="btn btn-secondary app-evidence-export-btn" type="button" data-export-format="pdf" disabled>PDF</button>
+              </div>
+              <span class="app-evidence-export-note" id="app-evidence-export-note">Select a completed run to enable exports.</span>
+            </div>
+          </div>
+
+          <div class="app-rail-footer" id="app-content-footer">Select a completed run from history to view evidence.</div>
+        </article>
+      </div>
+
+      <!-- ── Two-column workflow: history + run ── -->
+      <div class="app-workflow-stage" id="app-workflow-stage" data-focus="run">
+        <article class="app-workflow-rail app-rail-history" id="app-history-card" data-focus-target="history">
+          <div class="app-rail-header">
+            <div>
+              <div class="section-label">History</div>
+              <h3>History &amp; Resume</h3>
+            </div>
+          </div>
+          <p class="app-rail-copy" id="app-history-copy">Reopen a previous run or resume an active one.</p>
+          <div class="app-run-snapshot">
+            <span class="app-run-label">Selected status</span>
+            <strong id="app-history-latest-status">Loading recent runs</strong>
+            <span id="app-history-latest-note">Restoring signed-in history and checking for an active run to resume.</span>
+          </div>
+          <div class="app-mini-list">
+            <div class="app-mini-item"><span>Instance</span><strong id="app-history-latest-instance">…</strong></div>
+            <div class="app-mini-item"><span>Phase</span><strong id="app-history-latest-phase">loading</strong></div>
+            <div class="app-mini-item"><span>Next surface</span><strong id="app-history-latest-path">Checking workspace</strong></div>
+          </div>
+          <div class="app-history-list" id="app-history-list" aria-live="polite">Restoring signed-in history…</div>
+          <div class="app-rail-footer">Select a run to reopen this workspace state.</div>
+        </article>
+
+        <article class="app-workflow-rail app-rail-run" id="app-analysis-card" data-focus-target="run">
+          <div class="app-rail-header">
+            <div>
+              <div class="section-label">New Analysis</div>
+              <h3>Launch and Track</h3>
+            </div>
+          </div>
+          <p class="app-rail-copy" id="app-run-copy">Upload KML, queue the pipeline, and monitor progress.</p>
+          <div class="app-mode-card">
+            <span class="app-run-label">Workspace lens</span>
+            <strong id="app-analysis-lens-title">Conservation evidence run</strong>
+            <p id="app-analysis-lens-note">Frame this run around vegetation change, weather context, and plain-English proof. Bias the workspace toward outputs, evidence language, and what the next saved surface needs to deliver.</p>
+          </div>
+          <label class="app-field-label" for="app-analysis-file">KML or KMZ file</label>
+          <input id="app-analysis-file" type="file" accept=".kml,.kmz,application/vnd.google-earth.kml+xml,application/vnd.google-earth.kmz">
+          <p class="app-note" id="app-analysis-file-note">Choose a KML or KMZ file, or paste KML below.</p>
+          <label class="app-field-label" for="app-analysis-kml">KML Content</label>
+          <textarea id="app-analysis-kml" placeholder="Paste KML content for a signed-in analysis request…"></textarea>
+          <div class="app-preflight-card" id="app-analysis-preflight">
+            <div class="app-preflight-header">
+              <div>
+                <div class="section-label">Preflight</div>
+                <h4 id="app-preflight-headline">Awaiting KML</h4>
+              </div>
+              <span class="app-preflight-badge" id="app-preflight-mode">No file yet</span>
+            </div>
+            <p class="app-note" id="app-preflight-summary">Paste KML to see feature count, AOI spread, and signed-in product guidance before queueing.</p>
+            <div class="app-preflight-grid">
+              <div><span>Features</span><strong id="app-preflight-features">0</strong></div>
+              <div><span>AOIs</span><strong id="app-preflight-aois">0</strong></div>
+              <div><span>Spread</span><strong id="app-preflight-spread">—</strong></div>
+              <div><span>Quota impact</span><strong id="app-preflight-quota">—</strong></div>
+            </div>
+            <div class="app-preflight-list" id="app-preflight-warnings">
+              <div class="app-preflight-item" data-tone="info">Signed-in preflight will surface warnings here instead of inheriting demo-only rejections.</div>
+            </div>
+          </div>
+          <div class="app-select-row app-analysis-actions">
+            <button class="btn btn-primary" id="app-analysis-submit-btn" type="button">Queue Analysis</button>
+            <a class="btn btn-secondary" href="/#demo">View Public Demo</a>
+          </div>
+          <div class="app-callout" id="app-analysis-status" hidden></div>
+          <div id="app-analysis-progress" class="app-pipeline-progress" hidden>
+            <div class="pipeline-step" data-phase="submit"><span class="step-icon">○</span> Uploading KML and reserving pipeline capacity</div>
+            <div class="pipeline-step" data-phase="ingestion"><span class="step-icon">○</span> Parsing AOIs and validating geometry</div>
+            <div class="pipeline-step" data-phase="acquisition"><span class="step-icon">○</span> Searching NAIP and Sentinel-2 imagery</div>
+            <div class="pipeline-step" data-phase="fulfilment"><span class="step-icon">○</span> Downloading scenes, clipping, and reprojection</div>
+            <div class="pipeline-step" data-phase="enrichment"><span class="step-icon">○</span> Building NDVI, weather, and cache layers</div>
+            <div class="pipeline-step" data-phase="complete"><span class="step-icon">○</span> Complete</div>
+          </div>
+          <dl class="app-stats compact" id="app-analysis-run" hidden>
+            <div><dt>Instance</dt><dd id="app-analysis-instance">—</dd></div>
+            <div><dt>Status</dt><dd id="app-analysis-runtime">—</dd></div>
+            <div><dt>Phase</dt><dd id="app-analysis-phase">—</dd></div>
+          </dl>
+          <div class="app-run-detail-grid" id="app-run-detail-grid">
+            <div class="app-detail-card">
+              <span class="app-content-label">Submitted</span>
+              <strong id="app-run-submitted">—</strong>
+              <p id="app-run-submitted-note">Signed-in run detail restores here after reload.</p>
+            </div>
+            <div class="app-detail-card">
+              <span class="app-content-label">Scope</span>
+              <strong id="app-run-scope">—</strong>
+              <p id="app-run-scope-note">Feature and AOI counts appear when known.</p>
+            </div>
+            <div class="app-detail-card">
+              <span class="app-content-label">Delivery</span>
+              <strong id="app-run-delivery">—</strong>
+              <p id="app-run-delivery-note">Failure counts and tracked artifacts will appear here.</p>
+            </div>
+            <div class="app-detail-card">
+              <span class="app-content-label">Run Link</span>
+              <strong id="app-run-link-label">Dashboard state</strong>
+              <a class="app-inline-link" id="app-run-link" href="/app/">Open durable run state</a>
+              <div class="app-run-action-row" id="app-run-export-actions">
+                <button class="btn btn-secondary app-run-action-btn" id="app-run-export-geojson" type="button" data-export-format="geojson" disabled>GeoJSON</button>
+                <button class="btn btn-secondary app-run-action-btn" id="app-run-export-csv" type="button" data-export-format="csv" disabled>CSV</button>
+                <button class="btn btn-secondary app-run-action-btn" id="app-run-export-pdf" type="button" data-export-format="pdf" disabled>PDF</button>
+              </div>
+              <p class="app-note" id="app-run-export-note">Completed runs can download GeoJSON, CSV, and PDF exports here.</p>
+            </div>
+          </div>
+        </article>
+      </div>
+
+      <!-- ── Workspace settings (collapsible) ── -->
+      <details class="app-settings-disclosure" id="app-settings-disclosure">
+        <summary class="app-settings-toggle">Workspace Settings <span class="app-settings-hint">Role, preference, and account</span></summary>
+        <div class="app-settings-body">
+          <div class="app-lens-board">
+            <article class="app-card app-lens-card">
+              <div class="app-lens-header">
+                <div>
+                  <div class="section-label">Role View</div>
+                  <h3 id="app-role-title">Conservation monitoring</h3>
+                </div>
+                <span class="app-lens-tag" id="app-role-tag">Field evidence</span>
+              </div>
+              <div class="app-chip-row" id="app-role-switcher">
+                <button class="app-lens-chip" type="button" data-role-choice="conservation" aria-pressed="true">Conservation</button>
+                <button class="app-lens-chip" type="button" data-role-choice="eudr" aria-pressed="false">EUDR</button>
+                <button class="app-lens-chip" type="button" data-role-choice="portfolio" aria-pressed="false">Portfolio Ops</button>
+              </div>
+              <p class="app-lens-copy" id="app-role-summary">Built for protected-area coordinators who need rapid, plain-English evidence they can take to rangers, directors, or donors.</p>
+              <div class="app-brief-grid">
+                <div class="app-brief-item"><span>Primary outcome</span><strong id="app-role-outcome">Evidence packs</strong></div>
+                <div class="app-brief-item"><span>Operator stance</span><strong id="app-role-risk">No silent fallback</strong></div>
+                <div class="app-brief-item"><span>Default rhythm</span><strong id="app-role-rhythm">Monthly watchlist</strong></div>
+              </div>
+            </article>
+
+            <article class="app-card app-lens-card app-preference-card">
+              <div class="app-lens-header">
+                <div>
+                  <div class="section-label">Work Preference</div>
+                  <h3 id="app-preference-title">Investigate suspicious change</h3>
+                </div>
+                <span class="app-lens-tag" id="app-preference-tag">Run-first</span>
+              </div>
+              <div class="app-chip-row" id="app-preference-switcher">
+                <button class="app-lens-chip" type="button" data-preference-choice="investigate" aria-pressed="true">Investigate</button>
+                <button class="app-lens-chip" type="button" data-preference-choice="monitor" aria-pressed="false">Monitor</button>
+                <button class="app-lens-chip" type="button" data-preference-choice="report" aria-pressed="false">Report</button>
+              </div>
+              <p class="app-lens-copy" id="app-preference-summary">Stay centered on the live run while you prove what changed, why it changed, and what to do next.</p>
+              <div class="app-action-stack">
+                <button class="btn btn-primary" id="app-guided-primary-btn" type="button">Start evidence run</button>
+                <button class="btn btn-secondary" id="app-guided-secondary-btn" type="button">Review latest incident</button>
+              </div>
+              <div class="app-mini-list app-mini-list-tight">
+                <div class="app-mini-item"><span>Deliverable</span><strong id="app-guided-deliverable">Operator brief</strong></div>
+                <div class="app-mini-item"><span>Operator stance</span><strong id="app-guided-stance">Prove the change before escalation</strong></div>
+                <div class="app-mini-item"><span>Suggested focus</span><strong id="app-guided-focus">Run rail</strong></div>
+              </div>
+            </article>
+          </div>
+
+          <div class="app-support-grid">
+            <article class="app-card app-support-card">
+              <h3>Account &amp; Access</h3>
+              <dl class="app-stats compact">
+                <div><dt>Signed in as</dt><dd id="app-account-identifier">Loading…</dd></div>
+                <div><dt>Billing</dt><dd id="app-billing-note">Checking configuration…</dd></div>
+                <div><dt>Plan</dt><dd id="app-tier">Loading…</dd></div>
+                <div><dt>Status</dt><dd id="app-subscription-status">Loading…</dd></div>
+                <div><dt>Runs Remaining</dt><dd id="app-runs-remaining">Loading…</dd></div>
+                <div><dt>Concurrency</dt><dd id="app-concurrency">Loading…</dd></div>
+                <div><dt>AI Insights</dt><dd id="app-ai-access">Loading…</dd></div>
+                <div><dt>API Access</dt><dd id="app-api-access">Loading…</dd></div>
+                <div><dt>Retention</dt><dd id="app-retention">Loading…</dd></div>
+              </dl>
+            </article>
+
+            <article class="app-card app-support-card" id="app-tier-emulation-card" hidden>
+              <h3>Plan Emulation</h3>
+              <p>Local development only. Override this signed-in account to test plan-gated behavior without changing the billing record.</p>
+              <label class="app-field-label" for="app-tier-emulation-select">Effective plan</label>
+              <div class="app-select-row">
+                <select id="app-tier-emulation-select">
+                  <option value="actual">Actual billing state</option>
+                </select>
+                <button class="btn btn-secondary" id="app-apply-tier-emulation-btn" type="button">Apply</button>
+              </div>
+              <p class="app-note" id="app-tier-emulation-note">Using actual billing state.</p>
+            </article>
+          </div>
+        </div>
+      </details>
+
+    </div>
+  </section>
+</main>
+
+<footer>
+  <div class="container">TreeSight App — authenticated workspace for analyses, usage, and billing.</div>
+</footer>
+<!-- Expanded map viewer modal (must be direct child of body to avoid transform containment) -->
+<div class="app-map-expanded-backdrop" id="app-map-expanded-backdrop" hidden>
+  <div class="app-map-expanded-panel">
+    <div class="app-map-expanded-header">
+      <span class="app-content-label">Satellite imagery</span>
+      <div class="app-evidence-map-controls">
+        <button class="app-evidence-layer-btn" id="app-map-expanded-btn-rgb" type="button">RGB</button>
+        <button class="app-evidence-layer-btn" id="app-map-expanded-btn-ndvi" type="button">NDVI</button>
+        <button class="app-evidence-layer-btn" id="app-map-collapse-btn" type="button" title="Close expanded view">&times;</button>
+      </div>
+    </div>
+    <div class="app-map-expanded-body" id="app-map-expanded-body"></div>
+    <div class="app-map-expanded-controls" id="app-map-expanded-controls">
+      <button class="btn btn-secondary app-evidence-play-btn" id="app-map-expanded-play-btn" type="button">&#9654; Play</button>
+      <input type="range" id="app-map-expanded-slider" min="0" max="0" value="0">
+      <span id="app-map-expanded-counter">0/0</span>
+    </div>
+    <div class="app-evidence-frame-label" id="app-map-expanded-label"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/website/css/app.css
+++ b/website/css/app.css
@@ -1,0 +1,268 @@
+#status-badge{font-size:.75rem;padding:3px 10px;border-radius:12px;font-weight:600;background:var(--c-surface);color:var(--c-muted);border:1px solid var(--c-border);transition:all .3s}
+#status-badge.online{background:rgba(63,185,80,.15);color:var(--c-green);border-color:var(--c-green)}
+#status-badge.verified{background:rgba(63,185,80,.08);color:var(--c-green);border-color:var(--c-border)}
+#status-badge.offline{background:rgba(248,81,73,.15);color:var(--c-red);border-color:var(--c-red)}
+
+
+.app-main{padding:24px 0 64px}
+.app-gate{padding:32px 0 64px}
+.app-panel,.app-card,.app-banner{background:var(--c-surface);border:1px solid var(--c-border);border-radius:16px;box-shadow:var(--shadow)}
+.app-panel{max-width:760px;margin:0 auto;padding:32px}
+.app-panel h2{font-size:1.7rem;letter-spacing:-.02em}
+.app-panel p{color:var(--c-muted);margin-top:12px;max-width:54ch}
+.app-gate-actions{display:flex;gap:12px;flex-wrap:wrap;margin-top:24px}
+
+.app-dashboard .container{display:flex;flex-direction:column;gap:28px}
+.app-dashboard{--app-role-accent:var(--c-green);--app-role-tint:rgba(63,185,80,.14);--app-role-border:rgba(63,185,80,.26)}
+.app-dashboard[data-role="eudr"]{--app-role-accent:var(--c-accent);--app-role-tint:rgba(88,166,255,.14);--app-role-border:rgba(88,166,255,.26)}
+.app-dashboard[data-role="portfolio"]{--app-role-accent:var(--c-orange);--app-role-tint:rgba(210,153,34,.16);--app-role-border:rgba(210,153,34,.26)}
+/* Welcome bar — compact row replacing old banner + utility strip */
+.app-welcome-bar{display:grid;grid-template-columns:1fr auto;grid-template-rows:auto auto;gap:14px 24px;padding:20px 24px;border-radius:16px;background:linear-gradient(135deg, rgba(255,255,255,.03), rgba(255,255,255,0)), var(--c-surface);border:1px solid var(--c-border);box-shadow:var(--shadow)}
+.app-welcome-identity{grid-column:1;grid-row:1}
+.app-welcome-identity h2{font-size:1.2rem;letter-spacing:-.02em;margin:0}
+.app-welcome-note{font-size:.78rem;color:var(--c-muted);margin-top:2px}
+.app-welcome-actions{grid-column:2;grid-row:1;display:flex;gap:10px;align-items:center;flex-shrink:0}
+.app-welcome-stats{grid-column:1 / -1;grid-row:2;display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px}
+.app-stat-pill{display:flex;flex-direction:column;gap:3px;padding:8px 12px;background:rgba(13,17,23,.18);border:1px solid rgba(230,237,243,.08);border-radius:12px}
+.app-utility-label{font-size:.68rem;letter-spacing:.08em;text-transform:uppercase;color:var(--c-muted)}
+.app-stat-pill strong{font-size:.88rem;letter-spacing:-.01em;color:var(--c-text)}
+.app-utility-note{font-size:.72rem;line-height:1.3;color:var(--c-muted)}
+
+/* First-run hero — onboarding card for users with no runs */
+.app-first-run-hero[hidden]{display:none}
+.app-first-run-card{padding:28px;display:grid;grid-template-columns:1.4fr 1fr;gap:28px;align-items:start}
+.app-first-run-note{font-size:.88rem;color:var(--c-muted);max-width:52ch;margin-top:8px;line-height:1.6}
+.app-first-run-actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:18px}
+.app-first-run-checklist{padding:16px 20px;background:rgba(63,185,80,.06);border:1px solid rgba(63,185,80,.18);border-radius:12px}
+.app-first-run-checklist ol{margin:10px 0 0 18px;font-size:.84rem;color:var(--c-muted);line-height:1.8}
+@media (max-width:700px){.app-first-run-card{grid-template-columns:1fr}}
+
+/* Evidence hero — full-width prominent section */
+.app-evidence-hero{margin:0}
+.app-evidence-hero[hidden]{display:none}
+.app-evidence-hero-card{padding:24px;min-height:auto}
+.app-evidence-hero-header{display:flex;justify-content:space-between;gap:16px;align-items:flex-start;flex-wrap:wrap}
+.app-evidence-hero-note{font-size:.88rem;color:var(--c-muted);max-width:48ch;margin:0}
+.app-evidence-status-row{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:14px}
+.app-evidence-two-col{display:grid;grid-template-columns:1.6fr 1fr;gap:16px;align-items:start}
+.app-evidence-primary .app-evidence-map-wrap{height:420px}
+.app-evidence-sidebar{display:flex;flex-direction:column;gap:12px;max-height:600px;overflow-y:auto}
+
+/* AI / EUDR action row — full-width, prominent */
+.app-evidence-actions-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:14px}
+.app-evidence-action-card{background:linear-gradient(135deg, rgba(88,166,255,.06), rgba(13,17,23,.42));border-color:rgba(88,166,255,.22);padding:18px 20px}
+.app-evidence-action-card .app-evidence-ai-header{display:flex;justify-content:space-between;align-items:center;gap:16px}
+.app-evidence-action-card .app-evidence-ai-header .btn{flex-shrink:0;padding:10px 20px;font-size:.88rem}
+.app-evidence-action-hint{font-size:.82rem;line-height:1.5;color:var(--c-muted);margin-top:4px;max-width:40ch}
+
+/* Evidence export bar — prominent download row inside evidence surface */
+.app-evidence-export-bar{display:flex;align-items:center;gap:14px;padding:12px 16px;background:rgba(63,185,80,.06);border:1px solid rgba(63,185,80,.18);border-radius:12px}
+.app-evidence-export-actions{display:flex;gap:8px}
+.app-evidence-export-btn{padding:6px 14px;font-size:.82rem}
+.app-evidence-export-note{font-size:.78rem;color:var(--c-muted);margin-left:auto}
+
+.app-lens-board{display:grid;grid-template-columns:minmax(0,1.25fr) minmax(320px,.95fr);gap:22px}
+.app-lens-card{gap:16px;background:linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,.01)), var(--c-surface)}
+.app-lens-header{display:flex;justify-content:space-between;gap:16px;align-items:flex-start}
+.app-lens-header h3{font-size:1.12rem;letter-spacing:-.02em}
+.app-lens-tag{display:inline-flex;align-items:center;padding:8px 12px;border-radius:999px;background:var(--app-role-tint);border:1px solid var(--app-role-border);color:var(--c-text);font-size:.76rem;font-weight:600;white-space:nowrap}
+.app-chip-row{display:flex;gap:10px;flex-wrap:wrap}
+.app-lens-chip{appearance:none;border:1px solid rgba(230,237,243,.12);background:rgba(13,17,23,.38);color:var(--c-muted);padding:10px 14px;border-radius:999px;font:inherit;font-size:.84rem;font-weight:600;cursor:pointer;transition:all .2s ease}
+.app-lens-chip:hover{border-color:var(--app-role-border);color:var(--c-text)}
+.app-lens-chip[aria-pressed="true"]{background:var(--app-role-tint);border-color:var(--app-role-border);color:var(--c-text);box-shadow:0 8px 20px rgba(0,0,0,.18)}
+.app-lens-copy{font-size:.9rem;line-height:1.65;color:var(--c-muted)}
+.app-brief-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}
+.app-brief-item{padding:14px 16px;border-radius:14px;border:1px solid rgba(230,237,243,.08);background:rgba(13,17,23,.32);display:flex;flex-direction:column;gap:6px}
+.app-brief-item span{font-size:.72rem;letter-spacing:.08em;text-transform:uppercase;color:var(--c-muted)}
+.app-brief-item strong{font-size:.96rem;letter-spacing:-.01em}
+.app-action-stack{display:flex;gap:12px;flex-wrap:wrap}
+.app-mini-list-tight{gap:0}
+
+/* Settings disclosure — collapsible workspace settings */
+.app-settings-disclosure{border:1px solid var(--c-border);border-radius:16px;background:var(--c-surface);box-shadow:var(--shadow)}
+.app-settings-toggle{padding:16px 20px;cursor:pointer;font-size:.88rem;font-weight:600;color:var(--c-muted);display:flex;align-items:center;gap:8px;list-style:none}
+.app-settings-toggle::-webkit-details-marker{display:none}
+.app-settings-toggle::before{content:'\25B6';font-size:.64rem;transition:transform .2s ease}
+.app-settings-disclosure[open] .app-settings-toggle::before{transform:rotate(90deg)}
+.app-settings-hint{font-weight:400;font-size:.78rem;color:var(--c-muted);opacity:.7}
+.app-settings-body{padding:0 20px 20px;display:flex;flex-direction:column;gap:18px}
+
+.app-workflow-stage{display:grid;grid-template-columns:minmax(240px,.7fr) minmax(420px,1.3fr);gap:22px;align-items:stretch}
+.app-workflow-rail{padding:22px;border:1px solid var(--c-border);border-radius:18px;background:rgba(13,17,23,.62);box-shadow:var(--shadow);display:flex;flex-direction:column;gap:14px;position:relative;overflow:hidden;transition:transform .25s ease,opacity .25s ease,border-color .25s ease,box-shadow .25s ease;cursor:pointer;opacity:.78;transform:scale(.965)}
+.app-workflow-rail::after{content:"";position:absolute;inset:0;background:linear-gradient(180deg, rgba(255,255,255,.02), rgba(255,255,255,0));pointer-events:none}
+.app-workflow-stage[data-focus="history"] .app-rail-history,
+.app-workflow-stage[data-focus="run"] .app-rail-run{opacity:1;transform:translateY(-6px) scale(1.01);border-color:var(--app-role-border);box-shadow:0 20px 48px rgba(0,0,0,.28)}
+.app-workflow-stage[data-focus="history"] .app-rail-run,
+.app-workflow-stage[data-focus="run"] .app-rail-history{opacity:.72}
+.app-rail-header{display:flex;justify-content:space-between;gap:12px;align-items:flex-start}
+.app-rail-header h3{font-size:1.15rem;letter-spacing:-.02em}
+.app-rail-copy{font-size:.9rem;line-height:1.6;color:var(--c-muted)}
+.app-rail-footer{margin-top:auto;padding-top:14px;border-top:1px solid rgba(230,237,243,.08);font-size:.8rem;line-height:1.5;color:var(--c-muted)}
+.app-run-snapshot{display:flex;flex-direction:column;gap:6px;padding:14px 16px;border-radius:14px;background:rgba(88,166,255,.08);border:1px solid rgba(88,166,255,.18)}
+.app-run-label,.app-content-label{font-size:.72rem;letter-spacing:.08em;text-transform:uppercase;color:var(--c-muted)}
+.app-run-snapshot strong,.app-content-block strong{font-size:1rem;letter-spacing:-.01em;color:var(--c-text)}
+.app-run-snapshot span:last-child{font-size:.8rem;line-height:1.5;color:var(--c-muted)}
+.app-mini-list{display:grid;gap:10px}
+.app-mini-item{display:flex;justify-content:space-between;gap:16px;padding:10px 0;border-bottom:1px solid rgba(230,237,243,.08);font-size:.84rem}
+.app-mini-item:last-child{border-bottom:none}
+.app-mini-item span{color:var(--c-muted)}
+.app-mini-item strong{text-align:right;color:var(--c-text)}
+.app-history-list{display:grid;gap:10px}
+.app-history-item{appearance:none;width:100%;padding:14px 16px;border-radius:14px;border:1px solid rgba(230,237,243,.08);background:rgba(255,255,255,.02);color:var(--c-text);display:grid;gap:8px;text-align:left;cursor:pointer;transition:transform .2s ease,border-color .2s ease,background .2s ease,box-shadow .2s ease}
+.app-history-item:hover{transform:translateY(-1px);border-color:var(--app-role-border)}
+.app-history-item[data-selected="true"]{background:var(--app-role-tint);border-color:var(--app-role-border);box-shadow:0 14px 30px rgba(0,0,0,.2)}
+.app-history-item-header,.app-history-item-meta{display:flex;justify-content:space-between;gap:12px;align-items:center;flex-wrap:wrap}
+.app-history-item-title{font-size:.92rem;letter-spacing:-.01em}
+.app-history-item-status{display:inline-flex;align-items:center;padding:6px 10px;border-radius:999px;background:rgba(88,166,255,.08);border:1px solid rgba(88,166,255,.18);font-size:.72rem;font-weight:600;color:var(--c-text)}
+.app-history-item-meta{font-size:.76rem;color:var(--c-muted)}
+.app-history-item-note{font-size:.8rem;line-height:1.5;color:var(--c-muted)}
+.app-history-empty{padding:12px 14px;border-radius:14px;border:1px dashed rgba(230,237,243,.12);font-size:.82rem;line-height:1.5;color:var(--c-muted)}
+.app-content-stack{display:grid;gap:12px}
+.app-content-stack[hidden]{display:none}
+.app-content-block{padding:14px 16px;border-radius:14px;background:rgba(255,255,255,.02);border:1px solid rgba(230,237,243,.08)}
+.app-content-block p{margin-top:6px;font-size:.82rem;line-height:1.55}
+
+/* Evidence surface */
+.app-evidence-surface{display:grid;gap:12px}
+.app-evidence-surface[hidden]{display:none}
+.app-evidence-block{padding:14px 16px;border-radius:14px;background:rgba(255,255,255,.02);border:1px solid rgba(230,237,243,.08)}
+.app-evidence-block .app-content-label{display:block;margin-bottom:8px}
+.app-evidence-map-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:8px}
+.app-evidence-map-controls{display:flex;gap:4px}
+.app-evidence-layer-btn{appearance:none;padding:5px 10px;border:1px solid rgba(230,237,243,.12);background:rgba(13,17,23,.38);color:var(--c-muted);border-radius:8px;font:inherit;font-size:.76rem;font-weight:600;cursor:pointer;transition:all .2s}
+.app-evidence-layer-btn:hover{border-color:var(--app-role-border);color:var(--c-text)}
+.app-evidence-layer-btn.active{background:var(--app-role-tint);border-color:var(--app-role-border);color:var(--c-text)}
+.app-evidence-map-wrap{position:relative;width:100%;height:260px;border-radius:10px;overflow:hidden;border:1px solid rgba(230,237,243,.08)}
+#app-evidence-map{width:100%;height:100%;z-index:0}
+.app-evidence-map-overlay{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(13,17,23,.72);font-size:.88rem;color:var(--c-muted);z-index:10;pointer-events:none}
+.app-evidence-map-overlay[hidden]{display:none}
+.app-evidence-frame-controls{display:flex;gap:8px;align-items:center;margin-top:8px}
+.app-evidence-frame-controls input[type=range]{flex:1;accent-color:var(--app-role-accent)}
+.app-evidence-play-btn{padding:5px 12px;min-width:0;font-size:.82rem}
+#app-map-frame-counter{font-size:.78rem;color:var(--c-muted);white-space:nowrap}
+.app-evidence-frame-label{font-size:.78rem;color:var(--c-muted);margin-top:4px}
+
+/* Expanded map player */
+.app-map-expanded-backdrop{position:fixed;inset:0;z-index:9000;background:rgba(1,4,9,.92);display:flex;align-items:center;justify-content:center;padding:24px}
+.app-map-expanded-backdrop[hidden]{display:none}
+.app-map-expanded-panel{width:100%;max-width:1200px;height:100%;display:flex;flex-direction:column;gap:10px}
+.app-map-expanded-header{display:flex;justify-content:space-between;align-items:center}
+.app-map-expanded-header .app-content-label{font-size:1rem}
+.app-map-expanded-body{flex:1;min-height:0;border-radius:12px;overflow:hidden;border:1px solid rgba(230,237,243,.08);position:relative}
+.app-map-expanded-body #app-evidence-map{width:100%;height:100%}
+.app-map-expanded-controls{display:flex;gap:10px;align-items:center}
+.app-map-expanded-controls input[type=range]{flex:1;accent-color:var(--app-role-accent)}
+#app-map-collapse-btn{font-size:1.1rem;line-height:1;padding:4px 10px}
+.app-evidence-ndvi-grid,.app-evidence-weather-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-bottom:8px}
+.app-evidence-stat{padding:10px 12px;border-radius:10px;background:rgba(13,17,23,.42);border:1px solid rgba(230,237,243,.06);display:flex;flex-direction:column;gap:3px}
+.app-evidence-stat span{font-size:.68rem;letter-spacing:.08em;text-transform:uppercase;color:var(--c-muted)}
+.app-evidence-stat strong{font-size:.92rem;letter-spacing:-.01em}
+.app-evidence-stat strong.positive{color:var(--c-green)}
+.app-evidence-stat strong.negative{color:var(--c-red)}
+.app-evidence-stat strong.neutral{color:var(--c-text)}
+.app-evidence-note{font-size:.78rem;line-height:1.5;color:var(--c-muted);margin-top:4px}
+#app-evidence-ndvi-canvas,#app-evidence-weather-canvas{width:100%;height:80px;border-radius:8px}
+.app-evidence-change-item{padding:10px 12px;border-radius:10px;border:1px solid rgba(248,81,73,.2);background:rgba(248,81,73,.08);font-size:.82rem;line-height:1.5;margin-bottom:6px}
+.app-evidence-change-item.positive{border-color:rgba(63,185,80,.2);background:rgba(63,185,80,.08)}
+.app-evidence-ai-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:8px}
+.app-evidence-ai-header .btn{padding:5px 12px;font-size:.78rem;min-width:0}
+.app-evidence-ai-loading{font-size:.82rem;color:var(--c-muted);padding:8px 0}
+.app-evidence-obs{padding:12px 14px;border-radius:12px;border:1px solid rgba(230,237,243,.08);background:rgba(255,255,255,.02);margin-bottom:8px}
+.app-evidence-obs-header{display:flex;justify-content:space-between;align-items:center;gap:8px;margin-bottom:4px}
+.app-evidence-obs-category{font-size:.78rem;font-weight:600;text-transform:uppercase;letter-spacing:.04em}
+.app-evidence-obs-severity{display:inline-flex;padding:3px 8px;border-radius:999px;font-size:.68rem;font-weight:600}
+.app-evidence-obs-severity.severity-low,.app-evidence-obs-severity.severity-normal{background:rgba(63,185,80,.12);color:var(--c-green);border:1px solid rgba(63,185,80,.2)}
+.app-evidence-obs-severity.severity-moderate{background:rgba(210,153,34,.12);color:#f6d78b;border:1px solid rgba(210,153,34,.24)}
+.app-evidence-obs-severity.severity-high,.app-evidence-obs-severity.severity-critical{background:rgba(248,81,73,.12);color:#ffb2ad;border:1px solid rgba(248,81,73,.24)}
+.app-evidence-obs p{font-size:.82rem;line-height:1.55;color:var(--c-muted);margin-top:4px}
+.app-evidence-obs .obs-recommendation{color:var(--c-text);font-style:italic}
+.app-evidence-summary{padding:12px 14px;border-radius:12px;background:var(--app-role-tint);border:1px solid var(--app-role-border);font-size:.84rem;line-height:1.6;margin-bottom:8px}
+.app-evidence-eudr-result{padding:14px 16px;border-radius:12px;font-size:.84rem;line-height:1.6}
+.app-evidence-eudr-result.compliant{background:rgba(63,185,80,.1);border:1px solid rgba(63,185,80,.24);color:var(--c-text)}
+.app-evidence-eudr-result.non-compliant{background:rgba(248,81,73,.1);border:1px solid rgba(248,81,73,.24);color:var(--c-text)}
+
+.app-mode-card,.app-preflight-card{padding:16px;border-radius:16px;border:1px solid rgba(230,237,243,.08);background:linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,.01)), rgba(13,17,23,.42)}
+.app-mode-card p{margin-top:6px;font-size:.84rem;line-height:1.6;color:var(--c-muted)}
+.app-preflight-header{display:flex;justify-content:space-between;gap:16px;align-items:flex-start}
+.app-preflight-header h4{font-size:1.02rem;letter-spacing:-.02em}
+.app-preflight-badge{display:inline-flex;align-items:center;padding:8px 12px;border-radius:999px;background:rgba(88,166,255,.08);border:1px solid rgba(88,166,255,.18);font-size:.76rem;font-weight:600;color:var(--c-text);white-space:nowrap}
+.app-preflight-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px;margin-top:12px}
+.app-preflight-grid div{padding:12px 14px;border-radius:12px;background:rgba(13,17,23,.42);border:1px solid rgba(230,237,243,.08);display:flex;flex-direction:column;gap:5px}
+.app-preflight-grid span{font-size:.7rem;letter-spacing:.08em;text-transform:uppercase;color:var(--c-muted)}
+.app-preflight-grid strong{font-size:.95rem;letter-spacing:-.01em}
+.app-preflight-list{display:grid;gap:8px;margin-top:12px}
+.app-preflight-item{padding:10px 12px;border-radius:12px;font-size:.8rem;line-height:1.55;border:1px solid rgba(88,166,255,.18);background:rgba(88,166,255,.08);color:var(--c-text)}
+.app-preflight-item[data-tone="warning"]{background:rgba(210,153,34,.12);border-color:rgba(210,153,34,.24);color:#f6d78b}
+.app-preflight-item[data-tone="error"]{background:rgba(248,81,73,.12);border-color:rgba(248,81,73,.24);color:#ffb2ad}
+
+.app-support-grid{display:grid;grid-template-columns:minmax(0,1.1fr) minmax(320px,.9fr);gap:22px}
+.app-card{padding:24px;display:flex;flex-direction:column;gap:12px;min-height:220px}
+.app-card h3{font-size:1.05rem;letter-spacing:-.01em}
+.app-card p{color:var(--c-muted)}
+.app-support-card{background:linear-gradient(180deg, rgba(255,255,255,.02), rgba(255,255,255,.01)), var(--c-surface)}
+.app-inline-action{align-self:flex-start;margin-top:auto}
+.app-field-label{display:block;font-size:.78rem;font-weight:600;color:var(--c-text);margin-top:4px}
+.app-select-row{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
+.app-select-row select{flex:1;min-width:220px;padding:10px 12px;background:var(--c-bg);border:1px solid var(--c-border);border-radius:var(--radius);color:var(--c-text);font-size:.88rem}
+.app-note{font-size:.78rem;line-height:1.5;color:var(--c-muted)}
+.app-workflow-rail input[type=file],.app-workflow-rail textarea,.app-card input[type=file],.app-card textarea{width:100%;padding:10px 12px;background:var(--c-bg);border:1px solid var(--c-border);border-radius:var(--radius);color:var(--c-text);font:inherit}
+.app-workflow-rail textarea,.app-card textarea{min-height:160px;resize:vertical}
+.app-analysis-actions{margin-top:4px}
+.app-callout{padding:12px 14px;border-radius:var(--radius);font-size:.82rem;line-height:1.5}
+.app-callout[data-tone="info"]{background:rgba(88,166,255,.1);border:1px solid rgba(88,166,255,.25);color:var(--c-text)}
+.app-callout[data-tone="error"]{background:rgba(248,81,73,.12);border:1px solid rgba(248,81,73,.28);color:#ffb2ad}
+.app-callout[data-tone="success"]{background:rgba(63,185,80,.12);border:1px solid rgba(63,185,80,.28);color:var(--c-text)}
+.app-pipeline-progress{display:grid;gap:6px;margin-top:14px;padding:14px 16px;background:linear-gradient(180deg,rgba(88,166,255,.06),rgba(13,17,23,.02));border:1px solid rgba(230,237,243,.08);border-radius:var(--radius)}
+.app-pipeline-progress .pipeline-step{display:flex;align-items:center;gap:10px;font-size:.84rem;color:var(--c-muted);transition:color .2s ease,transform .2s ease}
+.app-pipeline-progress .pipeline-step.active{color:var(--c-text);font-weight:600;transform:translateX(2px)}
+.app-pipeline-progress .pipeline-step.done{color:var(--c-green)}
+.app-pipeline-progress .pipeline-step.failed{color:#ffb2ad}
+.app-pipeline-progress .step-icon{width:20px;text-align:center;font-size:.9rem;flex:0 0 20px}
+.app-pipeline-progress .spinner{display:inline-block;width:14px;height:14px;border:2px solid var(--c-border);border-top-color:var(--c-accent);border-radius:50%;animation:spin .8s linear infinite}
+.app-run-detail-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
+.app-detail-card{padding:14px 16px;border-radius:14px;background:rgba(255,255,255,.02);border:1px solid rgba(230,237,243,.08);display:flex;flex-direction:column;gap:6px}
+.app-detail-card strong{font-size:1rem;letter-spacing:-.01em;color:var(--c-text)}
+.app-detail-card p{font-size:.82rem;line-height:1.55;color:var(--c-muted)}
+.app-inline-link{color:var(--app-role-accent);font-size:.84rem;font-weight:600;text-decoration:none}
+.app-inline-link:hover{text-decoration:underline}
+.app-run-action-row{display:flex;gap:8px;flex-wrap:wrap;margin-top:4px}
+.app-run-action-btn{padding:8px 12px;min-width:0}
+.app-run-action-btn:disabled{opacity:.55;cursor:not-allowed}
+
+.btn:focus-visible,.auth-btn:focus-visible,.app-lens-chip:focus-visible,.app-history-item:focus-visible,.app-inline-link:focus-visible,.app-workflow-rail input[type=file]:focus-visible,.app-workflow-rail textarea:focus-visible,.app-card input[type=file]:focus-visible,.app-card textarea:focus-visible,.app-select-row select:focus-visible{outline:2px solid var(--app-role-accent);outline-offset:2px}
+
+.app-stats{display:grid;gap:12px}
+.app-stats div{display:flex;justify-content:space-between;gap:16px;padding:12px 0;border-bottom:1px solid rgba(230,237,243,.08)}
+.app-stats div:last-child{border-bottom:none}
+.app-stats dt{color:var(--c-muted)}
+.app-stats dd{font-weight:700;text-align:right}
+.app-stats.compact dd{font-weight:600;max-width:16rem;overflow-wrap:anywhere}
+
+@keyframes spin{to{transform:rotate(360deg)}}
+
+@media(max-width:900px){
+  .app-welcome-bar{grid-template-columns:1fr;grid-template-rows:auto auto auto}
+  .app-welcome-actions{grid-column:1;grid-row:2}
+  .app-welcome-stats{grid-column:1;grid-row:3;grid-template-columns:repeat(2,minmax(0,1fr))}
+  .app-evidence-two-col{grid-template-columns:1fr}
+  .app-evidence-status-row{grid-template-columns:1fr}
+  .app-lens-board{grid-template-columns:1fr}
+  .app-brief-grid{grid-template-columns:1fr}
+  .app-workflow-stage{grid-template-columns:1fr}
+  .app-workflow-rail{opacity:1;transform:none;cursor:default}
+  .app-preflight-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .app-run-detail-grid{grid-template-columns:1fr}
+  .app-support-grid{grid-template-columns:1fr}
+}
+
+@media(max-width:640px){
+  .app-panel,.app-card{padding:20px}
+  .app-welcome-bar{padding:12px 14px}
+  .app-welcome-identity h2,.app-panel h2{font-size:1.5rem}
+  .app-evidence-primary .app-evidence-map-wrap{height:240px}
+  .app-utility-strip{grid-template-columns:1fr}
+  .app-chip-row,.app-action-stack{flex-direction:column;align-items:stretch}
+  .app-preflight-header{flex-direction:column}
+  .app-preflight-grid{grid-template-columns:1fr}
+  .app-select-row{flex-direction:column;align-items:stretch}
+}

--- a/website/css/shared.css
+++ b/website/css/shared.css
@@ -35,13 +35,14 @@ a:hover{text-decoration:underline}
 
 /* --- Nav --- */
 nav{position:sticky;top:0;z-index:1000;background:rgba(12,17,23,.85);backdrop-filter:blur(12px);border-bottom:1px solid var(--c-border);padding:12px 0}
-nav .container{display:flex;align-items:center;gap:16px}
+nav .container{display:flex;align-items:center;gap:24px}
 nav .logo{font-weight:700;font-size:1.25rem;display:flex;align-items:center;gap:8px;flex-shrink:0;text-decoration:none;color:var(--c-text)}
 nav .logo:hover{text-decoration:none}
 nav .logo svg{width:24px;height:24px;fill:var(--c-accent)}
 nav ul{list-style:none;display:flex;gap:20px;margin:0 auto;flex-wrap:wrap;justify-content:center}
-nav ul a{color:var(--c-muted);font-size:.875rem;transition:color .15s}
-nav ul a:hover{color:var(--c-text);text-decoration:none}
+nav ul a{color:var(--c-muted);font-size:.875rem;transition:color .15s;padding:6px 14px;border-radius:var(--radius) var(--radius) 0 0;border:1px solid transparent;border-bottom:none;margin-bottom:-13px;padding-bottom:13px}
+nav ul a:hover{color:var(--c-text);text-decoration:none;background:rgba(88,166,255,.06)}
+nav ul a[aria-current="page"]{color:var(--c-text);background:var(--c-surface);border-color:var(--c-border);font-weight:600}
 
 @media(max-width:860px){
   nav ul{gap:12px}
@@ -71,7 +72,7 @@ nav ul a:hover{color:var(--c-text);text-decoration:none}
 footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;color:var(--c-muted);font-size:.8rem}
 
 /* --- Auth Area (nav) --- */
-.auth-area{display:flex;align-items:center;gap:10px;flex-shrink:0}
+.auth-area{display:flex;align-items:center;gap:14px;flex-shrink:0}
 .auth-btn{padding:6px 16px;border-radius:var(--radius);font-size:.8rem;font-weight:600;cursor:pointer;border:1px solid var(--c-accent);background:transparent;color:var(--c-accent);transition:all .15s;white-space:nowrap;text-decoration:none;display:inline-block}
 .auth-btn:hover{background:rgba(88,166,255,.15);text-decoration:none}
 .auth-btn.primary{background:var(--c-accent);color:#fff;border-color:var(--c-accent)}

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -48,6 +48,10 @@ section:nth-child(even){background:var(--c-surface)}
 #timelapse-header .layer-toggle{margin-left:auto;flex-shrink:0}
 .demo-layout.timelapse-active #map{height:520px}
 .demo-form{background:var(--c-bg);border:1px solid var(--c-border);border-radius:var(--radius);padding:24px}
+.demo-bounds{margin-bottom:16px;padding:12px 14px;border:1px solid rgba(240,136,62,.28);border-radius:var(--radius);background:rgba(240,136,62,.08)}
+.demo-bounds-label{font-size:.72rem;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--c-orange);margin-bottom:6px}
+.demo-bounds ul{list-style:disc;padding-left:18px;color:var(--c-muted);font-size:.76rem;line-height:1.55}
+.demo-bounds li+li{margin-top:4px}
 label{display:block;font-size:.875rem;font-weight:500;margin-bottom:4px}
 input[type=email],textarea,input[type=text],select{width:100%;padding:10px 12px;background:var(--c-surface);border:1px solid var(--c-border);border-radius:var(--radius);color:var(--c-text);font-size:.875rem;font-family:inherit;margin-bottom:16px;resize:vertical}
 input:focus,textarea:focus,select:focus{outline:none;border-color:var(--c-accent)}
@@ -133,6 +137,16 @@ textarea{min-height:120px;font-family:monospace;font-size:.8rem}
 /* --- AI Insights panel --- */
 #ai-insights-panel{background:var(--c-surface);border:1px solid var(--c-border);border-radius:var(--radius);padding:14px 16px;display:none}
 #ai-insights-panel h4{font-size:.8rem;margin-bottom:8px;color:var(--c-text)}
+.ai-plan-note{font-size:.72rem;color:var(--c-muted);margin-bottom:12px;line-height:1.5}
+
+/* --- Demo conversion prompt --- */
+.demo-conversion-prompt[hidden]{display:none}
+.demo-conversion-prompt{margin-top:16px}
+.demo-conversion-inner{padding:16px 18px;background:linear-gradient(135deg,rgba(63,185,80,.08),rgba(88,166,255,.06));border:1px solid rgba(63,185,80,.22);border-radius:var(--radius)}
+.demo-conversion-inner h4{font-size:.92rem;margin-bottom:6px;color:var(--c-text)}
+.demo-conversion-inner p{font-size:.8rem;color:var(--c-muted);line-height:1.6;margin-bottom:12px}
+.demo-conversion-actions{display:flex;gap:8px;flex-wrap:wrap}
+
 #ai-insights-content{background:rgba(88,166,255,.08);border:1px solid rgba(88,166,255,.2);border-radius:4px;padding:10px;font-size:.75rem;line-height:1.5;color:var(--c-text)}
 #ai-insights-content .observation{margin-bottom:10px;padding-bottom:10px;border-bottom:1px solid rgba(88,166,255,.1)}
 #ai-insights-content .observation:last-child{border-bottom:none;margin-bottom:0;padding-bottom:0}
@@ -147,6 +161,7 @@ textarea{min-height:120px;font-family:monospace;font-size:.8rem}
 #ai-insights-content .obs-recommendation{font-size:.7rem;color:var(--c-muted);font-style:italic}
 #ai-insights-summary{font-size:.75rem;color:var(--c-muted);margin:8px 0;padding:8px;background:rgba(139,148,158,.05);border-radius:4px}
 #btn-get-ai-insights:hover{background:#79c0ff;text-decoration:none}
+#btn-get-ai-insights[disabled]{background:rgba(139,148,158,.35)!important;color:var(--c-muted)!important;cursor:not-allowed}
 
 /* --- NDVI trend chart --- */
 #ndvi-trend-panel{background:var(--c-surface);border:1px solid var(--c-border);border-radius:var(--radius);padding:14px 16px;display:none}
@@ -264,4 +279,6 @@ footer{padding:32px 0;border-top:1px solid var(--c-border);text-align:center;col
 /* --- Auth UI (base in shared.css, modifiers here) --- */
 .auth-user{font-size:.8rem;color:var(--c-muted);max-width:140px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .login-prompt{background:rgba(88,166,255,.08);border:1px solid rgba(88,166,255,.2);border-radius:var(--radius);padding:12px 16px;margin-bottom:12px;font-size:.85rem;color:var(--c-muted);text-align:center;display:none}
-.login-prompt a{cursor:pointer;font-weight:600}
+.login-prompt .login-prompt-link{appearance:none;background:none;border:none;color:var(--c-accent);cursor:pointer;font:inherit;font-weight:600;padding:0;text-decoration:underline;text-underline-offset:2px}
+.login-prompt .login-prompt-link:hover{color:#79c0ff}
+.login-prompt .login-prompt-link:focus-visible{outline:2px solid rgba(88,166,255,.55);outline-offset:2px;border-radius:2px}

--- a/website/index.html
+++ b/website/index.html
@@ -123,7 +123,16 @@
           <div class="drop-divider">— or paste KML text —</div>
           <label for="demo-kml">KML Content</label>
           <textarea id="demo-kml" placeholder="Paste your KML content here, or use the sample below…"></textarea>
-          <div class="login-prompt" id="login-prompt">� <a id="login-prompt-link">Sign in</a> to process your KML and get satellite imagery, NDVI analysis, and weather data — free.</div>
+          <div class="demo-bounds" id="demo-bounds">
+            <div class="demo-bounds-label">Public Demo Limits</div>
+            <ul>
+              <li>Max 3 AOIs per run</li>
+              <li>Max 10,000 hectares per AOI</li>
+              <li>No saved history, exports, or bulk workflow</li>
+              <li>AI timelapse analysis is reserved for paid plans in the signed-in app</li>
+            </ul>
+          </div>
+          <div class="login-prompt" id="login-prompt"><button type="button" class="login-prompt-link" id="login-prompt-link">Sign in</button> to run the public demo. Paid plans unlock AI analysis, higher limits, and the dedicated app workspace.</div>
           <button class="btn btn-primary" id="demo-submit" style="width:100%">Process KML</button>
           <p style="font-size:.7rem;color:var(--c-muted);text-align:center;margin-top:8px">Your data is automatically deleted after 30 days. <a href="/privacy.html">Privacy Policy</a></p>
           <div id="demo-status" class="demo-status"></div>
@@ -213,16 +222,28 @@
         </div>
         <div id="ai-insights-panel" style="display:none">
           <h3>🤖 AI Analysis</h3>
+          <p class="ai-plan-note" id="ai-insights-plan-note">AI analysis is disabled on the public demo and free accounts. Starter and above unlock it in the signed-in workspace.</p>
           <div id="ai-insights-example" style="font-size:.8rem;margin-bottom:12px;padding:10px;background:rgba(100,200,255,.07);border:1px solid var(--c-border);border-radius:var(--radius);color:var(--c-muted)">
             <p style="margin-bottom:6px;color:var(--c-text);font-weight:600">Example AI Analysis Output</p>
             <p style="margin-bottom:6px">"NDVI declined steadily from 0.72 to 0.58 between March–August 2024. This coincides with a 34% below-average rainfall period (Open-Meteo). The vegetation stress pattern is consistent with drought-induced canopy thinning rather than land-use change, as the decline is gradual and spatially uniform across the AOI."</p>
             <p style="font-size:.75rem;color:var(--c-muted);font-style:italic">Powered by LLM analysis of NDVI trends + weather data. Not a trained computer vision model.</p>
           </div>
-          <button id="btn-get-ai-insights" type="button" style="margin-bottom:12px;padding:8px 14px;background:var(--c-accent);color:#fff;border:none;border-radius:var(--radius);cursor:pointer;font-size:.8rem;width:100%;">Get AI Analysis for Timelapse</button>
+          <button id="btn-get-ai-insights" type="button" style="margin-bottom:12px;padding:8px 14px;background:var(--c-accent);color:#fff;border:none;border-radius:var(--radius);cursor:pointer;font-size:.8rem;width:100%;" disabled aria-disabled="true">AI Analysis Available on Paid Plans</button>
           <div id="ai-insights-summary" style="display:none;font-size:.8rem;margin-bottom:12px;padding:8px;background:rgba(100,200,255,.1);border-radius:var(--radius)"></div>
           <div id="ai-insights-content" style="display:none;font-size:.8rem"></div>
           <div id="ai-insights-loading" style="display:none;font-size:.8rem;color:var(--c-muted)">Analyzing timelapse with AI...</div>
           <div id="ai-insights-error" style="display:none;font-size:.8rem;color:var(--c-red);background:rgba(248,81,73,.1);padding:8px;border-radius:var(--radius)"></div>
+        </div>
+        <div id="demo-conversion-prompt" class="demo-conversion-prompt" hidden>
+          <div class="demo-conversion-inner">
+            <h4>Ready for more?</h4>
+            <p>The public demo shows what TreeSight can do with a single run. Upgrade to unlock AI analysis, higher limits, saved history, and GeoJSON/CSV/PDF exports in your dedicated workspace.</p>
+            <div class="demo-conversion-actions">
+              <a class="btn btn-primary" href="#pricing">View Plans</a>
+              <a class="btn btn-secondary" href="/app/">Go to Workspace</a>
+              <button class="btn btn-secondary" id="demo-conversion-dismiss" type="button">Dismiss</button>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -1,0 +1,2854 @@
+(function(){
+  'use strict';
+
+  const POST_LOGIN_DESTINATION_KEY = 'treesight-post-login';
+  const CIAM_TENANT_NAME = 'treesightauth';
+  const CIAM_TENANT_DOMAIN = CIAM_TENANT_NAME ? CIAM_TENANT_NAME + '.onmicrosoft.com' : '';
+  const CIAM_CLIENT_ID = '6e2abd0a-61a4-41a5-bdb5-7e1c91471fc6';
+  const CIAM_AUTHORITY = CIAM_TENANT_NAME
+    ? 'https://' + CIAM_TENANT_NAME + '.ciamlogin.com/' + CIAM_TENANT_DOMAIN + '/'
+    : '';
+  const CIAM_KNOWN_AUTHORITY = CIAM_TENANT_NAME
+    ? CIAM_TENANT_NAME + '.ciamlogin.com'
+    : '';
+  const CIAM_SCOPES = CIAM_CLIENT_ID ? ['openid', 'profile'] : [];
+  const IDENTITY_ONLY_SCOPES = ['openid', 'profile', 'email', 'offline_access'];
+  const WORKSPACE_ROLE_STORAGE_KEY = 'treesight-workspace-role';
+  const WORKSPACE_PREFERENCE_STORAGE_KEY = 'treesight-workspace-preference';
+  const WORKSPACE_ROLES = {
+    conservation: {
+      label: 'Conservation',
+      tag: 'Field evidence',
+      title: 'Conservation monitoring',
+      summary: 'Built for protected-area coordinators who need rapid, plain-English evidence they can take to rangers, directors, or donors.',
+      outcome: 'Evidence packs',
+      risk: 'No silent fallback',
+      rhythm: 'Monthly watchlist',
+      historyCopy: 'Keep the most recent incident visible while you compare new reports against what already ran.',
+      runCopy: 'Queue a real signed-in analysis for a protected area or reported clearing, not the public demo.',
+      contentCopy: 'Use this rail to understand what evidence is being assembled and what will be ready for a field or donor brief.',
+      runLensTitle: 'Conservation evidence run',
+      runLensNote: 'Frame this run around vegetation change, weather context, and plain-English proof.',
+      readyNote: 'Launch a signed-in conservation evidence run from this workspace.',
+      emptyHistoryNote: 'Your next signed-in submission becomes the first item in the field evidence queue.',
+      activeHistoryContext: 'field evidence',
+      completedHistoryOutcome: 'shareable evidence brief',
+      activePath: 'Tracking evidence build',
+      completedPath: 'Prepare evidence brief',
+      runLabel: 'Start evidence run',
+      reviewLabel: 'Review latest incident',
+      deliverableLabel: 'Open evidence rail',
+      emptyContent: {
+        imageryTitle: 'Waiting for a run',
+        imageryNote: 'Before/after imagery and NDVI layers will appear here as the evidence stack forms.',
+        enrichmentTitle: 'Context pending',
+        enrichmentNote: 'Weather and narrative context will follow once the imagery pipeline is stable.',
+        exportsTitle: 'Evidence pack next',
+        exportsNote: 'Saved maps, narrative, and donor-ready exports will land here once run detail is wired.'
+      },
+      completedContent: {
+        exportsTitle: 'Evidence pack next',
+        exportsNote: 'The next signed-in slice should reopen this run into maps, narrative, and a field-ready evidence pack.'
+      }
+    },
+    eudr: {
+      label: 'EUDR',
+      tag: 'Audit trail',
+      title: 'EUDR due diligence',
+      summary: 'Support compliance teams that need post-2020 evidence, clear audit language, and no ambiguity about what the product actually processed.',
+      outcome: 'Due diligence dossier',
+      risk: 'Audit-ready trust',
+      rhythm: 'Quarterly refresh cadence',
+      historyCopy: 'Keep the most recent assessment visible while you decide whether another supplier plot needs review.',
+      runCopy: 'Queue a real signed-in due diligence run with explicit product-path status, not demo behavior.',
+      contentCopy: 'Use this rail to understand what audit evidence is forming before it becomes a saved due diligence dossier.',
+      runLensTitle: 'Due diligence evidence run',
+      runLensNote: 'Keep baseline integrity, plain-English findings, and product-path reliability front and center.',
+      readyNote: 'Launch a signed-in due diligence run from this workspace.',
+      emptyHistoryNote: 'Your next signed-in submission becomes the first item in the due diligence queue.',
+      activeHistoryContext: 'audit context',
+      completedHistoryOutcome: 'due diligence dossier',
+      activePath: 'Tracking audit evidence',
+      completedPath: 'Prepare audit dossier',
+      runLabel: 'Start due diligence run',
+      reviewLabel: 'Review latest assessment',
+      deliverableLabel: 'Open dossier rail',
+      emptyContent: {
+        imageryTitle: 'Awaiting baseline review',
+        imageryNote: 'Before/after imagery will anchor the post-2020 evidence trail once you queue a run.',
+        enrichmentTitle: 'Assessment pending',
+        enrichmentNote: 'Narrative findings and methodology framing follow after imagery is stable.',
+        exportsTitle: 'Audit dossier next',
+        exportsNote: 'Saved evidence packages with coordinates, methods, and narrative will land here once run detail is wired.'
+      },
+      completedContent: {
+        exportsTitle: 'Audit dossier next',
+        exportsNote: 'The next signed-in slice should reopen this run with coordinates, methods, and exportable due diligence evidence.'
+      }
+    },
+    portfolio: {
+      label: 'Portfolio Ops',
+      tag: 'Batch triage',
+      title: 'Portfolio operations',
+      summary: 'Support advisors, insurers, and ops teams who need to scan many parcels quickly, keep batch context visible, and decide what needs follow-up.',
+      outcome: 'Batch triage',
+      risk: 'Scale without guesswork',
+      rhythm: 'Event-driven review',
+      historyCopy: 'Keep the most recent batch visible so you can triage new uploads against what already moved.',
+      runCopy: 'Queue a signed-in batch-style analysis and keep scale warnings visible instead of inheriting demo guardrails.',
+      contentCopy: 'Use this rail to understand what the current run is building before you reopen it as a parcel-level review.',
+      runLensTitle: 'Portfolio triage run',
+      runLensNote: 'Bias the workspace toward batch readiness, AOI spread, and which runs need deeper follow-up.',
+      readyNote: 'Launch a signed-in portfolio triage run from this workspace.',
+      emptyHistoryNote: 'Your next signed-in submission becomes the first item in the batch review queue.',
+      activeHistoryContext: 'batch context',
+      completedHistoryOutcome: 'triage summary',
+      activePath: 'Tracking batch progress',
+      completedPath: 'Open triage summary',
+      runLabel: 'Start batch triage run',
+      reviewLabel: 'Review latest batch',
+      deliverableLabel: 'Open triage rail',
+      emptyContent: {
+        imageryTitle: 'Awaiting parcel stack',
+        imageryNote: 'Imagery layers will appear here as batch-ready AOIs begin resolving into usable review outputs.',
+        enrichmentTitle: 'Triage context pending',
+        enrichmentNote: 'Context layers follow once the imagery stack shows where deeper review is needed.',
+        exportsTitle: 'Triage summary next',
+        exportsNote: 'Saved parcel review packs and export actions will land here once run detail is wired.'
+      },
+      completedContent: {
+        exportsTitle: 'Triage summary next',
+        exportsNote: 'The next signed-in slice should reopen this run into parcel-level review and export actions.'
+      }
+    }
+  };
+  const WORKSPACE_PREFERENCES = {
+    investigate: {
+      label: 'Investigate',
+      tag: 'Run-first',
+      title: 'Investigate suspicious change',
+      summary: 'Stay centered on the live run while you prove what changed, why it changed, and what to do next.',
+      deliverable: 'Operator brief',
+      stance: 'Prove the change before escalation',
+      focusLabel: 'Run rail',
+      focusTarget: 'run',
+      primaryTarget: 'run',
+      secondaryTarget: 'history'
+    },
+    monitor: {
+      label: 'Monitor',
+      tag: 'Queue-first',
+      title: 'Monitor for movement over time',
+      summary: 'Bias the workspace toward what changed recently so recurring reviews and follow-up runs stay efficient.',
+      deliverable: 'Monitoring cadence',
+      stance: 'Spot movement early and repeat',
+      focusLabel: 'History rail',
+      focusTarget: 'history',
+      primaryTarget: 'history',
+      secondaryTarget: 'run'
+    },
+    report: {
+      label: 'Report',
+      tag: 'Deliverable-first',
+      title: 'Package findings for action',
+      summary: 'Bias the workspace toward outputs, evidence language, and what the next saved surface needs to deliver.',
+      deliverable: 'Decision packet',
+      stance: 'Translate signal into action',
+      focusLabel: 'Content rail',
+      focusTarget: 'content',
+      primaryTarget: 'content',
+      secondaryTarget: 'run'
+    }
+  };
+
+  var apiBase = '';
+  var apiDiscoveryReady = null;
+  var msalInstance = null;
+  var currentAccount = null;
+  var accessToken = null;
+  var latestBillingStatus = null;
+  var latestAnalysisRun = null;
+  var analysisHistoryRuns = [];
+  var analysisHistoryLoaded = false;
+  var selectedAnalysisRunId = null;
+  var analysisDraftSummary = null;
+  var workspaceRole = 'conservation';
+  var workspacePreference = 'investigate';
+  var activeAnalysisPoll = null;
+  var ANALYSIS_PHASES = ['submit', 'ingestion', 'acquisition', 'fulfilment', 'enrichment', 'complete'];
+  var ANALYSIS_PHASE_DETAILS = {
+    submit: 'Uploading your KML and reserving a pipeline worker for this run.',
+    ingestion: 'Parsing the file, validating AOI geometry, and preparing the analysis package.',
+    acquisition: 'Searching NAIP and Sentinel-2 coverage to find the best imagery for each AOI.',
+    fulfilment: 'Downloading scenes, clipping to your AOIs, and reprojecting them into the output stack.',
+    enrichment: 'Adding NDVI, weather context, and cached artifacts so the workspace has richer outputs ready.',
+    complete: 'Analysis completed. Use history to reopen this run or resume another active submission from this workspace.'
+  };
+
+  function authEnabled() { return !!(CIAM_TENANT_NAME && CIAM_CLIENT_ID && typeof msal !== 'undefined'); }
+
+  function rememberPostLoginDestination() {
+    try { sessionStorage.setItem(POST_LOGIN_DESTINATION_KEY, 'app'); } catch { /* ignore */ }
+  }
+
+  function setServiceStatus(text, className) {
+    var badge = document.getElementById('status-badge');
+    if (!badge) return;
+    badge.textContent = text;
+    badge.className = className || '';
+  }
+
+  function runningOnLocalDevOrigin() {
+    return window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+  }
+
+  function ciamRedirectOrigin() {
+    return runningOnLocalDevOrigin() ? 'http://localhost:4280' : window.location.origin;
+  }
+
+  function localLoginTransitionUrl() {
+    var url = new URL(window.location.href);
+    url.protocol = 'http:';
+    url.hostname = 'localhost';
+    url.port = '4280';
+    url.searchParams.set('localLogin', '1');
+    return url.toString();
+  }
+
+  function consumeLocalLoginRequest() {
+    try {
+      var url = new URL(window.location.href);
+      if (url.searchParams.get('localLogin') !== '1') return false;
+      url.searchParams.delete('localLogin');
+      var nextUrl = url.pathname + (url.search || '') + (url.hash || '');
+      window.history.replaceState({}, '', nextUrl || '/app/');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async function discoverApiBase() {
+    if (runningOnLocalDevOrigin()) {
+      try {
+        var localRes = await fetch('/api/health');
+        if (localRes.ok) {
+          apiBase = '';
+          setServiceStatus('Online', 'online');
+          return;
+        }
+      } catch { /* local proxy unavailable */ }
+    }
+
+    try {
+      var cfgRes = await fetch('/api-config.json');
+      if (cfgRes.ok) {
+        var cfg = await cfgRes.json();
+        if (cfg.apiBase && cfg.apiBase !== 'http://localhost:7071') {
+          apiBase = cfg.apiBase;
+          setServiceStatus('Verified', 'verified');
+          fetch(cfg.apiBase + '/api/health').then(function(resp) {
+            if (resp.ok) setServiceStatus('Online', 'online');
+          }).catch(function() { /* verified is enough */ });
+          return;
+        }
+        if (cfg.apiBase) {
+          try {
+            var probe = await fetch(cfg.apiBase + '/api/health');
+            if (probe.ok) {
+              apiBase = cfg.apiBase;
+              setServiceStatus('Online', 'online');
+              return;
+            }
+          } catch { /* fall through */ }
+        }
+      }
+    } catch { /* fall through */ }
+
+    try {
+      var res = await fetch('/api/health');
+      if (res.ok) {
+        apiBase = '';
+        setServiceStatus('Online', 'online');
+        return;
+      }
+    } catch { /* ignore */ }
+
+    setServiceStatus('Unavailable', 'offline');
+  }
+
+  function login() {
+    if (window.location.hostname === '127.0.0.1') {
+      window.location.replace(localLoginTransitionUrl());
+      return;
+    }
+    if (!msalInstance) return;
+    rememberPostLoginDestination();
+    msalInstance.loginRedirect({ scopes: CIAM_SCOPES });
+  }
+
+  function logout() {
+    if (!msalInstance) return;
+    try { sessionStorage.removeItem(POST_LOGIN_DESTINATION_KEY); } catch { /* ignore */ }
+    msalInstance.logoutRedirect({ account: currentAccount });
+  }
+
+  function parseJwtPayload(token) {
+    if (!token) return null;
+    try {
+      var parts = token.split('.');
+      if (parts.length < 2) return null;
+      return JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
+    } catch {
+      return null;
+    }
+  }
+
+  function tokenExpired(token, skewSeconds) {
+    var payload = parseJwtPayload(token);
+    if (!payload || !payload.exp) return false;
+    return payload.exp <= Math.floor(Date.now() / 1000) + (skewSeconds || 0);
+  }
+
+  function shouldUseIdTokenForApi(resp) {
+    if (!resp || !resp.accessToken || !resp.idToken) return false;
+    var payload = parseJwtPayload(resp.accessToken);
+    if (!payload) return false;
+    var scopes = String(payload.scp || '').split(/\s+/).filter(Boolean);
+    if (String(payload.aud || '') === '00000003-0000-0000-c000-000000000000') return true;
+    return scopes.length > 0 && scopes.every(function(scope) {
+      return IDENTITY_ONLY_SCOPES.indexOf(scope) > -1;
+    });
+  }
+
+  function selectApiBearerToken(resp) {
+    if (!resp) return null;
+    if (shouldUseIdTokenForApi(resp)) return resp.idToken;
+    return resp.accessToken || resp.idToken || null;
+  }
+
+  async function acquireToken() {
+    if (!msalInstance || !currentAccount) return null;
+    try {
+      var resp = await msalInstance.acquireTokenSilent({ scopes: CIAM_SCOPES, account: currentAccount });
+      if (shouldUseIdTokenForApi(resp) && tokenExpired(resp.idToken, 60)) {
+        resp = await msalInstance.acquireTokenSilent({ scopes: CIAM_SCOPES, account: currentAccount, forceRefresh: true });
+      }
+      accessToken = selectApiBearerToken(resp);
+      return accessToken;
+    } catch {
+      try {
+        rememberPostLoginDestination();
+        msalInstance.acquireTokenRedirect({ scopes: CIAM_SCOPES });
+      } catch { /* redirect will navigate away */ }
+      return null;
+    }
+  }
+
+  async function apiFetch(path, opts) {
+    opts = opts || {};
+    opts.headers = opts.headers || {};
+    if (currentAccount && authEnabled()) {
+      var token = accessToken;
+      if (!token || tokenExpired(token, 60)) token = await acquireToken();
+      if (token) opts.headers.Authorization = 'Bearer ' + token;
+    }
+    try { return await fetch(apiBase + path, opts); } catch { return null; }
+  }
+
+  function setAnalysisStatus(message, tone) {
+    var status = document.getElementById('app-analysis-status');
+    if (!status) return;
+    if (!message) {
+      status.hidden = true;
+      status.textContent = '';
+      status.removeAttribute('data-tone');
+      return;
+    }
+    status.hidden = false;
+    status.textContent = message;
+    status.setAttribute('data-tone', tone || 'info');
+  }
+
+  function setHeroRunSummary(title, note) {
+    var titleEl = document.getElementById('app-hero-active-run');
+    var noteEl = document.getElementById('app-hero-active-run-note');
+    if (!titleEl || !noteEl) return;
+    titleEl.textContent = title || 'Ready to queue';
+    noteEl.textContent = note || 'Launch a signed-in analysis from this workspace.';
+  }
+
+  function setWorkflowFocus(focus) {
+    var stage = document.getElementById('app-workflow-stage');
+    if (!stage || !focus) return;
+    // Evidence is now in its own hero section — map 'content' to scroll there
+    if (focus === 'content') {
+      var hero = document.getElementById('app-evidence-hero');
+      if (hero) hero.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      stage.setAttribute('data-focus', 'run');
+    } else {
+      stage.setAttribute('data-focus', focus);
+    }
+    if (selectedAnalysisRunId) updateRunSelectionLocation(selectedAnalysisRunId, focus);
+  }
+
+  function readRunSelectionFromLocation() {
+    try {
+      var params = new URLSearchParams(window.location.search || '');
+      return {
+        instanceId: params.get('run') || '',
+        focus: params.get('focus') || ''
+      };
+    } catch {
+      return { instanceId: '', focus: '' };
+    }
+  }
+
+  function selectedRunPermalink(instanceId, focus) {
+    try {
+      var url = new URL(window.location.href);
+      if (instanceId) {
+        url.searchParams.set('run', instanceId);
+      } else {
+        url.searchParams.delete('run');
+      }
+      if (focus) {
+        url.searchParams.set('focus', focus);
+      } else {
+        url.searchParams.delete('focus');
+      }
+      var nextPath = url.pathname;
+      var nextSearch = url.searchParams.toString();
+      return nextSearch ? nextPath + '?' + nextSearch : nextPath;
+    } catch {
+      return '/app/';
+    }
+  }
+
+  function updateRunSelectionLocation(instanceId, focus) {
+    if (!window.history || typeof window.history.replaceState !== 'function') return;
+    try {
+      window.history.replaceState({}, '', selectedRunPermalink(instanceId, focus));
+    } catch { /* ignore */ }
+  }
+
+  function readStoredUiValue(key) {
+    try { return localStorage.getItem(key); } catch { return null; }
+  }
+
+  function storeUiValue(key, value) {
+    try { localStorage.setItem(key, value); } catch { /* ignore */ }
+  }
+
+  function currentRoleConfig() {
+    return WORKSPACE_ROLES[workspaceRole] || WORKSPACE_ROLES.conservation;
+  }
+
+  function currentPreferenceConfig() {
+    return WORKSPACE_PREFERENCES[workspacePreference] || WORKSPACE_PREFERENCES.investigate;
+  }
+
+  function actionLabelForTarget(target) {
+    var role = currentRoleConfig();
+    if (target === 'history') return role.reviewLabel;
+    if (target === 'content') return role.deliverableLabel;
+    return role.runLabel;
+  }
+
+  function revealWorkflowTarget(target) {
+    var cardId = target === 'history'
+      ? 'app-history-card'
+      : target === 'content'
+        ? 'app-content-card'
+        : 'app-analysis-card';
+    setWorkflowFocus(target || 'run');
+    var card = document.getElementById(cardId);
+    if (card) card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  function renderWorkspaceGuidance() {
+    var role = currentRoleConfig();
+    var preference = currentPreferenceConfig();
+    var dashboard = document.getElementById('app-dashboard');
+    if (dashboard) {
+      dashboard.setAttribute('data-role', workspaceRole);
+      dashboard.setAttribute('data-preference', workspacePreference);
+    }
+
+    document.querySelectorAll('[data-role-choice]').forEach(function(button) {
+      button.setAttribute('aria-pressed', button.getAttribute('data-role-choice') === workspaceRole ? 'true' : 'false');
+    });
+    document.querySelectorAll('[data-preference-choice]').forEach(function(button) {
+      button.setAttribute('aria-pressed', button.getAttribute('data-preference-choice') === workspacePreference ? 'true' : 'false');
+    });
+
+    document.getElementById('app-role-title').textContent = role.title;
+    document.getElementById('app-role-tag').textContent = role.tag;
+    document.getElementById('app-role-summary').textContent = role.summary;
+    document.getElementById('app-role-outcome').textContent = role.outcome;
+    document.getElementById('app-role-risk').textContent = role.risk;
+    document.getElementById('app-role-rhythm').textContent = role.rhythm;
+
+    document.getElementById('app-preference-title').textContent = preference.title;
+    document.getElementById('app-preference-tag').textContent = preference.tag;
+    document.getElementById('app-preference-summary').textContent = preference.summary;
+    document.getElementById('app-guided-deliverable').textContent = preference.deliverable;
+    document.getElementById('app-guided-stance').textContent = preference.stance;
+    document.getElementById('app-guided-focus').textContent = preference.focusLabel;
+
+    var primaryButton = document.getElementById('app-guided-primary-btn');
+    var secondaryButton = document.getElementById('app-guided-secondary-btn');
+    primaryButton.textContent = actionLabelForTarget(preference.primaryTarget);
+    primaryButton.setAttribute('data-target', preference.primaryTarget);
+    secondaryButton.textContent = actionLabelForTarget(preference.secondaryTarget);
+    secondaryButton.setAttribute('data-target', preference.secondaryTarget);
+
+    document.getElementById('app-history-copy').textContent = role.historyCopy;
+    document.getElementById('app-run-copy').textContent = role.runCopy;
+    document.getElementById('app-content-copy').textContent = role.contentCopy;
+    document.getElementById('app-analysis-lens-title').textContent = role.runLensTitle;
+    document.getElementById('app-analysis-lens-note').textContent = role.runLensNote + ' ' + preference.summary;
+
+    if (!latestAnalysisRun) {
+      if (!analysisHistoryLoaded && currentAccount) {
+        setHeroRunSummary('Checking recent runs', 'Restoring signed-in history and active run state.');
+      } else {
+        setHeroRunSummary('Ready to queue', role.readyNote);
+      }
+    }
+    if (latestBillingStatus) updateHeroSummary(latestBillingStatus);
+    updateHistorySummary(latestAnalysisRun);
+    renderAnalysisHistoryList();
+    updateContentSummary(latestAnalysisRun);
+    var draftTextarea = document.getElementById('app-analysis-kml');
+    updateAnalysisPreflight(draftTextarea ? draftTextarea.value : '');
+  }
+
+  function setWorkspaceRole(roleKey, options) {
+    if (!WORKSPACE_ROLES[roleKey]) return;
+    workspaceRole = roleKey;
+    if (!options || options.persist !== false) storeUiValue(WORKSPACE_ROLE_STORAGE_KEY, roleKey);
+    renderWorkspaceGuidance();
+    if (!options || options.alignFocus !== false) setWorkflowFocus(currentPreferenceConfig().focusTarget);
+  }
+
+  function setWorkspacePreference(preferenceKey, options) {
+    if (!WORKSPACE_PREFERENCES[preferenceKey]) return;
+    workspacePreference = preferenceKey;
+    if (!options || options.persist !== false) storeUiValue(WORKSPACE_PREFERENCE_STORAGE_KEY, preferenceKey);
+    renderWorkspaceGuidance();
+    if (!options || options.alignFocus !== false) setWorkflowFocus(currentPreferenceConfig().focusTarget);
+  }
+
+  function displayAnalysisPhase(customStatus, runtimeStatus) {
+    if (runtimeStatus === 'Completed') return 'complete';
+    return (customStatus && customStatus.phase) || 'queued';
+  }
+
+  function parseStatusTimestamp(value) {
+    if (!value) return null;
+    var normalized = String(value).replace(' ', 'T');
+    var parsed = Date.parse(normalized);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  function formatRelativeDuration(ms) {
+    if (ms == null || ms < 0) return null;
+    var totalSeconds = Math.round(ms / 1000);
+    if (totalSeconds < 60) return totalSeconds + 's';
+    var minutes = Math.floor(totalSeconds / 60);
+    var seconds = totalSeconds % 60;
+    if (minutes < 60) return minutes + 'm' + (seconds >= 5 ? ' ' + seconds + 's' : '');
+    var hours = Math.floor(minutes / 60);
+    var remainingMinutes = minutes % 60;
+    return hours + 'h' + (remainingMinutes ? ' ' + remainingMinutes + 'm' : '');
+  }
+
+  function summarizeRunTiming(data) {
+    var createdMs = parseStatusTimestamp(data && data.createdTime);
+    var updatedMs = parseStatusTimestamp(data && data.lastUpdatedTime);
+    var now = Date.now();
+    return {
+      elapsed: createdMs ? formatRelativeDuration(now - createdMs) : null,
+      sinceUpdate: updatedMs ? formatRelativeDuration(now - updatedMs) : null,
+      stale: updatedMs ? (now - updatedMs) >= 90000 : false,
+    };
+  }
+
+  function capabilityHeadline(caps) {
+    var parts = [];
+    if (caps.ai_insights) parts.push('AI insights');
+    if (caps.api_access) parts.push('API ready');
+    if (caps.concurrency && caps.concurrency > 1) parts.push(String(caps.concurrency) + ' concurrent runs');
+    if (!parts.length) return 'Core analysis workspace';
+    return parts.slice(0, 2).join(' + ');
+  }
+
+  function updateHeroSummary(data) {
+    var role = currentRoleConfig();
+    var preference = currentPreferenceConfig();
+    var caps = data.capabilities || {};
+    var planEl = document.getElementById('app-hero-plan');
+    var planNoteEl = document.getElementById('app-hero-plan-note');
+    var runsEl = document.getElementById('app-hero-runs');
+    var runsNoteEl = document.getElementById('app-hero-runs-note');
+    var modeEl = document.getElementById('app-hero-mode');
+    var modeNoteEl = document.getElementById('app-hero-mode-note');
+    if (!planEl || !planNoteEl || !runsEl || !runsNoteEl || !modeEl || !modeNoteEl) return;
+
+    planEl.textContent = (caps.label || data.tier || 'Free') + (data.tier_source === 'emulated' ? ' (emulated)' : '');
+    planNoteEl.textContent = data.tier_source === 'emulated'
+      ? 'Local override for product testing.'
+      : 'Driven by the signed-in account state.';
+    runsEl.textContent = data.runs_remaining == null ? '—' : String(data.runs_remaining);
+    runsNoteEl.textContent = data.runs_remaining == null
+      ? 'Quota unavailable in this environment.'
+      : 'Remaining analyses before the current limit is reached.';
+    modeEl.textContent = capabilityHeadline(caps);
+    modeNoteEl.textContent = role.label + ' • ' + preference.label + ' • Retention ' + formatRetention(caps.retention_days) + ' • ' + (caps.api_access ? 'API enabled' : 'API not included');
+  }
+
+  function updateHistorySummary(data) {
+    var role = currentRoleConfig();
+    var statusEl = document.getElementById('app-history-latest-status');
+    var noteEl = document.getElementById('app-history-latest-note');
+    var instanceEl = document.getElementById('app-history-latest-instance');
+    var phaseEl = document.getElementById('app-history-latest-phase');
+    var pathEl = document.getElementById('app-history-latest-path');
+    if (!statusEl || !noteEl || !instanceEl || !phaseEl || !pathEl) return;
+
+    if (!data) {
+      if (!analysisHistoryLoaded && currentAccount) {
+        statusEl.textContent = 'Loading recent runs';
+        noteEl.textContent = 'Restoring signed-in history and checking for an active run to resume.';
+        instanceEl.textContent = '…';
+        phaseEl.textContent = 'loading';
+        pathEl.textContent = role.activePath;
+        return;
+      }
+      statusEl.textContent = 'No runs yet';
+      noteEl.textContent = role.emptyHistoryNote;
+      instanceEl.textContent = '—';
+      phaseEl.textContent = '—';
+      pathEl.textContent = role.completedPath;
+      return;
+    }
+
+    var instanceId = data.instanceId || data.instance_id || '—';
+    var runtimeStatus = data.runtimeStatus || 'Pending';
+    var phase = displayAnalysisPhase(data.customStatus, runtimeStatus);
+    var timing = summarizeRunTiming(data);
+    var summaryLabel = analysisHistoryRuns.length > 1 && selectedAnalysisRunId
+      ? 'Selected signed-in analysis'
+      : 'Latest signed-in analysis';
+    statusEl.textContent = runtimeStatus;
+    noteEl.textContent = runtimeStatus === 'Completed'
+      ? summaryLabel + ' completed and is ready to become a ' + role.completedHistoryOutcome + '.'
+      : summaryLabel + ' is active. This rail keeps ' + role.activeHistoryContext + ' visible while you stay centered on the run.';
+    if (runtimeStatus !== 'Completed' && timing.sinceUpdate) {
+      noteEl.textContent += ' Last backend update ' + timing.sinceUpdate + ' ago.';
+    }
+    instanceEl.textContent = instanceId;
+    phaseEl.textContent = phase;
+    pathEl.textContent = runtimeStatus === 'Completed' ? role.completedPath : role.activePath;
+  }
+
+  function normalizeAnalysisRun(run) {
+    if (!run) return null;
+    var normalized = Object.assign({}, run);
+    normalized.instanceId = normalized.instanceId || normalized.instance_id || '';
+    normalized.submissionId = normalized.submissionId || normalized.submission_id || normalized.instanceId;
+    normalized.submittedAt = normalized.submittedAt || normalized.submitted_at || normalized.createdTime || '';
+    normalized.submissionPrefix = normalized.submissionPrefix || normalized.submission_prefix || 'analysis';
+    normalized.providerName = normalized.providerName || normalized.provider_name || 'planetary_computer';
+    normalized.featureCount = normalized.featureCount != null ? normalized.featureCount : normalized.feature_count;
+    normalized.aoiCount = normalized.aoiCount != null ? normalized.aoiCount : normalized.aoi_count;
+    normalized.processingMode = normalized.processingMode || normalized.processing_mode;
+    normalized.maxSpreadKm = normalized.maxSpreadKm != null ? normalized.maxSpreadKm : normalized.max_spread_km;
+    normalized.totalAreaHa = normalized.totalAreaHa != null ? normalized.totalAreaHa : normalized.total_area_ha;
+    normalized.largestAreaHa = normalized.largestAreaHa != null ? normalized.largestAreaHa : normalized.largest_area_ha;
+    normalized.workspaceRole = normalized.workspaceRole || normalized.workspace_role;
+    normalized.workspacePreference = normalized.workspacePreference || normalized.workspace_preference;
+    if (normalized.output) {
+      if (normalized.featureCount == null && normalized.output.featureCount != null) normalized.featureCount = normalized.output.featureCount;
+      if (normalized.aoiCount == null && normalized.output.aoiCount != null) normalized.aoiCount = normalized.output.aoiCount;
+      if (normalized.artifactCount == null && normalized.output.artifacts) normalized.artifactCount = Object.keys(normalized.output.artifacts).length;
+      if (!normalized.partialFailures) {
+        normalized.partialFailures = {
+          imagery: normalized.output.imageryFailed || 0,
+          downloads: normalized.output.downloadsFailed || 0,
+          postProcess: normalized.output.postProcessFailed || 0,
+        };
+      }
+    }
+    return normalized.instanceId ? normalized : null;
+  }
+
+  function historyRunSortValue(run) {
+    return parseStatusTimestamp((run && (run.submittedAt || run.createdTime || run.lastUpdatedTime)) || '') || 0;
+  }
+
+  function sortAnalysisHistoryRuns(runs) {
+    return (runs || [])
+      .map(normalizeAnalysisRun)
+      .filter(Boolean)
+      .sort(function(a, b) {
+        return historyRunSortValue(b) - historyRunSortValue(a);
+      });
+  }
+
+  function shortInstanceId(instanceId) {
+    var value = String(instanceId || 'pending');
+    return value.length > 8 ? value.slice(0, 8) : value;
+  }
+
+  function formatHistoryTimestamp(value) {
+    var parsed = parseStatusTimestamp(value);
+    if (parsed == null) return 'Time unavailable';
+    return new Date(parsed).toLocaleString([], {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit'
+    });
+  }
+
+  function formatCountLabel(count, singular, plural) {
+    if (count == null || isNaN(count)) return null;
+    var whole = Number(count);
+    var noun = whole === 1 ? singular : (plural || singular + 's');
+    return whole + ' ' + noun;
+  }
+
+  function providerLabel(providerName) {
+    if (!providerName) return null;
+    if (providerName === 'planetary_computer') return 'Planetary Computer';
+    return String(providerName).replace(/_/g, ' ');
+  }
+
+  function summarizeFailureCounts(partialFailures) {
+    if (!partialFailures) return null;
+    var parts = [];
+    if (partialFailures.imagery) parts.push(partialFailures.imagery + ' imagery');
+    if (partialFailures.downloads) parts.push(partialFailures.downloads + ' download');
+    if (partialFailures.postProcess) parts.push(partialFailures.postProcess + ' post-process');
+    if (!parts.length) return null;
+    return 'Failures: ' + parts.join(', ');
+  }
+
+  function parseDownloadFilename(response, fallbackName) {
+    var disposition = response && response.headers ? response.headers.get('Content-Disposition') : '';
+    var match = disposition && disposition.match(/filename="?([^";]+)"?/i);
+    return match && match[1] ? match[1] : fallbackName;
+  }
+
+  function historyRunIsActive(run) {
+    var runtimeStatus = String(run && run.runtimeStatus || '').trim().toLowerCase();
+    return ['completed', 'failed', 'terminated', 'canceled'].indexOf(runtimeStatus) === -1;
+  }
+
+  function renderAnalysisHistoryList() {
+    var container = document.getElementById('app-history-list');
+    if (!container) return;
+
+    container.replaceChildren();
+    if (!analysisHistoryLoaded && currentAccount) {
+      var loading = document.createElement('div');
+      loading.className = 'app-history-empty';
+      loading.textContent = 'Restoring signed-in history…';
+      container.appendChild(loading);
+      return;
+    }
+    if (!analysisHistoryRuns.length) {
+      var empty = document.createElement('div');
+      empty.className = 'app-history-empty';
+      empty.textContent = currentRoleConfig().emptyHistoryNote;
+      container.appendChild(empty);
+      return;
+    }
+
+    analysisHistoryRuns.forEach(function(run) {
+      var instanceId = run.instanceId || run.instance_id;
+      var runtimeStatus = run.runtimeStatus || 'Pending';
+      var phase = displayAnalysisPhase(run.customStatus, runtimeStatus);
+      var button = document.createElement('button');
+      var header = document.createElement('div');
+      var title = document.createElement('strong');
+      var status = document.createElement('span');
+      var meta = document.createElement('div');
+      var submitted = document.createElement('span');
+      var phaseMeta = document.createElement('span');
+      var scopeMeta = document.createElement('span');
+      var note = document.createElement('div');
+
+      button.type = 'button';
+      button.className = 'app-history-item';
+      button.setAttribute('data-selected', instanceId === selectedAnalysisRunId ? 'true' : 'false');
+      button.addEventListener('click', function(event) {
+        event.stopPropagation();
+        selectAnalysisRun(instanceId, { focus: 'history', resume: historyRunIsActive(run) });
+      });
+
+      header.className = 'app-history-item-header';
+      title.className = 'app-history-item-title';
+      title.textContent = (historyRunIsActive(run) ? 'Resume run ' : 'Open run ') + shortInstanceId(instanceId);
+      status.className = 'app-history-item-status';
+      status.textContent = runtimeStatus;
+      header.appendChild(title);
+      header.appendChild(status);
+
+      meta.className = 'app-history-item-meta';
+      submitted.textContent = formatHistoryTimestamp(run.submittedAt || run.createdTime);
+      phaseMeta.textContent = 'Phase ' + phase;
+      scopeMeta.textContent = [formatCountLabel(run.aoiCount, 'AOI'), providerLabel(run.providerName)].filter(Boolean).join(' • ') || 'Tracked run';
+      meta.appendChild(submitted);
+      meta.appendChild(phaseMeta);
+      meta.appendChild(scopeMeta);
+
+      note.className = 'app-history-item-note';
+      if (historyRunIsActive(run)) {
+        note.textContent = 'Resume this run from ' + phase + ' and keep polling the signed-in pipeline.';
+      } else if (runtimeStatus === 'Completed') {
+        note.textContent = 'Reopen the completed workspace state and use the run rail to download signed-in exports.';
+      } else {
+        note.textContent = 'Review this run state without falling back to the public demo.';
+      }
+
+      button.appendChild(header);
+      button.appendChild(meta);
+      button.appendChild(note);
+      container.appendChild(button);
+    });
+  }
+
+  function upsertAnalysisHistoryRun(run) {
+    var normalized = normalizeAnalysisRun(run);
+    if (!normalized) return;
+
+    var replaced = false;
+    analysisHistoryRuns = analysisHistoryRuns.map(function(existing) {
+      var existingId = existing.instanceId || existing.instance_id;
+      if (existingId !== normalized.instanceId) return existing;
+      replaced = true;
+      return Object.assign({}, existing, normalized);
+    });
+    if (!replaced) analysisHistoryRuns.unshift(normalized);
+    analysisHistoryRuns = sortAnalysisHistoryRuns(analysisHistoryRuns);
+    renderAnalysisHistoryList();
+  }
+
+  function selectAnalysisRun(instanceId, options) {
+    options = options || {};
+    var run = analysisHistoryRuns.find(function(entry) {
+      return (entry.instanceId || entry.instance_id) === instanceId;
+    });
+    if (!run) return;
+
+    selectedAnalysisRunId = instanceId;
+    renderAnalysisHistoryList();
+    if (options.focus) setWorkflowFocus(options.focus);
+    updateRunSelectionLocation(instanceId, options.focus || document.getElementById('app-workflow-stage').getAttribute('data-focus') || 'run');
+
+    stopAnalysisPolling();
+    updateAnalysisRun(run);
+    resetAnalysisProgress();
+    setAnalysisProgressVisible(true);
+
+    var runtimeStatus = run.runtimeStatus || 'Pending';
+    var phase = mapAnalysisPhase(run.customStatus, runtimeStatus);
+    if (runtimeStatus === 'Completed') {
+      setAnalysisStep('complete', 'done');
+      updateAnalysisStory('complete', runtimeStatus, run);
+      loadRunEvidence(instanceId);
+      return;
+    }
+    if (runtimeStatus === 'Failed' || runtimeStatus === 'Canceled' || runtimeStatus === 'Terminated') {
+      setAnalysisStep(phase, 'failed');
+      updateAnalysisStory(phase, runtimeStatus, run);
+      return;
+    }
+
+    setAnalysisStep(phase, 'active');
+    updateAnalysisStory(phase, runtimeStatus || 'Pending', run);
+    if (options.resume !== false) pollAnalysisRun(instanceId);
+  }
+
+  function applyAnalysisHistory(payload, options) {
+    options = options || {};
+    var locationSelection = readRunSelectionFromLocation();
+
+    if (locationSelection.focus) setWorkflowFocus(locationSelection.focus);
+
+    var normalizedActiveRun = normalizeAnalysisRun(payload && payload.activeRun);
+    analysisHistoryRuns = sortAnalysisHistoryRuns(payload && payload.runs);
+    if (normalizedActiveRun && !analysisHistoryRuns.some(function(run) {
+      return run.instanceId === normalizedActiveRun.instanceId;
+    })) {
+      analysisHistoryRuns.unshift(normalizedActiveRun);
+      analysisHistoryRuns = sortAnalysisHistoryRuns(analysisHistoryRuns);
+    }
+
+    var nextSelectedId = options.preferInstanceId || selectedAnalysisRunId || locationSelection.instanceId;
+    if (nextSelectedId && !analysisHistoryRuns.some(function(run) { return run.instanceId === nextSelectedId; })) {
+      nextSelectedId = null;
+    }
+    if (!nextSelectedId && normalizedActiveRun) nextSelectedId = normalizedActiveRun.instanceId;
+    if (!nextSelectedId && analysisHistoryRuns[0]) nextSelectedId = analysisHistoryRuns[0].instanceId;
+
+    if (!nextSelectedId) {
+      selectedAnalysisRunId = null;
+      updateRunSelectionLocation('', document.getElementById('app-workflow-stage').getAttribute('data-focus') || 'run');
+      stopAnalysisPolling();
+      resetAnalysisProgress();
+      renderAnalysisHistoryList();
+      updateAnalysisRun(null);
+      return;
+    }
+
+    var selectedRun = analysisHistoryRuns.find(function(run) { return run.instanceId === nextSelectedId; });
+    selectAnalysisRun(nextSelectedId, { resume: historyRunIsActive(selectedRun) });
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  First-run layout — toggle onboarding vs standard dashboard        */
+  /* ------------------------------------------------------------------ */
+
+  function applyFirstRunLayout() {
+    var firstRun = document.getElementById('app-first-run-hero');
+    var evidenceHero = document.getElementById('app-evidence-hero');
+    if (!firstRun) return;
+
+    var isEmpty = analysisHistoryLoaded && analysisHistoryRuns.length === 0 && !latestAnalysisRun;
+    firstRun.hidden = !isEmpty;
+    if (evidenceHero) evidenceHero.hidden = isEmpty;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Evidence surface — fetches and renders real data for completed runs */
+  /* ------------------------------------------------------------------ */
+
+  var evidenceMap = null;
+  var evidenceMapLayers = [];
+  var evidenceFrameIndex = 0;
+  var evidenceLayerMode = 'rgb'; // 'rgb' | 'ndvi'
+  var evidencePlayInterval = null;
+  var evidenceManifest = null;
+  var evidenceAnalysis = null;
+  var evidenceInstanceId = null;
+  var evidenceMapExpanded = false;
+
+  function expandEvidenceMap() {
+    var mapEl = document.getElementById('app-evidence-map');
+    var backdrop = document.getElementById('app-map-expanded-backdrop');
+    var body = document.getElementById('app-map-expanded-body');
+    if (!mapEl || !backdrop || !body || evidenceMapExpanded) return;
+
+    body.appendChild(mapEl);
+    backdrop.hidden = false;
+    evidenceMapExpanded = true;
+
+    // Sync expanded controls state
+    syncExpandedControls();
+
+    setTimeout(function() { if (evidenceMap) evidenceMap.invalidateSize(); }, 100);
+    document.addEventListener('keydown', expandedEscHandler);
+  }
+
+  function collapseEvidenceMap() {
+    var mapEl = document.getElementById('app-evidence-map');
+    var backdrop = document.getElementById('app-map-expanded-backdrop');
+    var wrap = document.getElementById('app-evidence-map-wrap');
+    if (!mapEl || !backdrop || !wrap || !evidenceMapExpanded) return;
+
+    wrap.insertBefore(mapEl, wrap.firstChild);
+    backdrop.hidden = true;
+    evidenceMapExpanded = false;
+
+    setTimeout(function() { if (evidenceMap) evidenceMap.invalidateSize(); }, 100);
+    document.removeEventListener('keydown', expandedEscHandler);
+  }
+
+  function expandedEscHandler(e) {
+    if (e.key === 'Escape') collapseEvidenceMap();
+  }
+
+  function syncExpandedControls() {
+    var slider = document.getElementById('app-map-expanded-slider');
+    var counter = document.getElementById('app-map-expanded-counter');
+    var label = document.getElementById('app-map-expanded-label');
+    var rgbBtn = document.getElementById('app-map-expanded-btn-rgb');
+    var ndviBtn = document.getElementById('app-map-expanded-btn-ndvi');
+
+    if (slider && evidenceMapLayers.length) {
+      slider.max = evidenceMapLayers.length - 1;
+      slider.value = evidenceFrameIndex;
+    }
+    if (counter) counter.textContent = (evidenceFrameIndex + 1) + '/' + evidenceMapLayers.length;
+    if (label && evidenceMapLayers[evidenceFrameIndex]) {
+      label.textContent = evidenceMapLayers[evidenceFrameIndex].label + ' — ' + evidenceMapLayers[evidenceFrameIndex].info;
+    }
+    if (rgbBtn) rgbBtn.classList.toggle('active', evidenceLayerMode === 'rgb');
+    if (ndviBtn) ndviBtn.classList.toggle('active', evidenceLayerMode === 'ndvi');
+  }
+
+  function showEvidenceSurface(visible) {
+    var surface = document.getElementById('app-evidence-surface');
+    var phaseStatus = document.getElementById('app-content-phase-status');
+    if (surface) surface.hidden = !visible;
+    if (phaseStatus) phaseStatus.hidden = visible;
+  }
+
+  async function loadRunEvidence(instanceId) {
+    if (evidenceInstanceId === instanceId && evidenceManifest) return;
+    evidenceInstanceId = instanceId;
+    evidenceManifest = null;
+    evidenceAnalysis = null;
+    showEvidenceSurface(true);
+    clearEvidencePanels();
+
+    var footerEl = document.getElementById('app-content-footer');
+    if (footerEl) footerEl.textContent = 'Loading evidence for run ' + instanceId.slice(0, 8) + '…';
+
+    try {
+      await apiDiscoveryReady;
+      var manifestRes = await apiFetch('/api/timelapse-data/' + encodeURIComponent(instanceId));
+      if (!manifestRes || !manifestRes.ok) throw new Error('Could not load enrichment manifest.');
+      evidenceManifest = await manifestRes.json();
+    } catch (err) {
+      if (footerEl) footerEl.textContent = 'Could not load enrichment data: ' + ((err && err.message) || 'unknown error');
+      return;
+    }
+
+    renderEvidenceNdvi(evidenceManifest);
+    renderEvidenceWeather(evidenceManifest);
+    renderEvidenceChangeDetection(evidenceManifest);
+    initEvidenceMap(evidenceManifest);
+
+    // Load saved AI analysis (non-blocking)
+    loadSavedAnalysis(instanceId);
+
+    // Show EUDR block for eudr role
+    var eudrBlock = document.getElementById('app-evidence-eudr-block');
+    if (eudrBlock) eudrBlock.hidden = (workspaceRole !== 'eudr');
+
+    // Show AI block if tier supports it
+    var aiBlock = document.getElementById('app-evidence-ai-block');
+    if (aiBlock) aiBlock.hidden = !(latestBillingStatus && latestBillingStatus.capabilities && latestBillingStatus.capabilities.ai_insights);
+
+    if (footerEl) footerEl.textContent = 'Evidence loaded for run ' + instanceId.slice(0, 8) + '.';
+  }
+
+  function clearEvidencePanels() {
+    var ids = ['app-evidence-ndvi-grid', 'app-evidence-weather-grid', 'app-evidence-change-list', 'app-evidence-ai-content', 'app-evidence-eudr-content'];
+    ids.forEach(function(id) { var el = document.getElementById(id); if (el) el.innerHTML = ''; });
+    var noteEl = document.getElementById('app-evidence-ndvi-note');
+    if (noteEl) noteEl.textContent = '';
+    var canvases = ['app-evidence-ndvi-canvas', 'app-evidence-weather-canvas'];
+    canvases.forEach(function(id) {
+      var c = document.getElementById(id);
+      if (c) { var ctx = c.getContext('2d'); ctx.clearRect(0, 0, c.width, c.height); }
+    });
+    if (evidencePlayInterval) { clearInterval(evidencePlayInterval); evidencePlayInterval = null; }
+  }
+
+  function evidenceStatHtml(label, value, tone) {
+    var cls = tone === 'positive' ? ' positive' : tone === 'negative' ? ' negative' : ' neutral';
+    return '<div class="app-evidence-stat"><span>' + escHtml(label) + '</span><strong class="' + cls + '">' + escHtml(value) + '</strong></div>';
+  }
+
+  function escHtml(s) {
+    if (!s) return '';
+    return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  /* ---- NDVI evidence ---- */
+  function renderEvidenceNdvi(manifest) {
+    var grid = document.getElementById('app-evidence-ndvi-grid');
+    var note = document.getElementById('app-evidence-ndvi-note');
+    var canvas = document.getElementById('app-evidence-ndvi-canvas');
+    if (!grid) return;
+
+    var ndvi = (manifest.ndvi_stats || []).filter(function(f) { return f != null; });
+    if (!ndvi.length) {
+      grid.innerHTML = evidenceStatHtml('Status', 'No NDVI data', '');
+      return;
+    }
+
+    var means = ndvi.map(function(f) { return f.mean; }).filter(function(v) { return v != null && !isNaN(v); });
+    var overallMean = means.length ? (means.reduce(function(a, b) { return a + b; }, 0) / means.length) : null;
+    var overallMin = means.length ? Math.min.apply(null, means) : null;
+    var overallMax = means.length ? Math.max.apply(null, means) : null;
+
+    // Trajectory — prefer backend season-aware change detection
+    var trajectory = 'Stable';
+    var trajectoryTone = '';
+    var cdSummary = manifest.change_detection && manifest.change_detection.summary;
+    if (cdSummary && cdSummary.trajectory) {
+      var t = cdSummary.trajectory;
+      if (t === 'Improving') { trajectory = 'Improving ↑'; trajectoryTone = 'positive'; }
+      else if (t === 'Declining') { trajectory = 'Declining ↓'; trajectoryTone = 'negative'; }
+      else { trajectory = 'Stable'; trajectoryTone = ''; }
+    } else if (means.length >= 4) {
+      var firstHalf = means.slice(0, Math.floor(means.length / 2));
+      var secondHalf = means.slice(Math.floor(means.length / 2));
+      var avgFirst = firstHalf.reduce(function(a, b) { return a + b; }, 0) / firstHalf.length;
+      var avgSecond = secondHalf.reduce(function(a, b) { return a + b; }, 0) / secondHalf.length;
+      var delta = avgSecond - avgFirst;
+      if (delta > 0.05) { trajectory = 'Improving ↑'; trajectoryTone = 'positive'; }
+      else if (delta < -0.05) { trajectory = 'Declining ↓'; trajectoryTone = 'negative'; }
+    }
+
+    grid.innerHTML =
+      evidenceStatHtml('Mean NDVI', overallMean != null ? overallMean.toFixed(3) : '—', overallMean > 0.4 ? 'positive' : overallMean < 0.2 ? 'negative' : '') +
+      evidenceStatHtml('Range', overallMin != null ? overallMin.toFixed(2) + ' – ' + overallMax.toFixed(2) : '—', '') +
+      evidenceStatHtml('Trajectory', trajectory, trajectoryTone);
+
+    if (note) note.textContent = means.length + ' frames sampled across the analysis period.';
+
+    // Draw sparkline
+    if (canvas && means.length > 1) drawNdviSparkline(canvas, ndvi);
+  }
+
+  function drawNdviSparkline(canvas, ndviStats) {
+    var dpr = window.devicePixelRatio || 1;
+    var w = canvas.clientWidth;
+    var h = canvas.clientHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    var ctx = canvas.getContext('2d');
+    ctx.scale(dpr, dpr);
+
+    var means = ndviStats.map(function(f) { return f ? f.mean : null; });
+    var valid = means.filter(function(v) { return v != null && !isNaN(v); });
+    if (valid.length < 2) return;
+    var minV = Math.min.apply(null, valid) - 0.05;
+    var maxV = Math.max.apply(null, valid) + 0.05;
+    var range = maxV - minV || 1;
+    var pad = 4;
+
+    // Background
+    ctx.fillStyle = 'rgba(13,17,23,.4)';
+    ctx.beginPath();
+    ctx.roundRect(0, 0, w, h, 8);
+    ctx.fill();
+
+    // Line
+    ctx.strokeStyle = 'rgba(63,185,80,.8)';
+    ctx.lineWidth = 2;
+    ctx.lineJoin = 'round';
+    ctx.beginPath();
+    var drawn = false;
+    for (var i = 0; i < means.length; i++) {
+      if (means[i] == null || isNaN(means[i])) continue;
+      var x = pad + (i / (means.length - 1)) * (w - 2 * pad);
+      var y = h - pad - ((means[i] - minV) / range) * (h - 2 * pad);
+      if (!drawn) { ctx.moveTo(x, y); drawn = true; } else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+
+    // Drop markers
+    ctx.fillStyle = 'rgba(248,81,73,.9)';
+    for (var j = 1; j < means.length; j++) {
+      if (means[j] == null || means[j - 1] == null) continue;
+      var drop = means[j] - means[j - 1];
+      if (drop <= -0.1) {
+        var dx = pad + (j / (means.length - 1)) * (w - 2 * pad);
+        var dy = h - pad - ((means[j] - minV) / range) * (h - 2 * pad);
+        ctx.beginPath();
+        ctx.arc(dx, dy, 3, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+  }
+
+  /* ---- Weather evidence ---- */
+  function renderEvidenceWeather(manifest) {
+    var grid = document.getElementById('app-evidence-weather-grid');
+    var canvas = document.getElementById('app-evidence-weather-canvas');
+    if (!grid) return;
+
+    var monthly = manifest.weather_monthly;
+    var daily = manifest.weather_daily;
+    if (!monthly && !daily) {
+      grid.innerHTML = evidenceStatHtml('Status', 'No weather data', '');
+      return;
+    }
+
+    var temps = [];
+    var precips = [];
+    var source = [];
+
+    // weather_monthly may be { labels, temp, precip } parallel arrays
+    if (monthly && monthly.labels && Array.isArray(monthly.labels)) {
+      source = monthly.labels.map(function(lbl, i) {
+        return {
+          label: lbl,
+          temperature: (monthly.temp && monthly.temp[i] != null) ? monthly.temp[i] : null,
+          precipitation: (monthly.precip && monthly.precip[i] != null) ? monthly.precip[i] : null
+        };
+      });
+    } else if (Array.isArray(monthly)) {
+      source = monthly;
+    }
+
+    if (!source.length && daily) {
+      // aggregate daily to monthly — daily may be { dates, temp, precip }
+      var byMonth = {};
+      var dates = daily.dates || daily.time || [];
+      var dTemps = daily.temp || daily.temperature_2m_mean || [];
+      var dPrecip = daily.precip || daily.precipitation_sum || [];
+      dates.forEach(function(d, i) {
+        var key = d.slice(0, 7);
+        if (!byMonth[key]) byMonth[key] = { temps: [], precips: [] };
+        if (dTemps[i] != null) byMonth[key].temps.push(dTemps[i]);
+        if (dPrecip[i] != null) byMonth[key].precips.push(dPrecip[i]);
+      });
+      source = Object.keys(byMonth).sort().map(function(key) {
+        var m = byMonth[key];
+        return {
+          label: key,
+          temperature: m.temps.length ? m.temps.reduce(function(a, b) { return a + b; }, 0) / m.temps.length : null,
+          precipitation: m.precips.length ? m.precips.reduce(function(a, b) { return a + b; }, 0) : null
+        };
+      });
+    }
+
+    source.forEach(function(m) {
+      if (m.temperature != null) temps.push(m.temperature);
+      if (m.precipitation != null) precips.push(m.precipitation);
+    });
+
+    var avgTemp = temps.length ? (temps.reduce(function(a, b) { return a + b; }, 0) / temps.length) : null;
+    var totalPrecip = precips.reduce(function(a, b) { return a + b; }, 0);
+
+    grid.innerHTML =
+      evidenceStatHtml('Avg temp', avgTemp != null ? avgTemp.toFixed(1) + '°C' : '—', '') +
+      evidenceStatHtml('Total precip', totalPrecip ? Math.round(totalPrecip) + ' mm' : '—', '') +
+      evidenceStatHtml('Months', source.length + ' months', '');
+
+    if (canvas && source.length > 1) drawWeatherSparkline(canvas, source);
+  }
+
+  function drawWeatherSparkline(canvas, monthly) {
+    var dpr = window.devicePixelRatio || 1;
+    var w = canvas.clientWidth;
+    var h = canvas.clientHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    var ctx = canvas.getContext('2d');
+    ctx.scale(dpr, dpr);
+    var pad = 4;
+
+    ctx.fillStyle = 'rgba(13,17,23,.4)';
+    ctx.beginPath();
+    ctx.roundRect(0, 0, w, h, 8);
+    ctx.fill();
+
+    var temps = monthly.map(function(m) { return m.temperature; });
+    var precips = monthly.map(function(m) { return m.precipitation; });
+    var validTemps = temps.filter(function(v) { return v != null; });
+    var validPrecips = precips.filter(function(v) { return v != null; });
+    var maxPrecip = validPrecips.length ? Math.max.apply(null, validPrecips) : 1;
+    var minT = validTemps.length ? Math.min.apply(null, validTemps) - 2 : 0;
+    var maxT = validTemps.length ? Math.max.apply(null, validTemps) + 2 : 30;
+
+    // Precipitation bars
+    var barW = Math.max(2, (w - 2 * pad) / monthly.length - 1);
+    ctx.fillStyle = 'rgba(88,166,255,.35)';
+    for (var i = 0; i < precips.length; i++) {
+      if (precips[i] == null) continue;
+      var bx = pad + (i / monthly.length) * (w - 2 * pad);
+      var bh = (precips[i] / (maxPrecip || 1)) * (h - 2 * pad) * 0.8;
+      ctx.fillRect(bx, h - pad - bh, barW, bh);
+    }
+
+    // Temperature line
+    ctx.strokeStyle = 'rgba(210,153,34,.9)';
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    var drawn = false;
+    for (var j = 0; j < temps.length; j++) {
+      if (temps[j] == null) continue;
+      var tx = pad + ((j + 0.5) / monthly.length) * (w - 2 * pad);
+      var ty = h - pad - ((temps[j] - minT) / (maxT - minT)) * (h - 2 * pad);
+      if (!drawn) { ctx.moveTo(tx, ty); drawn = true; } else ctx.lineTo(tx, ty);
+    }
+    ctx.stroke();
+  }
+
+  /* ---- Change detection ---- */
+  function renderEvidenceChangeDetection(manifest) {
+    var block = document.getElementById('app-evidence-change-block');
+    var list = document.getElementById('app-evidence-change-list');
+    if (!block || !list) return;
+
+    var cd = manifest.change_detection;
+    if (!cd || (!cd.season_changes && !cd.significant_changes && !cd.events && !cd.summary)) {
+      block.hidden = true;
+      return;
+    }
+
+    block.hidden = false;
+    var items = cd.season_changes || cd.significant_changes || cd.events || [];
+
+    // Summary may be an object { comparisons, total_loss_ha, total_gain_ha, avg_mean_delta, trajectory }
+    if (cd.summary) {
+      var s = cd.summary;
+      var summaryText = typeof s === 'string' ? s :
+        (s.trajectory || 'Stable') + ' — ' + (s.comparisons || 0) + ' comparisons, ' +
+        'net loss ' + (s.total_loss_ha ? s.total_loss_ha.toFixed(0) + ' ha' : '—') +
+        ', net gain ' + (s.total_gain_ha ? s.total_gain_ha.toFixed(0) + ' ha' : '—');
+      list.innerHTML = '<div class="app-evidence-change-item positive">' + escHtml(summaryText) + '</div>';
+    }
+
+    // Show notable season changes (loss_pct > 20% or gain_pct > 20%)
+    var notable = items.filter(function(item) {
+      return typeof item === 'object' && (item.loss_pct > 20 || item.gain_pct > 20);
+    });
+    if (!notable.length && items.length > 3) notable = items.slice(0, 5);
+    else if (!notable.length) notable = items;
+
+    notable.forEach(function(item) {
+      var text;
+      if (typeof item === 'string') {
+        text = item;
+      } else if (item.label) {
+        var parts = [item.label];
+        if (item.mean_delta != null) parts.push('Δ ' + (item.mean_delta > 0 ? '+' : '') + item.mean_delta.toFixed(3));
+        if (item.loss_pct != null) parts.push('loss ' + item.loss_pct + '%');
+        if (item.gain_pct != null) parts.push('gain ' + item.gain_pct + '%');
+        text = parts.join(' — ');
+      } else {
+        text = item.description || item.text || JSON.stringify(item);
+      }
+      var cls = 'app-evidence-change-item';
+      if (typeof item === 'object' && (item.gain_pct > item.loss_pct || item.mean_delta > 0.02)) cls += ' positive';
+      var el = document.createElement('div');
+      el.className = cls;
+      el.textContent = text;
+      list.appendChild(el);
+    });
+  }
+
+  /* ---- Map viewer ---- */
+  function initEvidenceMap(manifest) {
+    var container = document.getElementById('app-evidence-map');
+    var overlay = document.getElementById('app-evidence-map-overlay');
+    var controls = document.getElementById('app-evidence-frame-controls');
+    if (!container) return;
+
+    // Clean up old map
+    if (evidenceMap) { evidenceMap.remove(); evidenceMap = null; }
+    evidenceMapLayers = [];
+    evidenceFrameIndex = 0;
+    if (evidencePlayInterval) { clearInterval(evidencePlayInterval); evidencePlayInterval = null; }
+
+    var center = manifest.center || manifest.coords;
+    if (!center) {
+      if (overlay) overlay.textContent = 'No location data available.';
+      return;
+    }
+
+    var lat = Array.isArray(center) ? center[0] : center.lat || center.latitude;
+    var lon = Array.isArray(center) ? center[1] : center.lon || center.longitude;
+    if (!lat || !lon) {
+      if (overlay) overlay.textContent = 'Invalid coordinates in manifest.';
+      return;
+    }
+
+    evidenceMap = L.map(container, { zoomControl: true, attributionControl: false }).setView([lat, lon], 13);
+    L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
+      maxZoom: 18
+    }).addTo(evidenceMap);
+
+    // AOI polygon outlines (coords are [lon, lat] GeoJSON; Leaflet needs [lat, lon])
+    // Multi-AOI runs concatenate all rings; split on ring-closure (first == last point)
+    if (manifest.coords && Array.isArray(manifest.coords)) {
+      try {
+        var rings = [];
+        var ringStart = 0;
+        for (var ci = ringStart + 3; ci < manifest.coords.length; ci++) {
+          if (Math.abs(manifest.coords[ci][0] - manifest.coords[ringStart][0]) < 1e-5 &&
+              Math.abs(manifest.coords[ci][1] - manifest.coords[ringStart][1]) < 1e-5) {
+            rings.push(manifest.coords.slice(ringStart, ci + 1));
+            ringStart = ci + 1;
+            ci = ringStart + 2;
+          }
+        }
+        if (ringStart < manifest.coords.length) rings.push(manifest.coords.slice(ringStart));
+        if (!rings.length) rings.push(manifest.coords);
+
+        var allBounds = L.latLngBounds([]);
+        rings.forEach(function(ring) {
+          var ll = ring.map(function(c) { return [c[1], c[0]]; });
+          L.polygon(ll, { color: 'rgba(88,166,255,.7)', weight: 2, fillOpacity: 0.05 }).addTo(evidenceMap);
+          allBounds.extend(L.polygon(ll).getBounds());
+        });
+        evidenceMap.fitBounds(allBounds.pad(0.1));
+      } catch (e) { /* skip polygon */ }
+    }
+
+    if (overlay) overlay.hidden = true;
+
+    // Add PC timelapse frames if search_ids available
+    var searchIds = manifest.search_ids || [];
+    var ndviSearchIds = manifest.ndvi_search_ids || [];
+    var framePlan = manifest.frame_plan || [];
+
+    if (searchIds.length && framePlan.length) {
+      buildEvidenceFrames(framePlan, searchIds, ndviSearchIds);
+      if (controls) controls.hidden = false;
+    } else if (controls) {
+      controls.hidden = true;
+    }
+
+    // Force resize
+    setTimeout(function() { if (evidenceMap) evidenceMap.invalidateSize(); }, 200);
+  }
+
+  function pcTileUrl(searchId, collection, asset) {
+    asset = asset || 'visual';
+    return 'https://planetarycomputer.microsoft.com/api/data/v1/mosaic/tiles/' +
+      encodeURIComponent(searchId) + '/WebMercatorQuad/{z}/{x}/{y}@2x?' +
+      'collection=' + encodeURIComponent(collection) + '&assets=' + encodeURIComponent(asset);
+  }
+
+  function pcNdviTileUrl(searchId) {
+    return 'https://planetarycomputer.microsoft.com/api/data/v1/mosaic/tiles/' +
+      encodeURIComponent(searchId) + '/WebMercatorQuad/{z}/{x}/{y}@2x?' +
+      'collection=sentinel-2-l2a&expression=(B08-B04)/(B08%2BB04)&rescale=-0.2,0.8&colormap_name=rdylgn';
+  }
+
+  function buildEvidenceFrames(framePlan, searchIds, ndviSearchIds) {
+    evidenceMapLayers = [];
+    var slider = document.getElementById('app-map-frame-slider');
+    if (slider) { slider.max = framePlan.length - 1; slider.value = 0; }
+
+    framePlan.forEach(function(frame, idx) {
+      var sid = searchIds[idx];
+      var ndviSid = ndviSearchIds[idx] || sid;
+      var collection = frame.collection || 'sentinel-2-l2a';
+      var asset = collection.indexOf('naip') >= 0 ? 'image' : 'visual';
+
+      var rgbLayer = null;
+      var ndviLayer = null;
+      if (sid) {
+        rgbLayer = L.tileLayer(pcTileUrl(sid, collection, asset), { maxZoom: 18, opacity: 0 });
+        rgbLayer.addTo(evidenceMap);
+      }
+      if (ndviSid && collection.indexOf('sentinel') >= 0) {
+        ndviLayer = L.tileLayer(pcNdviTileUrl(ndviSid), { maxZoom: 18, opacity: 0 });
+        ndviLayer.addTo(evidenceMap);
+      }
+
+      evidenceMapLayers.push({
+        rgb: rgbLayer,
+        ndvi: ndviLayer,
+        label: frame.label || ('Frame ' + (idx + 1)),
+        info: [collection, frame.start_date, frame.end_date].filter(Boolean).join(' | ')
+      });
+    });
+
+    showEvidenceFrame(0);
+  }
+
+  function showEvidenceFrame(idx) {
+    if (idx < 0 || idx >= evidenceMapLayers.length) return;
+    evidenceFrameIndex = idx;
+
+    evidenceMapLayers.forEach(function(frame, i) {
+      var showRgb = (i === idx && evidenceLayerMode === 'rgb');
+      var showNdvi = (i === idx && evidenceLayerMode === 'ndvi');
+      if (frame.rgb) frame.rgb.setOpacity(showRgb ? 1 : 0);
+      if (frame.ndvi) frame.ndvi.setOpacity(showNdvi ? 1 : 0);
+    });
+
+    var slider = document.getElementById('app-map-frame-slider');
+    var counter = document.getElementById('app-map-frame-counter');
+    var label = document.getElementById('app-map-frame-label');
+    if (slider) slider.value = idx;
+    if (counter) counter.textContent = (idx + 1) + '/' + evidenceMapLayers.length;
+    if (label) label.textContent = evidenceMapLayers[idx].label + ' — ' + evidenceMapLayers[idx].info;
+
+    // Sync expanded controls if open
+    if (evidenceMapExpanded) syncExpandedControls();
+  }
+
+  function toggleEvidencePlay() {
+    var btn = document.getElementById('app-map-play-btn');
+    var expBtn = document.getElementById('app-map-expanded-play-btn');
+    if (evidencePlayInterval) {
+      clearInterval(evidencePlayInterval);
+      evidencePlayInterval = null;
+      if (btn) btn.textContent = '▶ Play';
+      if (expBtn) expBtn.textContent = '▶ Play';
+      return;
+    }
+    if (btn) btn.textContent = '⏸ Pause';
+    if (expBtn) expBtn.textContent = '⏸ Pause';
+    evidencePlayInterval = setInterval(function() {
+      var next = (evidenceFrameIndex + 1) % evidenceMapLayers.length;
+      showEvidenceFrame(next);
+    }, 1500);
+  }
+
+  /* ---- AI analysis ---- */
+  async function loadSavedAnalysis(instanceId) {
+    var aiBlock = document.getElementById('app-evidence-ai-block');
+    var content = document.getElementById('app-evidence-ai-content');
+    if (!aiBlock || !content) return;
+
+    try {
+      await apiDiscoveryReady;
+      var res = await apiFetch('/api/timelapse-analysis-load/' + encodeURIComponent(instanceId));
+      if (res && res.ok) {
+        evidenceAnalysis = await res.json();
+        if (evidenceAnalysis && (evidenceAnalysis.observations || evidenceAnalysis.summary)) {
+          aiBlock.hidden = false;
+          renderEvidenceAnalysis(evidenceAnalysis);
+        }
+      }
+    } catch (e) { /* ignore — no saved analysis yet */ }
+  }
+
+  async function requestAiAnalysis() {
+    var loading = document.getElementById('app-evidence-ai-loading');
+    var content = document.getElementById('app-evidence-ai-content');
+    var btn = document.getElementById('app-evidence-ai-btn');
+    if (!loading || !content || !evidenceManifest) return;
+
+    var originalLabel = btn ? btn.textContent : '';
+    if (btn) { btn.disabled = true; btn.textContent = 'Analyzing…'; }
+    loading.hidden = false;
+    content.innerHTML = '';
+
+    try {
+      await apiDiscoveryReady;
+
+      var ndviTimeseries = (evidenceManifest.ndvi_stats || []).map(function(f, i) {
+        if (!f) return null;
+        var fp = (evidenceManifest.frame_plan || [])[i] || {};
+        return { date: f.datetime || fp.label, mean: f.mean, min: f.min, max: f.max, year: fp.year, season: fp.season };
+      }).filter(Boolean);
+
+      // weather_monthly may be { labels, temp, precip } parallel arrays
+      var wm = evidenceManifest.weather_monthly;
+      var weatherTimeseries = [];
+      if (wm && wm.labels && Array.isArray(wm.labels)) {
+        weatherTimeseries = wm.labels.map(function(lbl, i) {
+          return { month_index: i, label: lbl, temperature: wm.temp ? wm.temp[i] : null, precipitation: wm.precip ? wm.precip[i] : null };
+        });
+      } else if (Array.isArray(wm)) {
+        weatherTimeseries = wm.map(function(m, i) {
+          return { month_index: i, temperature: m.temperature, precipitation: m.precipitation };
+        });
+      }
+
+      var center = evidenceManifest.center || evidenceManifest.coords;
+      var lat = Array.isArray(center) ? center[0] : (center && center.lat) || 0;
+      var lon = Array.isArray(center) ? center[1] : (center && center.lon) || 0;
+
+      var body = {
+        context: {
+          aoi_name: 'Analysis area',
+          latitude: lat,
+          longitude: lon,
+          frame_count: ndviTimeseries.length,
+          date_range_start: ndviTimeseries.length ? ndviTimeseries[0].date : '',
+          date_range_end: ndviTimeseries.length ? ndviTimeseries[ndviTimeseries.length - 1].date : '',
+          ndvi_timeseries: ndviTimeseries,
+          weather_timeseries: weatherTimeseries
+        }
+      };
+
+      var res = await apiFetch('/api/timelapse-analysis', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+
+      if (!res || !res.ok) {
+        var err = res ? await res.json().catch(function() { return {}; }) : {};
+        throw new Error(err.error || 'AI analysis failed.');
+      }
+
+      evidenceAnalysis = await res.json();
+      renderEvidenceAnalysis(evidenceAnalysis);
+
+      // Save the analysis
+      apiFetch('/api/timelapse-analysis-save', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ instance_id: evidenceInstanceId, analysis: evidenceAnalysis })
+      }).catch(function() {});
+    } catch (err) {
+      content.innerHTML = '<div class="app-callout" data-tone="error">' + escHtml((err && err.message) || 'Could not run AI analysis.') + '</div>';
+    } finally {
+      loading.hidden = true;
+      if (btn) { btn.disabled = false; btn.textContent = originalLabel; }
+    }
+  }
+
+  function renderEvidenceAnalysis(analysis) {
+    var content = document.getElementById('app-evidence-ai-content');
+    if (!content) return;
+    content.innerHTML = '';
+
+    if (analysis.summary) {
+      var summaryEl = document.createElement('div');
+      summaryEl.className = 'app-evidence-summary';
+      summaryEl.textContent = analysis.summary;
+      content.appendChild(summaryEl);
+    }
+
+    (analysis.observations || []).forEach(function(obs) {
+      var card = document.createElement('div');
+      card.className = 'app-evidence-obs';
+
+      var header = document.createElement('div');
+      header.className = 'app-evidence-obs-header';
+
+      var cat = document.createElement('span');
+      cat.className = 'app-evidence-obs-category';
+      cat.textContent = (obs.category || 'observation').replace(/_/g, ' ');
+
+      var sev = document.createElement('span');
+      sev.className = 'app-evidence-obs-severity severity-' + (obs.severity || 'normal');
+      sev.textContent = obs.severity || 'normal';
+
+      header.appendChild(cat);
+      header.appendChild(sev);
+      card.appendChild(header);
+
+      if (obs.description) {
+        var desc = document.createElement('p');
+        desc.textContent = obs.description;
+        card.appendChild(desc);
+      }
+      if (obs.recommendation) {
+        var rec = document.createElement('p');
+        rec.className = 'obs-recommendation';
+        rec.textContent = '💡 ' + obs.recommendation;
+        card.appendChild(rec);
+      }
+
+      content.appendChild(card);
+    });
+  }
+
+  /* ---- EUDR assessment ---- */
+  async function requestEudrAssessment() {
+    var loading = document.getElementById('app-evidence-eudr-loading');
+    var content = document.getElementById('app-evidence-eudr-content');
+    var btn = document.getElementById('app-evidence-eudr-btn');
+    if (!loading || !content || !evidenceManifest) return;
+
+    if (btn) btn.disabled = true;
+    loading.hidden = false;
+    content.innerHTML = '';
+
+    try {
+      await apiDiscoveryReady;
+
+      var ndviTimeseries = (evidenceManifest.ndvi_stats || []).map(function(f) {
+        return { date: f.date || f.label, mean: f.mean, min: f.min, max: f.max, year: f.year, season: f.season };
+      });
+      var center = evidenceManifest.center || evidenceManifest.coords;
+      var lat = Array.isArray(center) ? center[0] : (center && center.lat) || 0;
+      var lon = Array.isArray(center) ? center[1] : (center && center.lon) || 0;
+
+      var body = {
+        context: {
+          aoi_name: 'Analysis area',
+          latitude: lat,
+          longitude: lon,
+          ndvi_timeseries: ndviTimeseries,
+          reference_date: '2020-12-31'
+        }
+      };
+
+      var res = await apiFetch('/api/eudr-assessment', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+
+      if (!res || !res.ok) {
+        var err = res ? await res.json().catch(function() { return {}; }) : {};
+        throw new Error(err.error || 'EUDR assessment failed.');
+      }
+
+      var result = await res.json();
+      var cls = (result.compliant || result.deforestation_free) ? 'compliant' : 'non-compliant';
+      var label = cls === 'compliant' ? '✓ No deforestation detected since Dec 2020' : '⚠ Potential deforestation detected';
+      content.innerHTML = '<div class="app-evidence-eudr-result ' + cls + '">' +
+        '<strong>' + escHtml(label) + '</strong>' +
+        (result.summary ? '<p>' + escHtml(result.summary) + '</p>' : '') +
+        '</div>';
+    } catch (err) {
+      content.innerHTML = '<div class="app-callout" data-tone="error">' + escHtml((err && err.message) || 'Could not run EUDR assessment.') + '</div>';
+    } finally {
+      loading.hidden = true;
+      if (btn) btn.disabled = false;
+    }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  END Evidence surface                                               */
+  /* ------------------------------------------------------------------ */
+
+  function updateContentSummary(data) {
+    var role = currentRoleConfig();
+    var imageryEl = document.getElementById('app-content-imagery');
+    var imageryNoteEl = document.getElementById('app-content-imagery-note');
+    var enrichmentEl = document.getElementById('app-content-enrichment');
+    var enrichmentNoteEl = document.getElementById('app-content-enrichment-note');
+    var exportsEl = document.getElementById('app-content-exports');
+    var exportsNoteEl = document.getElementById('app-content-exports-note');
+    if (!imageryEl || !imageryNoteEl || !enrichmentEl || !enrichmentNoteEl || !exportsEl || !exportsNoteEl) return;
+
+    if (!data) {
+      showEvidenceSurface(false);
+      imageryEl.textContent = role.emptyContent.imageryTitle;
+      imageryNoteEl.textContent = role.emptyContent.imageryNote;
+      enrichmentEl.textContent = role.emptyContent.enrichmentTitle;
+      enrichmentNoteEl.textContent = role.emptyContent.enrichmentNote;
+      exportsEl.textContent = role.emptyContent.exportsTitle;
+      exportsNoteEl.textContent = role.emptyContent.exportsNote;
+      return;
+    }
+
+    var runtimeStatus = data.runtimeStatus || 'Pending';
+    var phase = (data.customStatus && data.customStatus.phase) || 'queued';
+
+    if (runtimeStatus === 'Completed') {
+      // Evidence surface is loaded by loadRunEvidence(), triggered from selectAnalysisRun
+      // Phase status is hidden; evidence surface is shown
+      return;
+    }
+
+    showEvidenceSurface(false);
+
+    if (runtimeStatus === 'Failed' || runtimeStatus === 'Canceled' || runtimeStatus === 'Terminated') {
+      imageryEl.textContent = 'Run interrupted';
+      imageryNoteEl.textContent = 'The pipeline stopped before the imagery stack completed.';
+      enrichmentEl.textContent = 'Context incomplete';
+      enrichmentNoteEl.textContent = 'This run needs explicit failure handling rather than silent fallback behavior.';
+      exportsEl.textContent = 'Nothing staged';
+      exportsNoteEl.textContent = 'No saved outputs should be implied when the real pipeline fails.';
+      return;
+    }
+
+    if (phase === 'ingestion' || phase === 'queued') {
+      imageryEl.textContent = 'AOIs preparing';
+      imageryNoteEl.textContent = 'The workspace is validating geometry and shaping the request for imagery search.';
+      enrichmentEl.textContent = 'Waiting on imagery';
+      enrichmentNoteEl.textContent = 'Context layers follow once the pipeline has something real to attach to.';
+      exportsEl.textContent = 'No outputs yet';
+      exportsNoteEl.textContent = 'Saved artifacts stay unavailable until a real run starts producing outputs.';
+      return;
+    }
+
+    if (phase === 'acquisition') {
+      imageryEl.textContent = 'Scene search underway';
+      imageryNoteEl.textContent = 'NAIP and Sentinel-2 discovery is in progress so the run can pick the right source imagery.';
+      enrichmentEl.textContent = 'Queued behind acquisition';
+      enrichmentNoteEl.textContent = 'Context layers are staged after the imagery stack is selected.';
+      exportsEl.textContent = 'Awaiting artefacts';
+      exportsNoteEl.textContent = 'There is nothing to export until imagery is actually acquired.';
+      return;
+    }
+
+    if (phase === 'fulfilment') {
+      imageryEl.textContent = 'Clipping and reprojection';
+      imageryNoteEl.textContent = 'The pipeline is producing the concrete imagery assets that the signed-in workspace should eventually reopen.';
+      enrichmentEl.textContent = 'Preparing next';
+      enrichmentNoteEl.textContent = 'NDVI and weather context will follow immediately after fulfilment finishes.';
+      exportsEl.textContent = 'Outputs staging next';
+      exportsNoteEl.textContent = 'The run is close enough that saved outputs should feel tangible, not hypothetical.';
+      return;
+    }
+
+    imageryEl.textContent = 'Imagery stack stabilizing';
+    imageryNoteEl.textContent = 'Core imagery is in place and the workspace is adding the last supporting layers.';
+    enrichmentEl.textContent = 'Context packaging';
+    enrichmentNoteEl.textContent = 'NDVI, weather, and derived context are being assembled for the run detail experience.';
+    exportsEl.textContent = 'Preparing reopen surface';
+    exportsNoteEl.textContent = 'The next signed-in slices should turn this into saved outputs, exports, and revisit paths.';
+  }
+
+  function updateRunDetail(data) {
+    var submittedEl = document.getElementById('app-run-submitted');
+    var submittedNoteEl = document.getElementById('app-run-submitted-note');
+    var scopeEl = document.getElementById('app-run-scope');
+    var scopeNoteEl = document.getElementById('app-run-scope-note');
+    var deliveryEl = document.getElementById('app-run-delivery');
+    var deliveryNoteEl = document.getElementById('app-run-delivery-note');
+    var linkLabelEl = document.getElementById('app-run-link-label');
+    var linkEl = document.getElementById('app-run-link');
+    var exportNoteEl = document.getElementById('app-run-export-note');
+    if (!submittedEl || !submittedNoteEl || !scopeEl || !scopeNoteEl || !deliveryEl || !deliveryNoteEl || !linkLabelEl || !linkEl || !exportNoteEl) return;
+
+    if (!data) {
+      submittedEl.textContent = '—';
+      submittedNoteEl.textContent = 'Signed-in run detail restores here after reload.';
+      scopeEl.textContent = '—';
+      scopeNoteEl.textContent = 'Feature and AOI counts appear when known.';
+      deliveryEl.textContent = '—';
+      deliveryNoteEl.textContent = 'Failure counts and tracked artifacts will appear here.';
+      linkLabelEl.textContent = 'Dashboard state';
+      linkEl.href = '/app/';
+      linkEl.textContent = 'Open durable run state';
+      exportNoteEl.textContent = 'Completed runs can download GeoJSON, CSV, and PDF exports here.';
+      document.querySelectorAll('[data-export-format]').forEach(function(button) {
+        button.disabled = true;
+      });
+      return;
+    }
+
+    var runtimeStatus = data.runtimeStatus || 'Pending';
+    var timing = summarizeRunTiming(data);
+    var scopeSummary = [
+      formatCountLabel(data.featureCount, 'feature'),
+      formatCountLabel(data.aoiCount, 'AOI'),
+      data.processingMode,
+    ].filter(Boolean).join(' • ');
+    var scopeNote = [
+      data.maxSpreadKm != null ? 'Spread ' + formatDistance(data.maxSpreadKm) : null,
+      data.totalAreaHa != null ? 'Area ' + formatHectares(data.totalAreaHa) : null,
+      providerLabel(data.providerName),
+    ].filter(Boolean).join(' • ');
+    var failureSummary = summarizeFailureCounts(data.partialFailures);
+    var artifactCount = data.artifactCount || 0;
+
+    submittedEl.textContent = formatHistoryTimestamp(data.submittedAt || data.createdTime);
+    submittedNoteEl.textContent = timing.sinceUpdate
+      ? 'Last backend update ' + timing.sinceUpdate + ' ago.'
+      : 'Signed-in run history keeps this state durable across reloads.';
+    scopeEl.textContent = scopeSummary || 'Scope loading';
+    scopeNoteEl.textContent = scopeNote || 'Preflight detail appears when the run metadata is available.';
+
+    if (runtimeStatus === 'Completed') {
+      deliveryEl.textContent = artifactCount ? artifactCount + ' tracked outputs' : 'Exports ready';
+      deliveryNoteEl.textContent = failureSummary || 'GeoJSON, CSV, and PDF exports are ready for this completed run.';
+      exportNoteEl.textContent = 'Use these export actions to inspect or download the completed signed-in result set.';
+    } else if (runtimeStatus === 'Failed' || runtimeStatus === 'Canceled' || runtimeStatus === 'Terminated') {
+      deliveryEl.textContent = 'Run interrupted';
+      deliveryNoteEl.textContent = failureSummary || 'This run stopped before producing a complete result set.';
+      exportNoteEl.textContent = 'Exports stay unavailable when the real pipeline does not complete.';
+    } else {
+      deliveryEl.textContent = 'Tracking live pipeline';
+      deliveryNoteEl.textContent = failureSummary || 'Results will unlock here when the signed-in run completes.';
+      exportNoteEl.textContent = 'Exports unlock automatically after the enrichment manifest is ready.';
+    }
+
+    linkLabelEl.textContent = 'Durable run state';
+    linkEl.href = selectedRunPermalink(data.instanceId || data.instance_id, 'run');
+    linkEl.textContent = 'Open this run directly';
+
+    document.querySelectorAll('[data-export-format]').forEach(function(button) {
+      button.disabled = runtimeStatus !== 'Completed';
+    });
+    var evidenceExportNote = document.getElementById('app-evidence-export-note');
+    if (evidenceExportNote) {
+      evidenceExportNote.textContent = runtimeStatus === 'Completed'
+        ? 'Download GeoJSON, CSV, or PDF for this completed run.'
+        : 'Exports unlock when the selected run completes.';
+    }
+  }
+
+  async function downloadRunExport(format) {
+    var run = latestAnalysisRun;
+    if (!run || !(run.instanceId || run.instance_id)) {
+      setAnalysisStatus('Select a run first.', 'error');
+      return;
+    }
+
+    var instanceId = run.instanceId || run.instance_id;
+    if ((run.runtimeStatus || '') !== 'Completed') {
+      setAnalysisStatus('Exports become available once the selected run completes.', 'info');
+      return;
+    }
+
+    var button = document.querySelector('[data-export-format="' + format + '"]');
+    var originalText = button ? button.textContent : format.toUpperCase();
+    if (button) {
+      button.disabled = true;
+      button.textContent = 'Preparing…';
+    }
+
+    try {
+      await apiDiscoveryReady;
+      var res = await apiFetch('/api/export/' + encodeURIComponent(instanceId) + '/' + format);
+      if (!res || !res.ok) {
+        var err = res ? await res.json().catch(function() { return {}; }) : {};
+        throw new Error(err.error || 'Could not prepare the export.');
+      }
+      var blob = await res.blob();
+      var blobUrl = URL.createObjectURL(blob);
+      var link = document.createElement('a');
+      link.href = blobUrl;
+      link.download = parseDownloadFilename(res, 'treesight_' + instanceId + '.' + format);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(blobUrl);
+      setAnalysisStatus(format.toUpperCase() + ' export downloaded for the selected run.', 'success');
+    } catch (err) {
+      setAnalysisStatus((err && err.message) || 'Could not download the selected export.', 'error');
+    } finally {
+      if (button) {
+        button.disabled = (latestAnalysisRun && latestAnalysisRun.runtimeStatus !== 'Completed');
+        button.textContent = originalText;
+      }
+    }
+  }
+
+  function updateAnalysisRun(data) {
+    var panel = document.getElementById('app-analysis-run');
+    latestAnalysisRun = data || null;
+    if (!panel) return;
+    if (!data) {
+      panel.hidden = true;
+      setHeroRunSummary('Ready to queue', currentRoleConfig().readyNote);
+      updateHistorySummary(null);
+      updateRunDetail(null);
+      updateContentSummary(null);
+      return;
+    }
+    panel.hidden = false;
+    var instanceId = data.instanceId || data.instance_id || '—';
+    var runtimeStatus = data.runtimeStatus || 'queued';
+    var phase = displayAnalysisPhase(data.customStatus, runtimeStatus);
+    var timing = summarizeRunTiming(data);
+    document.getElementById('app-analysis-instance').textContent = instanceId;
+    document.getElementById('app-analysis-runtime').textContent = runtimeStatus;
+    document.getElementById('app-analysis-phase').textContent = phase;
+    setHeroRunSummary(
+      runtimeStatus,
+      runtimeStatus === 'Completed'
+        ? 'Pipeline finished successfully and is ready for the next signed-in surface.'
+        : 'Current phase: ' + phase + '.' + (timing.elapsed ? ' Elapsed ' + timing.elapsed + '.' : '')
+    );
+    updateHistorySummary(data);
+    updateRunDetail(data);
+    updateContentSummary(data);
+  }
+
+  function resetAnalysisProgress() {
+    var progress = document.getElementById('app-analysis-progress');
+    if (!progress) return;
+    progress.hidden = true;
+    progress.querySelectorAll('.pipeline-step').forEach(function(el) {
+      el.className = 'pipeline-step';
+      var icon = el.querySelector('.step-icon');
+      if (icon) icon.textContent = '○';
+    });
+  }
+
+  function setAnalysisProgressVisible(visible) {
+    var progress = document.getElementById('app-analysis-progress');
+    if (!progress) return;
+    progress.hidden = !visible;
+  }
+
+  function setAnalysisStep(phase, state) {
+    var steps = document.querySelectorAll('#app-analysis-progress .pipeline-step');
+    steps.forEach(function(el) {
+      var stepPhase = el.getAttribute('data-phase');
+      var icon = el.querySelector('.step-icon');
+      el.className = 'pipeline-step';
+
+      if (stepPhase === phase) {
+        el.classList.add(state === 'failed' ? 'failed' : state === 'done' ? 'done' : 'active');
+        if (!icon) return;
+        if (state === 'done') {
+          icon.textContent = '✓';
+        } else if (state === 'failed') {
+          icon.textContent = '✗';
+        } else {
+          icon.replaceChildren();
+          var spinner = document.createElement('span');
+          spinner.className = 'spinner';
+          icon.appendChild(spinner);
+        }
+        return;
+      }
+
+      if (!icon) return;
+      var stepIndex = ANALYSIS_PHASES.indexOf(stepPhase);
+      var currentIndex = ANALYSIS_PHASES.indexOf(phase);
+      if (stepIndex > -1 && currentIndex > -1 && stepIndex < currentIndex) {
+        el.classList.add('done');
+        icon.textContent = '✓';
+      } else {
+        icon.textContent = '○';
+      }
+    });
+  }
+
+  function mapAnalysisPhase(customStatus, runtimeStatus) {
+    if (runtimeStatus === 'Completed') return 'complete';
+    if (customStatus && customStatus.phase && ANALYSIS_PHASES.indexOf(customStatus.phase) > -1) {
+      return customStatus.phase;
+    }
+    return 'submit';
+  }
+
+  function updateAnalysisStory(phase, runtimeStatus, data) {
+    var runtime = runtimeStatus || 'Pending';
+    var detail = ANALYSIS_PHASE_DETAILS[phase] || 'Working through the analysis pipeline.';
+    var timing = summarizeRunTiming(data);
+
+    if (runtime !== 'Completed' && phase === 'enrichment') {
+      detail += ' Enrichment is the slowest local step because it batches weather, flood/fire checks, mosaic registration, NDVI, change detection, and manifest generation.';
+      if (timing.sinceUpdate) {
+        detail += ' Last backend update ' + timing.sinceUpdate + ' ago.';
+      }
+      if (timing.stale) {
+        detail += ' The UI will stay on this message until the enrichment activity finishes because the backend only publishes the next status after that activity returns.';
+      }
+    } else if (runtime !== 'Completed' && timing.elapsed) {
+      detail += ' Elapsed ' + timing.elapsed + '.';
+    }
+
+    if (runtime === 'Completed') {
+      setAnalysisStatus(detail, 'success');
+      return;
+    }
+    if (runtime === 'Failed' || runtime === 'Canceled' || runtime === 'Terminated') {
+      setAnalysisStatus('Analysis stopped during ' + phase + '. ' + detail, 'error');
+      return;
+    }
+    setAnalysisStatus(detail, 'info');
+  }
+
+  function parseKmlText(text) {
+    if (!text) return '';
+    return String(text).trim();
+  }
+
+  function parseCoordText(text) {
+    var raw = String(text || '').trim().split(/\s+/).filter(Boolean);
+    var coords = raw.map(function(chunk) {
+      var parts = chunk.split(',');
+      return [parseFloat(parts[1]), parseFloat(parts[0])];
+    }).filter(function(coord) {
+      return !isNaN(coord[0]) && !isNaN(coord[1]);
+    });
+    if (coords.length < 3) return null;
+    if (coords[0][0] !== coords[coords.length - 1][0] || coords[0][1] !== coords[coords.length - 1][1]) {
+      coords.push(coords[0].slice());
+    }
+    return coords;
+  }
+
+  function parseKmlGeometry(text) {
+    var parser = new DOMParser();
+    var doc = parser.parseFromString(text, 'text/xml');
+    if (doc.getElementsByTagName('parsererror').length) {
+      return { error: 'Could not parse the KML markup. Check that the XML is complete.' };
+    }
+
+    var placemarks = doc.getElementsByTagName('Placemark');
+    var polygons = [];
+    for (var p = 0; p < placemarks.length; p++) {
+      var coordEls = placemarks[p].getElementsByTagName('coordinates');
+      var nameEl = placemarks[p].getElementsByTagName('name')[0];
+      var polygonName = nameEl ? nameEl.textContent.trim() : 'Polygon ' + (polygons.length + 1);
+      for (var c = 0; c < coordEls.length; c++) {
+        var coords = parseCoordText(coordEls[c].textContent);
+        if (coords) polygons.push({ name: polygonName, coords: coords });
+      }
+    }
+
+    if (!polygons.length) {
+      var allCoords = doc.getElementsByTagName('coordinates');
+      for (var i = 0; i < allCoords.length; i++) {
+        var fallbackCoords = parseCoordText(allCoords[i].textContent);
+        if (fallbackCoords) polygons.push({ name: 'Polygon ' + (polygons.length + 1), coords: fallbackCoords });
+      }
+    }
+
+    return {
+      featureCount: placemarks.length || polygons.length,
+      polygons: polygons,
+    };
+  }
+
+  function haversineKm(lat1, lon1, lat2, lon2) {
+    var radiusKm = 6371;
+    var dLat = (lat2 - lat1) * Math.PI / 180;
+    var dLon = (lon2 - lon1) * Math.PI / 180;
+    var a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+      Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
+      Math.sin(dLon / 2) * Math.sin(dLon / 2);
+    return radiusKm * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  }
+
+  function polygonCentroid(coords) {
+    var latTotal = 0;
+    var lonTotal = 0;
+    var count = coords.length - 1;
+    for (var i = 0; i < count; i++) {
+      latTotal += coords[i][0];
+      lonTotal += coords[i][1];
+    }
+    return [latTotal / count, lonTotal / count];
+  }
+
+  function polygonAreaHa(coords) {
+    if (!coords || coords.length < 4) return 0;
+    var usable = coords.slice(0, -1);
+    var meanLat = usable.reduce(function(sum, coord) { return sum + coord[0]; }, 0) / usable.length;
+    var metresPerDegreeLat = 111320;
+    var metresPerDegreeLon = Math.cos(meanLat * Math.PI / 180) * metresPerDegreeLat;
+    var areaM2 = 0;
+    for (var i = 0; i < coords.length - 1; i++) {
+      var x1 = coords[i][1] * metresPerDegreeLon;
+      var y1 = coords[i][0] * metresPerDegreeLat;
+      var x2 = coords[i + 1][1] * metresPerDegreeLon;
+      var y2 = coords[i + 1][0] * metresPerDegreeLat;
+      areaM2 += (x1 * y2) - (x2 * y1);
+    }
+    return Math.abs(areaM2) / 2 / 10000;
+  }
+
+  function formatDistance(km) {
+    if (km == null || isNaN(km)) return '—';
+    if (km < 1) return '<1 km';
+    return (km >= 10 ? km.toFixed(0) : km.toFixed(1)) + ' km';
+  }
+
+  function formatHectares(ha) {
+    if (ha == null || isNaN(ha)) return '—';
+    if (ha < 1) return ha.toFixed(1) + ' ha';
+    return Math.round(ha).toLocaleString() + ' ha';
+  }
+
+  function determineProcessingMode(aoiCount, maxSpreadKm) {
+    if (aoiCount > 30 || maxSpreadKm > 100) return 'May batch';
+    if (aoiCount > 6 || maxSpreadKm > 25) return 'Bulk-ready';
+    return 'Single run';
+  }
+
+  function buildPreflightWarnings(preflight) {
+    var warnings = [];
+    if (preflight.aoiCount > 30) {
+      warnings.push({ tone: 'warning', text: preflight.aoiCount + ' AOIs detected. Large batches may take longer and could be split across runs.' });
+    } else if (preflight.aoiCount > 6) {
+      warnings.push({ tone: 'info', text: preflight.aoiCount + ' AOIs — this will queue as a bulk-ready run.' });
+    }
+    if (preflight.largestAreaHa > 50000) {
+      warnings.push({ tone: 'warning', text: 'At least one AOI covers ' + formatHectares(preflight.largestAreaHa) + '. Very large areas may produce lower-resolution output.' });
+    }
+    if (preflight.maxSpreadKm > 100) {
+      warnings.push({ tone: 'warning', text: 'AOI spread is ' + formatDistance(preflight.maxSpreadKm) + '. Widely spread areas may need batching in a future release.' });
+    } else if (preflight.maxSpreadKm > 25) {
+      warnings.push({ tone: 'info', text: 'AOI spread is ' + formatDistance(preflight.maxSpreadKm) + '. All areas will be processed in one run.' });
+    }
+    if (workspaceRole === 'eudr') {
+      warnings.push({ tone: 'info', text: 'This due diligence lens frames evidence for review and audit support. It is not a legal compliance certificate.' });
+    }
+    if (workspaceRole === 'portfolio' && preflight.aoiCount > 10) {
+      warnings.push({ tone: 'info', text: 'Large parcel sets are a good fit for later batch surfaces. This run still enters the tracked signed-in workflow today.' });
+    }
+    if (!warnings.length) {
+      warnings.push({ tone: 'info', text: 'No warnings. This will queue as one tracked analysis run.' });
+    }
+    return warnings;
+  }
+
+  function buildAnalysisPreflight(text) {
+    var trimmed = parseKmlText(text);
+    if (!trimmed) return null;
+
+    var parsed = parseKmlGeometry(trimmed);
+    if (parsed.error) return { error: parsed.error };
+    if (!parsed.polygons || !parsed.polygons.length) {
+      return { error: 'No polygon boundaries were detected. TreeSight expects polygon AOIs in the signed-in workflow.' };
+    }
+
+    var centroids = parsed.polygons.map(function(polygon) { return polygonCentroid(polygon.coords); });
+    var groupLat = centroids.reduce(function(sum, coord) { return sum + coord[0]; }, 0) / centroids.length;
+    var groupLon = centroids.reduce(function(sum, coord) { return sum + coord[1]; }, 0) / centroids.length;
+    var maxSpreadKm = centroids.reduce(function(maxDistance, coord) {
+      return Math.max(maxDistance, haversineKm(groupLat, groupLon, coord[0], coord[1]));
+    }, 0);
+    var totalAreaHa = parsed.polygons.reduce(function(sum, polygon) {
+      return sum + polygonAreaHa(polygon.coords);
+    }, 0);
+    var largestAreaHa = parsed.polygons.reduce(function(maxArea, polygon) {
+      return Math.max(maxArea, polygonAreaHa(polygon.coords));
+    }, 0);
+    var processingMode = determineProcessingMode(parsed.polygons.length, maxSpreadKm);
+    var preference = currentPreferenceConfig();
+
+    var preflight = {
+      featureCount: parsed.featureCount,
+      aoiCount: parsed.polygons.length,
+      maxSpreadKm: maxSpreadKm,
+      totalAreaHa: totalAreaHa,
+      largestAreaHa: largestAreaHa,
+      processingMode: processingMode,
+      quotaImpact: latestBillingStatus && latestBillingStatus.runs_remaining != null
+        ? '1 of ' + latestBillingStatus.runs_remaining + ' runs'
+        : '1 signed-in run',
+      summary: parsed.featureCount + ' features across ' + parsed.polygons.length + ' AOIs covering about ' + formatHectares(totalAreaHa) + '. ' + processingMode + ' keeps the ' + preference.focusLabel.toLowerCase() + ' in focus for this request.'
+    };
+    preflight.warnings = buildPreflightWarnings(preflight);
+    return preflight;
+  }
+
+  function renderPreflightWarnings(items) {
+    var list = document.getElementById('app-preflight-warnings');
+    if (!list) return;
+    list.replaceChildren();
+    items.forEach(function(item) {
+      var el = document.createElement('div');
+      el.className = 'app-preflight-item';
+      el.setAttribute('data-tone', item.tone || 'info');
+      el.textContent = item.text;
+      list.appendChild(el);
+    });
+  }
+
+  function updateAnalysisPreflight(text) {
+    var headlineEl = document.getElementById('app-preflight-headline');
+    var modeEl = document.getElementById('app-preflight-mode');
+    var summaryEl = document.getElementById('app-preflight-summary');
+    var featuresEl = document.getElementById('app-preflight-features');
+    var aoisEl = document.getElementById('app-preflight-aois');
+    var spreadEl = document.getElementById('app-preflight-spread');
+    var quotaEl = document.getElementById('app-preflight-quota');
+    if (!headlineEl || !modeEl || !summaryEl || !featuresEl || !aoisEl || !spreadEl || !quotaEl) return null;
+
+    var role = currentRoleConfig();
+    var trimmed = parseKmlText(text);
+    if (!trimmed) {
+      analysisDraftSummary = null;
+      headlineEl.textContent = 'Awaiting KML';
+      modeEl.textContent = 'No file yet';
+      summaryEl.textContent = 'Paste KML to see feature count, AOI spread, and signed-in product guidance for the ' + role.label + ' view.';
+      featuresEl.textContent = '0';
+      aoisEl.textContent = '0';
+      spreadEl.textContent = '—';
+      quotaEl.textContent = '—';
+      renderPreflightWarnings([{ tone: 'info', text: 'Signed-in preflight will surface warnings here instead of inheriting demo-only rejections.' }]);
+      return null;
+    }
+
+    var preflight = buildAnalysisPreflight(trimmed);
+    analysisDraftSummary = preflight;
+    if (preflight && preflight.error) {
+      headlineEl.textContent = 'KML needs attention';
+      modeEl.textContent = 'Check geometry';
+      summaryEl.textContent = preflight.error;
+      featuresEl.textContent = '—';
+      aoisEl.textContent = '—';
+      spreadEl.textContent = '—';
+      quotaEl.textContent = '—';
+      renderPreflightWarnings([{ tone: 'error', text: preflight.error }]);
+      return preflight;
+    }
+
+    headlineEl.textContent = preflight.aoiCount + '-AOI request ready';
+    modeEl.textContent = preflight.processingMode;
+    summaryEl.textContent = preflight.summary;
+    featuresEl.textContent = String(preflight.featureCount);
+    aoisEl.textContent = String(preflight.aoiCount);
+    spreadEl.textContent = formatDistance(preflight.maxSpreadKm);
+    quotaEl.textContent = preflight.quotaImpact;
+    renderPreflightWarnings(preflight.warnings);
+    return preflight;
+  }
+
+  function readKmlFile(file) {
+    return new Promise(function(resolve, reject) {
+      var reader = new FileReader();
+      reader.onload = function(e) { resolve(String(e.target.result || '')); };
+      reader.onerror = function() { reject(new Error('Could not read KML file')); };
+      reader.readAsText(file);
+    });
+  }
+
+  async function readKmzFile(file) {
+    var buffer = await file.arrayBuffer();
+    var view = new DataView(buffer);
+    var offset = 0;
+
+    while (offset < buffer.byteLength - 4) {
+      var signature = view.getUint32(offset, true);
+      if (signature !== 0x04034b50) break;
+      var compressionMethod = view.getUint16(offset + 8, true);
+      var compressedSize = view.getUint32(offset + 18, true);
+      var fileNameLength = view.getUint16(offset + 26, true);
+      var extraLength = view.getUint16(offset + 28, true);
+      var fileNameBytes = new Uint8Array(buffer, offset + 30, fileNameLength);
+      var fileName = new TextDecoder().decode(fileNameBytes);
+      var dataStart = offset + 30 + fileNameLength + extraLength;
+
+      if (fileName.toLowerCase().endsWith('.kml')) {
+        var compressed = new Uint8Array(buffer, dataStart, compressedSize);
+        if (compressionMethod === 0) {
+          return new TextDecoder().decode(compressed);
+        }
+        if (compressionMethod === 8) {
+          var stream = new Blob([compressed]).stream().pipeThrough(new DecompressionStream('deflate-raw'));
+          return await new Response(stream).text();
+        }
+      }
+      offset = dataStart + compressedSize;
+    }
+
+    throw new Error('No .kml found inside KMZ archive');
+  }
+
+  async function loadAnalysisFile(file) {
+    var note = document.getElementById('app-analysis-file-note');
+    var textarea = document.getElementById('app-analysis-kml');
+    if (!file || !note || !textarea) return;
+
+    try {
+      var name = file.name.toLowerCase();
+      var content = name.endsWith('.kmz') ? await readKmzFile(file) : await readKmlFile(file);
+      textarea.value = content;
+      note.textContent = 'Loaded ' + file.name + ' into the signed-in analysis form.';
+      updateAnalysisPreflight(content);
+    } catch (err) {
+      note.textContent = err.message || 'Could not read file';
+    }
+  }
+
+  function stopAnalysisPolling() {
+    if (activeAnalysisPoll) {
+      clearInterval(activeAnalysisPoll);
+      activeAnalysisPoll = null;
+    }
+  }
+
+  async function pollAnalysisRun(instanceId) {
+    stopAnalysisPolling();
+    async function refreshRun() {
+      try {
+        var res = await apiFetch('/api/orchestrator/' + instanceId);
+        if (!res || !res.ok) return null;
+        var data = await res.json();
+        upsertAnalysisHistoryRun(data);
+        updateAnalysisRun(data);
+
+        var runtime = data.runtimeStatus || '';
+        var phase = mapAnalysisPhase(data.customStatus, runtime);
+        setAnalysisProgressVisible(true);
+        if (runtime === 'Completed') {
+          stopAnalysisPolling();
+          setAnalysisStep('complete', 'done');
+          updateAnalysisStory('complete', runtime, data);
+          loadBillingStatus();
+          loadAnalysisHistory({ preferInstanceId: instanceId });
+        } else if (runtime === 'Failed' || runtime === 'Canceled' || runtime === 'Terminated') {
+          stopAnalysisPolling();
+          setAnalysisStep(phase, 'failed');
+          updateAnalysisStory(phase, runtime, data);
+          loadAnalysisHistory({ preferInstanceId: instanceId });
+        } else {
+          setAnalysisStep(phase, 'active');
+          updateAnalysisStory(phase, runtime || 'Pending', data);
+        }
+        return data;
+      } catch {
+        return null;
+      }
+    }
+
+    var initialData = await refreshRun();
+    if (initialData) {
+      var initialRuntime = initialData.runtimeStatus || '';
+      if (initialRuntime === 'Completed' || initialRuntime === 'Failed' || initialRuntime === 'Canceled' || initialRuntime === 'Terminated') {
+        return;
+      }
+    }
+
+    activeAnalysisPoll = setInterval(function() {
+      refreshRun();
+    }, 3000);
+  }
+
+  async function submitAnalysis() {
+    if (!currentAccount) {
+      login();
+      return;
+    }
+
+    var button = document.getElementById('app-analysis-submit-btn');
+    var textarea = document.getElementById('app-analysis-kml');
+    if (!button || !textarea) return;
+
+    var kmlContent = parseKmlText(textarea.value);
+    if (!kmlContent) {
+      setAnalysisStatus('Paste KML content or load a KML/KMZ file first.', 'error');
+      updateAnalysisRun(null);
+      resetAnalysisProgress();
+      return;
+    }
+
+    var preflight = analysisDraftSummary || updateAnalysisPreflight(kmlContent);
+    if (preflight && preflight.error) {
+      setAnalysisStatus(preflight.error, 'error');
+      resetAnalysisProgress();
+      return;
+    }
+
+    button.disabled = true;
+    button.textContent = 'Queueing…';
+    resetAnalysisProgress();
+    setAnalysisProgressVisible(true);
+    setAnalysisStep('submit', 'active');
+    setWorkflowFocus('run');
+    updateAnalysisStory('submit', 'Pending', null);
+    updateAnalysisRun(null);
+
+    try {
+      await apiDiscoveryReady;
+      var submissionContext = preflight ? {
+        feature_count: preflight.featureCount,
+        aoi_count: preflight.aoiCount,
+        max_spread_km: preflight.maxSpreadKm,
+        total_area_ha: preflight.totalAreaHa,
+        largest_area_ha: preflight.largestAreaHa,
+        processing_mode: preflight.processingMode,
+        provider_name: 'planetary_computer',
+        workspace_role: workspaceRole,
+        workspace_preference: workspacePreference
+      } : null;
+      var res = await apiFetch('/api/analysis/submit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          kml_content: kmlContent,
+          submission_context: submissionContext
+        })
+      });
+      if (!res || !res.ok) {
+        var err = res ? await res.json().catch(function(){ return {}; }) : {};
+        setAnalysisStatus(err.error || 'Could not queue analysis request.', 'error');
+        updateContentSummary(null);
+        return;
+      }
+
+      var data = await res.json();
+      analysisHistoryLoaded = true;
+      applyFirstRunLayout();
+      var queuedAt = new Date().toISOString();
+      upsertAnalysisHistoryRun({
+        instanceId: data.instance_id,
+        submittedAt: queuedAt,
+        createdTime: queuedAt,
+        lastUpdatedTime: queuedAt,
+        runtimeStatus: 'Pending',
+        customStatus: { phase: 'queued' },
+        providerName: 'planetary_computer',
+        featureCount: preflight && preflight.featureCount,
+        aoiCount: preflight && preflight.aoiCount,
+        processingMode: preflight && preflight.processingMode,
+        maxSpreadKm: preflight && preflight.maxSpreadKm,
+        totalAreaHa: preflight && preflight.totalAreaHa,
+        largestAreaHa: preflight && preflight.largestAreaHa,
+        workspaceRole: workspaceRole,
+        workspacePreference: workspacePreference
+      });
+      selectAnalysisRun(data.instance_id, { focus: 'run', resume: true });
+      setAnalysisStatus('Analysis queued. The app will walk through each stage as the pipeline advances.', 'info');
+      loadBillingStatus();
+    } catch {
+      setAnalysisStatus('Could not queue analysis request.', 'error');
+      resetAnalysisProgress();
+    } finally {
+      button.disabled = false;
+      button.textContent = 'Queue Analysis';
+    }
+  }
+
+  async function manageBilling() {
+    if (!currentAccount) {
+      login();
+      return;
+    }
+
+    await apiDiscoveryReady;
+    try {
+      var res = await apiFetch('/api/billing/portal', { method: 'POST' });
+      if (!res || !res.ok) {
+        var err = res ? await res.json().catch(function(){ return {}; }) : {};
+        alert(err.error || 'Could not open billing portal. Please try again.');
+        return;
+      }
+      var data = await res.json();
+      if (data.portal_url) window.location.href = data.portal_url;
+    } catch {
+      alert('Could not open billing portal. Please try again.');
+    }
+  }
+
+  function formatRetention(days) {
+    if (days == null) return 'Custom';
+    if (days === 365) return '1 year';
+    return String(days) + ' days';
+  }
+
+  function updateCapabilityFields(caps) {
+    document.getElementById('app-concurrency').textContent = caps.concurrency == null ? '—' : String(caps.concurrency);
+    document.getElementById('app-ai-access').textContent = caps.ai_insights ? 'Included' : 'Not included';
+    document.getElementById('app-api-access').textContent = caps.api_access ? 'Enabled' : 'Not included';
+    document.getElementById('app-retention').textContent = formatRetention(caps.retention_days);
+  }
+
+  function renderTierEmulation(data) {
+    var card = document.getElementById('app-tier-emulation-card');
+    var select = document.getElementById('app-tier-emulation-select');
+    var note = document.getElementById('app-tier-emulation-note');
+
+    if (!card || !select || !note) return;
+
+    if (!data.emulation || !data.emulation.available) {
+      card.hidden = true;
+      return;
+    }
+
+    card.hidden = false;
+    select.replaceChildren();
+
+    var actualOption = document.createElement('option');
+    actualOption.value = 'actual';
+    actualOption.textContent = 'Actual billing state';
+    select.appendChild(actualOption);
+
+    (data.emulation.tiers || []).forEach(function(tier) {
+      var option = document.createElement('option');
+      option.value = tier;
+      option.textContent = tier.charAt(0).toUpperCase() + tier.slice(1);
+      select.appendChild(option);
+    });
+
+    select.value = data.emulation.active ? data.emulation.tier : 'actual';
+    if (data.emulation.active) {
+      note.textContent = 'Currently emulating ' + (data.capabilities.label || data.tier) + ' for this signed-in account. Billing remains ' + ((data.subscription && data.subscription.tier) || 'free') + '.';
+    } else {
+      note.textContent = 'Using the actual billing state for this account.';
+    }
+  }
+
+  function applyBillingStatus(data) {
+    var tierEl = document.getElementById('app-tier');
+    var statusEl = document.getElementById('app-subscription-status');
+    var remainingEl = document.getElementById('app-runs-remaining');
+    var billingNoteEl = document.getElementById('app-billing-note');
+    var billingBtn = document.getElementById('app-manage-billing-btn');
+    var accountNote = document.getElementById('app-account-note');
+    var caps = data.capabilities || {};
+
+    latestBillingStatus = data;
+    tierEl.textContent = (caps.label || data.tier || 'Free') + (data.tier_source === 'emulated' ? ' (emulated)' : '');
+    statusEl.textContent = data.status || 'none';
+    remainingEl.textContent = data.runs_remaining == null ? '—' : String(data.runs_remaining);
+    updateCapabilityFields(caps);
+
+    if (data.tier_source === 'emulated') {
+      billingNoteEl.textContent = 'Local tier override active. Real billing is ' + ((data.subscription && data.subscription.tier) || 'free') + '.';
+      billingBtn.style.display = data.billing_configured ? 'inline-block' : 'none';
+      accountNote.textContent = 'Use the role view and work preference controls to tune this workspace for the job at hand. Local plan emulation stays separate from the public demo and real billing.';
+    } else if (data.billing_configured) {
+      billingNoteEl.textContent = 'Stripe customer portal available';
+      billingBtn.style.display = 'inline-block';
+      accountNote.textContent = 'Use the role view and work preference controls to bias the workspace toward investigation, monitoring, or reporting. This surface is the product, not the marketing demo.';
+    } else {
+      billingNoteEl.textContent = 'Billing is not configured in this environment';
+      billingBtn.style.display = 'none';
+      accountNote.textContent = 'Use the role view and work preference controls to bias the workspace toward investigation, monitoring, or reporting. This surface is the product, not the marketing demo.';
+    }
+
+    updateHeroSummary(data);
+    renderTierEmulation(data);
+  }
+
+  async function saveTierEmulation() {
+    if (!currentAccount) {
+      login();
+      return;
+    }
+
+    var button = document.getElementById('app-apply-tier-emulation-btn');
+    var select = document.getElementById('app-tier-emulation-select');
+    if (!button || !select) return;
+
+    button.disabled = true;
+    button.textContent = 'Applying…';
+    try {
+      await apiDiscoveryReady;
+      var res = await apiFetch('/api/billing/emulation', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tier: select.value })
+      });
+      if (!res || !res.ok) {
+        var err = res ? await res.json().catch(function(){ return {}; }) : {};
+        alert(err.error || 'Could not update plan emulation. Please try again.');
+        return;
+      }
+      applyBillingStatus(await res.json());
+    } catch {
+      alert('Could not update plan emulation. Please try again.');
+    } finally {
+      button.disabled = false;
+      button.textContent = 'Apply';
+    }
+  }
+
+  async function loadBillingStatus() {
+    await apiDiscoveryReady;
+    if (!currentAccount) return;
+
+    try {
+      var res = await apiFetch('/api/billing/status');
+      if (!res || !res.ok) throw new Error('status unavailable');
+      applyBillingStatus(await res.json());
+    } catch {
+      document.getElementById('app-tier').textContent = 'Unknown';
+      document.getElementById('app-subscription-status').textContent = 'Unavailable';
+      document.getElementById('app-runs-remaining').textContent = '—';
+      document.getElementById('app-billing-note').textContent = 'Could not load billing state';
+      document.getElementById('app-manage-billing-btn').style.display = 'none';
+      updateCapabilityFields({});
+      setHeroRunSummary('Ready to queue', 'Billing is unavailable, but signed-in analysis can still be launched locally.');
+    }
+  }
+
+  async function loadAnalysisHistory(options) {
+    await apiDiscoveryReady;
+    if (!currentAccount && authEnabled()) return;
+
+    try {
+      var res = await apiFetch('/api/analysis/history?limit=6');
+      if (!res || !res.ok) throw new Error('history unavailable');
+      analysisHistoryLoaded = true;
+      applyAnalysisHistory(await res.json(), options || {});
+      applyFirstRunLayout();
+    } catch {
+      analysisHistoryLoaded = true;
+      if (!analysisHistoryRuns.length && !latestAnalysisRun) {
+        analysisHistoryRuns = [];
+        selectedAnalysisRunId = null;
+        renderAnalysisHistoryList();
+        updateHistorySummary(null);
+      }
+      applyFirstRunLayout();
+    }
+  }
+
+  function updateAuthUI() {
+    var loginBtn = document.getElementById('auth-login-btn');
+    var logoutBtn = document.getElementById('auth-logout-btn');
+    var userSpan = document.getElementById('auth-user');
+    var gate = document.getElementById('app-unauthenticated');
+    var dashboard = document.getElementById('app-dashboard');
+    var userName = document.getElementById('app-user-name');
+    var accountIdentifier = document.getElementById('app-account-identifier');
+    var accountNote = document.getElementById('app-account-note');
+    var billingBtn = document.getElementById('app-manage-billing-btn');
+
+    if (!authEnabled()) {
+      loginBtn.style.display = 'none';
+      logoutBtn.style.display = 'none';
+      userSpan.textContent = 'Local dev';
+      userSpan.style.display = 'inline';
+      gate.hidden = true;
+      dashboard.hidden = false;
+      userName.textContent = 'Local developer';
+      accountIdentifier.textContent = 'Authentication disabled';
+      accountNote.textContent = 'Auth is disabled in this environment, so this workspace is running in local development mode.';
+      billingBtn.style.display = 'none';
+      document.getElementById('app-tier').textContent = 'Local';
+      document.getElementById('app-subscription-status').textContent = 'disabled';
+      document.getElementById('app-runs-remaining').textContent = 'n/a';
+      document.getElementById('app-concurrency').textContent = 'n/a';
+      document.getElementById('app-ai-access').textContent = 'n/a';
+      document.getElementById('app-api-access').textContent = 'n/a';
+      document.getElementById('app-retention').textContent = 'n/a';
+      document.getElementById('app-billing-note').textContent = 'Billing is unavailable when auth is disabled';
+      document.getElementById('app-tier-emulation-card').hidden = true;
+      apiDiscoveryReady.then(function() {
+        loadAnalysisHistory();
+      });
+      return;
+    }
+
+    if (currentAccount) {
+      var displayName = currentAccount.name || currentAccount.username || 'User';
+      var identifier = currentAccount.username || currentAccount.name || 'Signed in';
+      userSpan.textContent = displayName;
+      userSpan.style.display = 'inline';
+      loginBtn.style.display = 'none';
+      logoutBtn.style.display = 'inline';
+      gate.hidden = true;
+      dashboard.hidden = false;
+      userName.textContent = displayName;
+      accountIdentifier.textContent = identifier;
+      accountNote.textContent = 'This is now the dedicated signed-in home for TreeSight. Choose the role view and work preference that match the job at hand.';
+      if (!analysisHistoryLoaded && !latestAnalysisRun) {
+        setHeroRunSummary('Checking recent runs', 'Restoring signed-in history and active run state.');
+        updateHistorySummary(null);
+        renderAnalysisHistoryList();
+      }
+      apiDiscoveryReady.then(loadBillingStatus);
+      apiDiscoveryReady.then(function() {
+        loadAnalysisHistory();
+      });
+    } else {
+      userSpan.style.display = 'none';
+      loginBtn.style.display = 'inline';
+      logoutBtn.style.display = 'none';
+      gate.hidden = false;
+      dashboard.hidden = true;
+      billingBtn.style.display = 'none';
+      analysisHistoryRuns = [];
+      analysisHistoryLoaded = false;
+      selectedAnalysisRunId = null;
+      stopAnalysisPolling();
+      resetAnalysisProgress();
+      renderAnalysisHistoryList();
+      updateAnalysisRun(null);
+    }
+  }
+
+  function initAuth() {
+    if (!authEnabled()) {
+      updateAuthUI();
+      return;
+    }
+
+    var redirectOrigin = ciamRedirectOrigin();
+
+    msalInstance = new msal.PublicClientApplication({
+      auth: {
+        clientId: CIAM_CLIENT_ID,
+        authority: CIAM_AUTHORITY,
+        knownAuthorities: [CIAM_KNOWN_AUTHORITY],
+        redirectUri: redirectOrigin,
+        postLogoutRedirectUri: redirectOrigin,
+      },
+      cache: { cacheLocation: 'sessionStorage', storeAuthStateInCookie: false },
+    });
+
+    msalInstance.handleRedirectPromise().then(function(resp) {
+      if (resp && resp.account) msalInstance.setActiveAccount(resp.account);
+      currentAccount = msalInstance.getActiveAccount() || (msalInstance.getAllAccounts()[0] || null);
+      if (currentAccount) msalInstance.setActiveAccount(currentAccount);
+      if (!currentAccount && consumeLocalLoginRequest()) {
+        login();
+        return;
+      }
+      updateAuthUI();
+    }).catch(function(err) {
+      console.warn('MSAL redirect error:', err);
+      updateAuthUI();
+    });
+  }
+
+  apiDiscoveryReady = discoverApiBase();
+  initAuth();
+  workspaceRole = readStoredUiValue(WORKSPACE_ROLE_STORAGE_KEY) || workspaceRole;
+  workspacePreference = readStoredUiValue(WORKSPACE_PREFERENCE_STORAGE_KEY) || workspacePreference;
+  renderWorkspaceGuidance();
+  setWorkflowFocus(currentPreferenceConfig().focusTarget);
+
+  document.querySelectorAll('.app-workflow-rail').forEach(function(rail) {
+    rail.addEventListener('click', function() {
+      var target = rail.getAttribute('data-focus-target');
+      if (target) setWorkflowFocus(target);
+    });
+  });
+
+  document.querySelectorAll('[data-role-choice]').forEach(function(button) {
+    button.addEventListener('click', function() {
+      setWorkspaceRole(button.getAttribute('data-role-choice'));
+    });
+  });
+
+  document.querySelectorAll('[data-preference-choice]').forEach(function(button) {
+    button.addEventListener('click', function() {
+      setWorkspacePreference(button.getAttribute('data-preference-choice'));
+    });
+  });
+
+  document.getElementById('auth-login-btn').addEventListener('click', login);
+  document.getElementById('auth-logout-btn').addEventListener('click', logout);
+  document.getElementById('app-sign-in-btn').addEventListener('click', login);
+  document.getElementById('app-manage-billing-btn').addEventListener('click', manageBilling);
+  document.getElementById('app-apply-tier-emulation-btn').addEventListener('click', saveTierEmulation);
+  document.getElementById('app-guided-primary-btn').addEventListener('click', function() {
+    revealWorkflowTarget(this.getAttribute('data-target') || currentPreferenceConfig().primaryTarget);
+  });
+  document.getElementById('app-guided-secondary-btn').addEventListener('click', function() {
+    revealWorkflowTarget(this.getAttribute('data-target') || currentPreferenceConfig().secondaryTarget);
+  });
+  document.getElementById('app-analysis-submit-btn').addEventListener('click', submitAnalysis);
+  document.querySelectorAll('[data-export-format]').forEach(function(button) {
+    button.addEventListener('click', function(event) {
+      event.stopPropagation();
+      downloadRunExport(button.getAttribute('data-export-format'));
+    });
+  });
+  document.getElementById('app-analysis-kml').addEventListener('input', function() {
+    updateAnalysisPreflight(this.value);
+  });
+  document.getElementById('app-analysis-file').addEventListener('change', function() {
+    if (this.files && this.files[0]) loadAnalysisFile(this.files[0]);
+  });
+
+  // Evidence surface controls
+  document.getElementById('app-map-play-btn').addEventListener('click', toggleEvidencePlay);
+  document.getElementById('app-map-frame-slider').addEventListener('input', function() {
+    showEvidenceFrame(parseInt(this.value, 10));
+  });
+  document.getElementById('app-map-btn-rgb').addEventListener('click', function() {
+    evidenceLayerMode = 'rgb';
+    document.getElementById('app-map-btn-rgb').classList.add('active');
+    document.getElementById('app-map-btn-ndvi').classList.remove('active');
+    showEvidenceFrame(evidenceFrameIndex);
+  });
+  document.getElementById('app-map-btn-ndvi').addEventListener('click', function() {
+    evidenceLayerMode = 'ndvi';
+    document.getElementById('app-map-btn-ndvi').classList.add('active');
+    document.getElementById('app-map-btn-rgb').classList.remove('active');
+    showEvidenceFrame(evidenceFrameIndex);
+  });
+  document.getElementById('app-evidence-ai-btn').addEventListener('click', requestAiAnalysis);
+  document.getElementById('app-evidence-eudr-btn').addEventListener('click', requestEudrAssessment);
+
+  // Expanded map viewer controls
+  document.getElementById('app-map-expand-btn').addEventListener('click', expandEvidenceMap);
+  document.getElementById('app-map-collapse-btn').addEventListener('click', collapseEvidenceMap);
+  document.getElementById('app-map-expanded-backdrop').addEventListener('click', function(e) {
+    if (e.target === this) collapseEvidenceMap();
+  });
+  document.getElementById('app-map-expanded-play-btn').addEventListener('click', toggleEvidencePlay);
+  document.getElementById('app-map-expanded-slider').addEventListener('input', function() {
+    showEvidenceFrame(parseInt(this.value, 10));
+  });
+  document.getElementById('app-map-expanded-btn-rgb').addEventListener('click', function() {
+    evidenceLayerMode = 'rgb';
+    document.getElementById('app-map-expanded-btn-rgb').classList.add('active');
+    document.getElementById('app-map-expanded-btn-ndvi').classList.remove('active');
+    document.getElementById('app-map-btn-rgb').classList.add('active');
+    document.getElementById('app-map-btn-ndvi').classList.remove('active');
+    showEvidenceFrame(evidenceFrameIndex);
+  });
+  document.getElementById('app-map-expanded-btn-ndvi').addEventListener('click', function() {
+    evidenceLayerMode = 'ndvi';
+    document.getElementById('app-map-expanded-btn-ndvi').classList.add('active');
+    document.getElementById('app-map-expanded-btn-rgb').classList.remove('active');
+    document.getElementById('app-map-btn-ndvi').classList.add('active');
+    document.getElementById('app-map-btn-rgb').classList.remove('active');
+    showEvidenceFrame(evidenceFrameIndex);
+  });
+})();

--- a/website/js/app.js
+++ b/website/js/app.js
@@ -4,6 +4,10 @@
   function escapeHtml(s) { if (s == null) return ''; var d = document.createElement('div'); d.appendChild(document.createTextNode(String(s))); return d.innerHTML; }
 
   const EXPECTED_CONTRACT = '2026-03-15.1';
+  const APP_HOME_PATH = '/app/';
+  const POST_LOGIN_DESTINATION_KEY = 'treesight-post-login';
+  const DEMO_MAX_POLYGONS = 3;
+  const DEMO_MAX_AREA_HA = 10000;
   let apiBase = '';
   var pipelineInstanceId = null;   /* current pipeline run — for data retrieval */
   var enrichmentPayload = null;    /* cached enrichment manifest from pipeline */
@@ -12,18 +16,34 @@
   /* These are populated once the CIAM tenant is provisioned.
      When CIAM_CLIENT_ID is empty, auth is disabled and the app works anonymously. */
   const CIAM_TENANT_NAME = 'treesightauth';
+  const CIAM_TENANT_DOMAIN = CIAM_TENANT_NAME ? CIAM_TENANT_NAME + '.onmicrosoft.com' : '';
   const CIAM_CLIENT_ID = '6e2abd0a-61a4-41a5-bdb5-7e1c91471fc6';
   const CIAM_AUTHORITY = CIAM_TENANT_NAME
-    ? 'https://' + CIAM_TENANT_NAME + '.ciamlogin.com/'
+    ? 'https://' + CIAM_TENANT_NAME + '.ciamlogin.com/' + CIAM_TENANT_DOMAIN + '/'
     : '';
-  const CIAM_KNOWN_AUTHORITY = CIAM_AUTHORITY;
+  const CIAM_KNOWN_AUTHORITY = CIAM_TENANT_NAME
+    ? CIAM_TENANT_NAME + '.ciamlogin.com'
+    : '';
   const CIAM_SCOPES = CIAM_CLIENT_ID ? ['openid', 'profile'] : [];
+  const IDENTITY_ONLY_SCOPES = ['openid', 'profile', 'email', 'offline_access'];
 
   var msalInstance = null;
   var currentAccount = null;
   var accessToken = null;
 
   function authEnabled() { return !!(CIAM_TENANT_NAME && CIAM_CLIENT_ID && typeof msal !== 'undefined'); }
+
+  function rememberPostLoginDestination() {
+    try { sessionStorage.setItem(POST_LOGIN_DESTINATION_KEY, 'app'); } catch { /* ignore */ }
+  }
+
+  function shouldRedirectToAppAfterLogin() {
+    try { return sessionStorage.getItem(POST_LOGIN_DESTINATION_KEY) === 'app'; } catch { return false; }
+  }
+
+  function clearPostLoginDestination() {
+    try { sessionStorage.removeItem(POST_LOGIN_DESTINATION_KEY); } catch { /* ignore */ }
+  }
 
   /* Initialise MSAL */
   function initAuth() {
@@ -32,13 +52,14 @@
       updateAuthUI();
       return;
     }
+    var redirectOrigin = ciamRedirectOrigin();
     var msalConfig = {
       auth: {
         clientId: CIAM_CLIENT_ID,
         authority: CIAM_AUTHORITY,
         knownAuthorities: [CIAM_KNOWN_AUTHORITY],
-        redirectUri: window.location.origin,
-        postLogoutRedirectUri: window.location.origin,
+        redirectUri: redirectOrigin,
+        postLogoutRedirectUri: redirectOrigin,
       },
       cache: { cacheLocation: 'sessionStorage', storeAuthStateInCookie: false },
     };
@@ -51,28 +72,81 @@
       }
       currentAccount = msalInstance.getActiveAccount() || (msalInstance.getAllAccounts()[0] || null);
       if (currentAccount) { msalInstance.setActiveAccount(currentAccount); }
+      if (!currentAccount && consumeLocalLoginRequest()) {
+        login();
+        return;
+      }
+      if (currentAccount && shouldRedirectToAppAfterLogin()) {
+        clearPostLoginDestination();
+        window.location.replace(APP_HOME_PATH);
+        return;
+      }
       updateAuthUI();
     }).catch(function(err) {
       console.warn('MSAL redirect error:', err);
+      clearPostLoginDestination();
       updateAuthUI();
     });
   }
 
   function login() {
+    if (window.location.hostname === '127.0.0.1') {
+      window.location.replace(localLoginTransitionUrl());
+      return;
+    }
     if (!msalInstance) return;
+    rememberPostLoginDestination();
     msalInstance.loginRedirect({ scopes: CIAM_SCOPES });
   }
 
   function logout() {
     if (!msalInstance) return;
+    clearPostLoginDestination();
     msalInstance.logoutRedirect({ account: currentAccount });
+  }
+
+  function parseJwtPayload(token) {
+    if (!token) return null;
+    try {
+      var parts = token.split('.');
+      if (parts.length < 2) return null;
+      return JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
+    } catch {
+      return null;
+    }
+  }
+
+  function tokenExpired(token, skewSeconds) {
+    var payload = parseJwtPayload(token);
+    if (!payload || !payload.exp) return false;
+    return payload.exp <= Math.floor(Date.now() / 1000) + (skewSeconds || 0);
+  }
+
+  function shouldUseIdTokenForApi(resp) {
+    if (!resp || !resp.accessToken || !resp.idToken) return false;
+    var payload = parseJwtPayload(resp.accessToken);
+    if (!payload) return false;
+    var scopes = String(payload.scp || '').split(/\s+/).filter(Boolean);
+    if (String(payload.aud || '') === '00000003-0000-0000-c000-000000000000') return true;
+    return scopes.length > 0 && scopes.every(function(scope) {
+      return IDENTITY_ONLY_SCOPES.indexOf(scope) > -1;
+    });
+  }
+
+  function selectApiBearerToken(resp) {
+    if (!resp) return null;
+    if (shouldUseIdTokenForApi(resp)) return resp.idToken;
+    return resp.accessToken || resp.idToken || null;
   }
 
   async function acquireToken() {
     if (!msalInstance || !currentAccount) return null;
     try {
       var resp = await msalInstance.acquireTokenSilent({ scopes: CIAM_SCOPES, account: currentAccount });
-      accessToken = resp.accessToken || resp.idToken;
+      if (shouldUseIdTokenForApi(resp) && tokenExpired(resp.idToken, 60)) {
+        resp = await msalInstance.acquireTokenSilent({ scopes: CIAM_SCOPES, account: currentAccount, forceRefresh: true });
+      }
+      accessToken = selectApiBearerToken(resp);
       return accessToken;
     } catch {
       /* Silent failed — trigger interactive */
@@ -96,6 +170,7 @@
       logoutBtn.style.display = 'none';
       userSpan.style.display = 'none';
       loginPrompt.style.display = 'none';
+      updateDemoAiControls(null);
       if (submitBtn) submitBtn.textContent = 'Process KML';
       return;
     }
@@ -115,7 +190,30 @@
       loginBtn.style.display = 'inline';
       logoutBtn.style.display = 'none';
       loginPrompt.style.display = 'block';
+      updateDemoAiControls(null);
       if (submitBtn) submitBtn.textContent = 'Sign In to Process KML';
+    }
+  }
+
+  function updateDemoAiControls(data) {
+    var btn = document.getElementById('btn-get-ai-insights');
+    var note = document.getElementById('ai-insights-plan-note');
+    if (!btn || !note) return;
+
+    var enabled = !!(data && data.capabilities && data.capabilities.ai_insights);
+    btn.disabled = !enabled;
+    btn.setAttribute('aria-disabled', enabled ? 'false' : 'true');
+
+    if (enabled) {
+      btn.textContent = 'Get AI Analysis for Timelapse';
+      if (data.tier_source === 'emulated') {
+        note.textContent = 'AI analysis is enabled for this local tier emulation.';
+      } else {
+        note.textContent = 'Your current plan includes AI timelapse analysis.';
+      }
+    } else {
+      btn.textContent = 'AI Analysis Available on Paid Plans';
+      note.textContent = 'AI analysis is disabled on the public demo and free accounts. Starter and above unlock it in the signed-in workspace.';
     }
   }
 
@@ -127,15 +225,59 @@
     opts.headers = opts.headers || {};
     /* Attach bearer token if authenticated */
     if (currentAccount && authEnabled()) {
-      var token = accessToken || await acquireToken();
+      var token = accessToken;
+      if (!token || tokenExpired(token, 60)) token = await acquireToken();
       if (token) { opts.headers['Authorization'] = 'Bearer ' + token; }
     }
     try { return await fetch(apiBase + path, opts); } catch { return null; }
   }
 
+  function runningOnLocalDevOrigin() {
+    return window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+  }
+
+  function ciamRedirectOrigin() {
+    return runningOnLocalDevOrigin() ? 'http://localhost:4280' : window.location.origin;
+  }
+
+  function localLoginTransitionUrl() {
+    var url = new URL(window.location.href);
+    url.protocol = 'http:';
+    url.hostname = 'localhost';
+    url.port = '4280';
+    url.searchParams.set('localLogin', '1');
+    return url.toString();
+  }
+
+  function consumeLocalLoginRequest() {
+    try {
+      var url = new URL(window.location.href);
+      if (url.searchParams.get('localLogin') !== '1') return false;
+      url.searchParams.delete('localLogin');
+      var nextUrl = url.pathname + (url.search || '') + (url.hash || '');
+      window.history.replaceState({}, '', nextUrl || '/');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   /* --- API discovery: resolve backend hostname --- */
   async function discoverApiBase() {
     var badge = document.getElementById('status-badge');
+
+    if (runningOnLocalDevOrigin()) {
+      try {
+        var localRes = await fetch('/api/health');
+        if (localRes.ok) {
+          apiBase = '';
+          badge.textContent = 'Online';
+          badge.className = 'online';
+          badge.title = '';
+          return;
+        }
+      } catch { /* local proxy unavailable */ }
+    }
 
     /* 1. Load deploy-time config first (fast, no cold-start penalty) */
     try {
@@ -427,6 +569,13 @@
     var polygons = parseKmlCoords(kml);
     if (!polygons) {
       statusEl.textContent = 'Could not find valid coordinates in the KML.';
+      statusEl.className = 'demo-status show error';
+      return;
+    }
+
+    var demoBoundsError = checkDemoBounds(polygons);
+    if (demoBoundsError) {
+      statusEl.textContent = demoBoundsError;
       statusEl.className = 'demo-status show error';
       return;
     }
@@ -818,6 +967,36 @@
     var latS = 0, lonS = 0, n = coords.length - 1; /* skip closing vertex */
     for (var i = 0; i < n; i++) { latS += coords[i][0]; lonS += coords[i][1]; }
     return [latS/n, lonS/n];
+  }
+
+  function polygonAreaHa(coords) {
+    if (!coords || coords.length < 4) return 0;
+    var usable = coords.slice(0, -1);
+    var meanLat = usable.reduce(function(sum, coord) { return sum + coord[0]; }, 0) / usable.length;
+    var metresPerDegreeLat = 111320;
+    var metresPerDegreeLon = Math.cos(meanLat * Math.PI / 180) * metresPerDegreeLat;
+    var areaM2 = 0;
+    for (var i = 0; i < coords.length - 1; i++) {
+      var x1 = coords[i][1] * metresPerDegreeLon;
+      var y1 = coords[i][0] * metresPerDegreeLat;
+      var x2 = coords[i + 1][1] * metresPerDegreeLon;
+      var y2 = coords[i + 1][0] * metresPerDegreeLat;
+      areaM2 += (x1 * y2) - (x2 * y1);
+    }
+    return Math.abs(areaM2) / 2 / 10000;
+  }
+
+  function checkDemoBounds(polygons) {
+    if (polygons.length > DEMO_MAX_POLYGONS) {
+      return 'Public demo is limited to ' + DEMO_MAX_POLYGONS + ' AOIs per run. Use the signed-in app for larger workloads.';
+    }
+    for (var i = 0; i < polygons.length; i++) {
+      var areaHa = polygonAreaHa(polygons[i].coords);
+      if (areaHa > DEMO_MAX_AREA_HA) {
+        return 'Public demo is limited to AOIs up to ' + DEMO_MAX_AREA_HA.toLocaleString() + ' ha. "' + polygons[i].name + '" is approximately ' + Math.round(areaHa).toLocaleString() + ' ha.';
+      }
+    }
+    return null;
   }
 
   /* Check all polygons are within maxKm of their group centroid */
@@ -2463,6 +2642,7 @@
   /* AI Insights button handler - analyze entire timelapse, not just current frame */
   document.getElementById('btn-get-ai-insights').addEventListener('click', async function() {
     var btn = this;
+    if (btn.disabled) return;
     var loading = document.getElementById('ai-insights-loading');
     var content = document.getElementById('ai-insights-content');
     var error = document.getElementById('ai-insights-error');
@@ -2740,6 +2920,11 @@
         document.getElementById('insights-panel').style.display = 'block';
         document.getElementById('ai-insights-panel').style.display = 'block';
         buildInsights(currentFrame);
+        /* Show post-demo conversion prompt after a short delay */
+        var conversionPrompt = document.getElementById('demo-conversion-prompt');
+        if (conversionPrompt && conversionPrompt.hidden) {
+          setTimeout(function() { conversionPrompt.hidden = false; }, 4000);
+        }
       }
 
       /* Kick off scope-aware analytics (collective by default; click polygon to focus) */
@@ -2811,6 +2996,11 @@
   document.getElementById('auth-logout-btn').addEventListener('click', logout);
   var loginPromptLink = document.getElementById('login-prompt-link');
   if (loginPromptLink) loginPromptLink.addEventListener('click', login);
+  var conversionDismiss = document.getElementById('demo-conversion-dismiss');
+  if (conversionDismiss) conversionDismiss.addEventListener('click', function() {
+    var prompt = document.getElementById('demo-conversion-prompt');
+    if (prompt) prompt.hidden = true;
+  });
 
   var apiDiscoveryReady = discoverApiBase();
 
@@ -2854,6 +3044,7 @@
         var res = await apiFetch('/api/billing/status');
         if (!res || !res.ok) return;
         var data = await res.json();
+        updateDemoAiControls(data);
 
         /* Update Pro button text based on subscription state */
         var proBtn = document.getElementById('btn-upgrade-pro');
@@ -2870,9 +3061,15 @@
         }
       } catch(e) {
         console.debug('Billing status check skipped:', e);
+        updateDemoAiControls(null);
       }
     }
   };
+
+  updateDemoAiControls(null);
+  if (currentAccount && apiDiscoveryReady) {
+    apiDiscoveryReady.then(function() { window.treesightBilling.loadStatus(); });
+  }
 
   /* Handle billing return query params */
   var params = new URLSearchParams(window.location.search);

--- a/website/staticwebapp.config.json
+++ b/website/staticwebapp.config.json
@@ -5,6 +5,10 @@
   },
   "routes": [
     {
+      "route": "/app",
+      "rewrite": "/app/index.html"
+    },
+    {
       "route": "/api/*",
       "allowedRoles": ["anonymous"]
     }


### PR DESCRIPTION
Superseded by #309 which already contains the first-run hero (#323), export bar (#324), and conversion prompt (#325) on the `feature/rate-limits-and-email` branch. The UX features in this PR were built on that same working branch.\n\nCI failures here (Semgrep SAST, Trivy) are pre-existing issues that #309 already fixed.