### PR TITLE
fix(infra): correct email domain_management enum — unblock deploys

### DIFF
--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -329,7 +329,7 @@ resource "azurerm_email_communication_service_domain" "azure_managed" {
   count             = var.enable_email ? 1 : 0
   name              = "AzureManagedDomain"
   email_service_id  = azurerm_email_communication_service.main[0].id
-  domain_management = "AzureManagedDomain"
+  domain_management = "AzureManaged"
   tags              = local.tags
 }
 


### PR DESCRIPTION
# Fix Deploy Infrastructure Failures

## Problem

Deploy #174, #175, #176 all failing at **Tofu Plan** with exit code 1.

Root cause: `azurerm_email_communication_service_domain.azure_managed` uses `domain_management = "AzureManagedDomain"` but the `azurerm` provider only accepts:
- `AzureManaged`
- `CustomerManaged`
- `CustomerManagedInExchangeOnline`

This was introduced in #309's email infrastructure resources. Even though `enable_email = false` (count = 0), OpenTofu validates enum constraints at plan time regardless of count.

## Fix

```diff
- domain_management = "AzureManagedDomain"
+ domain_management = "AzureManaged"
```

Confirmed via `tofu validate` — passes after fix.

## Deploy history
| Run | Commit | Result |
|-----|--------|--------|
| #173 | 2b381c5 | ✅ Success (pre-#309) |
| #174 | 885b8bf | ❌ Failed (#307 merge — may be separate issue) |
| #175 | 595102e | ❌ Failed (includes #309 email resources) |
| #176 | 595102e | ❌ Failed (re-run of same) |

## Also noted (not in this PR)
- Node.js 20 deprecation warnings on several GitHub Actions — forced to Node.js 24 from June 2, 2026
- `CodeQL Action v3` deprecation — update to v4 by December 2026
- `skip_api_build` input warning on SWA deploy action