### PR TITLE
Fix: Event Grid webhook target + load-runner auth hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,13 @@ for threshold analysis:
 uv run python scripts/load_baseline.py --runs-per-scenario 3 --concurrency 2
 ```
 
+If your local Event Grid webhook requires auth, provide the system key:
+
+```bash
+export EVENT_GRID_FUNCTION_KEY=<local-eventgrid-system-key>
+uv run python scripts/load_baseline.py --runs-per-scenario 3 --concurrency 2
+```
+
 Scenarios covered:
 
 - `baseline` (1 AOI)

--- a/docs/LOAD_TESTING_BASELINE.md
+++ b/docs/LOAD_TESTING_BASELINE.md
@@ -33,11 +33,20 @@ make dev-func
 uv run python scripts/load_baseline.py --runs-per-scenario 3 --concurrency 2
 ```
 
+If your local Event Grid webhook returns `401`, provide the function system key:
+
+```bash
+export EVENT_GRID_FUNCTION_KEY=<local-eventgrid-system-key>
+uv run python scripts/load_baseline.py --runs-per-scenario 3 --concurrency 2
+```
+
 Options:
 
 - `--timeout`: per-run timeout seconds (default `600`)
 - `--poll-interval`: orchestrator polling interval in seconds (default `3.0`)
 - `--container`: target blob container (default `kml-input`)
+- `--event-grid-function-name`: Event Grid trigger function name (default `blob_trigger`)
+- `--event-grid-function-key`: Event Grid system key (or use `EVENT_GRID_FUNCTION_KEY`)
 - `--out-dir`: report output directory (default `docs/baselines`)
 
 ## Outputs

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -633,7 +633,7 @@ resource "azapi_resource" "event_grid_subscription" {
       destination = {
         endpointType = "WebHook"
         properties = {
-          endpointUrl                   = "https://${azapi_resource.function_app.output.properties.defaultHostName}/runtime/webhooks/eventgrid?functionName=kml_blob_trigger&code=${local.eventgrid_key}"
+          endpointUrl                   = "https://${azapi_resource.function_app.output.properties.defaultHostName}/runtime/webhooks/eventgrid?functionName=blob_trigger&code=${local.eventgrid_key}"
           maxEventsPerBatch             = 1
           preferredBatchSizeInKilobytes = 64
         }

--- a/scripts/load_baseline.py
+++ b/scripts/load_baseline.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import statistics
 import tempfile
@@ -33,7 +34,13 @@ from typing import Any
 
 import httpx
 from generate_monster_kml import generate_kml
-from simulate_upload import FUNC_BASE, check_func_host, fire_event_grid, upload_kml
+from simulate_upload import (
+    DEFAULT_EVENT_GRID_FUNCTION_NAME,
+    FUNC_BASE,
+    check_func_host,
+    fire_event_grid,
+    upload_kml,
+)
 
 TERMINAL_STATUSES = {"Completed", "Failed", "Canceled", "Terminated"}
 
@@ -145,14 +152,41 @@ def _run_one(
     timeout_s: int,
     poll_interval_s: float,
     container: str,
+    function_name: str,
+    function_key: str | None,
 ) -> RunResult:
     run_file = source_kml.parent / f"{source_kml.stem}-run{run_id}.kml"
     shutil.copy2(source_kml, run_file)
 
     start = time.monotonic()
     blob_name, blob_url, content_length = upload_kml(run_file, container)
-    instance_id = fire_event_grid(blob_url, blob_name, content_length, container)
-    status, payload, timed_out = _poll_status(instance_id, timeout_s, poll_interval_s)
+    try:
+        instance_id = fire_event_grid(
+            blob_url,
+            blob_name,
+            content_length,
+            container,
+            function_name=function_name,
+            function_key=function_key,
+            strict=True,
+        )
+        status, payload, timed_out = _poll_status(instance_id, timeout_s, poll_interval_s)
+    except RuntimeError as exc:
+        duration_s = time.monotonic() - start
+        return RunResult(
+            scenario=scenario,
+            run_id=run_id,
+            aoi_count=aoi_count,
+            instance_id="",
+            runtime_status="TriggerRejected",
+            duration_s=duration_s,
+            timed_out=False,
+            had_throttle_signal=False,
+            had_timeout_signal=False,
+            had_memory_signal=False,
+            raw_status={"error": str(exc)},
+        )
+
     duration_s = time.monotonic() - start
 
     had_throttle_signal = _contains_signal(payload, "429", "throttle", "too many requests")
@@ -185,7 +219,11 @@ def _p95(values: list[float]) -> float:
 def _summarize(scenario: str, aoi_count: int, runs: list[RunResult]) -> ScenarioSummary:
     durations = [r.duration_s for r in runs]
     success_count = sum(1 for r in runs if r.runtime_status == "Completed")
-    failure_count = sum(1 for r in runs if r.runtime_status in {"Failed", "Canceled", "Terminated"})
+    failure_count = sum(
+        1
+        for r in runs
+        if r.runtime_status in {"Failed", "Canceled", "Terminated", "TriggerRejected"}
+    )
     timeout_count = sum(1 for r in runs if r.timed_out)
 
     return ScenarioSummary(
@@ -287,6 +325,16 @@ def main() -> None:
     )
     parser.add_argument("--container", default="kml-input", help="Target blob container")
     parser.add_argument(
+        "--event-grid-function-name",
+        default=DEFAULT_EVENT_GRID_FUNCTION_NAME,
+        help="Function name for Event Grid webhook (default: blob_trigger)",
+    )
+    parser.add_argument(
+        "--event-grid-function-key",
+        default=os.getenv("EVENT_GRID_FUNCTION_KEY"),
+        help="Event Grid system key (or set EVENT_GRID_FUNCTION_KEY env var)",
+    )
+    parser.add_argument(
         "--out-dir",
         default="docs/baselines",
         help="Directory for JSON/Markdown baseline artifacts",
@@ -344,6 +392,8 @@ def main() -> None:
                         args.timeout,
                         args.poll_interval,
                         args.container,
+                        args.event_grid_function_name,
+                        args.event_grid_function_key,
                     )
                     for run_id in range(1, args.runs_per_scenario + 1)
                 ]

--- a/scripts/simulate_upload.py
+++ b/scripts/simulate_upload.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import time
 import uuid
@@ -24,6 +25,7 @@ from azure.storage.blob import BlobServiceClient, ContentSettings
 FUNC_BASE = "http://localhost:7071"
 DEFAULT_KML = "tests/fixtures/sample.kml"
 DEFAULT_CONTAINER = "kml-input"
+DEFAULT_EVENT_GRID_FUNCTION_NAME = "blob_trigger"
 
 
 def upload_kml(kml_path: Path, container: str) -> tuple[str, str, int]:
@@ -54,6 +56,9 @@ def fire_event_grid(
     content_length: int,
     container: str,
     provider_config: dict[str, Any] | None = None,
+    function_name: str = DEFAULT_EVENT_GRID_FUNCTION_NAME,
+    function_key: str | None = None,
+    strict: bool = True,
 ) -> str:
     """Send a mock Event Grid BlobCreated event to the local func host."""
     event_id = str(uuid.uuid4())
@@ -83,7 +88,9 @@ def fire_event_grid(
         }
     ]
 
-    url = f"{FUNC_BASE}/runtime/webhooks/EventGrid?functionName=blob_trigger"
+    url = f"{FUNC_BASE}/runtime/webhooks/EventGrid?functionName={function_name}"
+    if function_key:
+        url += f"&code={function_key}"
     print(f"  Firing Event Grid event -> {url}")
     print(f"  Event ID (= orchestration instance ID): {event_id}")
 
@@ -97,7 +104,10 @@ def fire_event_grid(
     if resp.status_code in (200, 202):
         print(f"  Event accepted (HTTP {resp.status_code}).")
     else:
-        print(f"  WARNING: Event response HTTP {resp.status_code}: {resp.text}")
+        msg = f"Event Grid webhook rejected with HTTP {resp.status_code}: {resp.text}"
+        print(f"  WARNING: {msg}")
+        if strict:
+            raise RuntimeError(msg)
 
     return event_id
 
@@ -158,6 +168,16 @@ def main() -> None:
     parser.add_argument("--no-poll", action="store_true", help="Skip orchestrator polling")
     parser.add_argument("--timeout", type=int, default=600, help="Polling timeout in seconds")
     parser.add_argument(
+        "--event-grid-function-name",
+        default=DEFAULT_EVENT_GRID_FUNCTION_NAME,
+        help="Function name for Event Grid webhook (default: blob_trigger)",
+    )
+    parser.add_argument(
+        "--event-grid-function-key",
+        default=os.getenv("EVENT_GRID_FUNCTION_KEY"),
+        help="Event Grid system key (or set EVENT_GRID_FUNCTION_KEY env var)",
+    )
+    parser.add_argument(
         "--asset-key",
         default=None,
         help="Planetary Computer asset key (e.g. visual, SCL, B04). Injected as provider_config.",
@@ -195,6 +215,8 @@ def main() -> None:
         content_length,
         args.container,
         provider_config=provider_config,
+        function_name=args.event_grid_function_name,
+        function_key=args.event_grid_function_key,
     )
 
     # Step 4: Poll (optional)

--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -332,3 +332,25 @@ class TestDeployWorkflowSettings:
             "outputs.tf must export appinsights_connection_string for the "
             "deploy workflow to inject into the static site"
         )
+
+
+# ---------------------------------------------------------------------------
+# 10. Event Grid webhook wiring must match runtime function index
+# ---------------------------------------------------------------------------
+
+
+class TestEventGridWebhookWiring:
+    """Ensure Event Grid subscription targets the indexed function name with auth key."""
+
+    def test_event_grid_webhook_uses_blob_trigger_name(self):
+        tf = MAIN_TF.read_text()
+        assert "functionName=blob_trigger" in tf, (
+            "Event Grid subscription endpointUrl must target functionName=blob_trigger "
+            "to match the indexed Event Grid trigger function"
+        )
+
+    def test_event_grid_webhook_includes_code_query_param(self):
+        tf = MAIN_TF.read_text()
+        assert "&code=${local.eventgrid_key}" in tf, (
+            "Event Grid webhook endpointUrl must include the system key query param"
+        )

--- a/tests/test_simulate_upload.py
+++ b/tests/test_simulate_upload.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from scripts import simulate_upload
+
+
+class _DummyResponse:
+    def __init__(self, status_code: int, text: str = "") -> None:
+        self.status_code = status_code
+        self.text = text
+
+
+def test_fire_event_grid_includes_function_name_and_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, str] = {}
+
+    def _fake_post(url: str, **_: object) -> _DummyResponse:
+        captured["url"] = url
+        return _DummyResponse(202, "accepted")
+
+    monkeypatch.setattr(simulate_upload.httpx, "post", _fake_post)
+    monkeypatch.setattr(uuid, "uuid4", lambda: "test-id")
+
+    instance_id = simulate_upload.fire_event_grid(
+        blob_url="http://127.0.0.1:10000/devstoreaccount1/kml-input/file.kml",
+        blob_name="file.kml",
+        content_length=123,
+        container="kml-input",
+        function_name="blob_trigger",
+        function_key="abc123",
+    )
+
+    assert instance_id == "test-id"
+    assert "functionName=blob_trigger" in captured["url"]
+    assert "code=abc123" in captured["url"]
+
+
+def test_fire_event_grid_raises_on_rejected_webhook(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_post(*_: object, **__: object) -> _DummyResponse:
+        return _DummyResponse(401, "Unauthorized")
+
+    monkeypatch.setattr(simulate_upload.httpx, "post", _fake_post)
+
+    with pytest.raises(RuntimeError, match="HTTP 401"):
+        simulate_upload.fire_event_grid(
+            blob_url="http://127.0.0.1:10000/devstoreaccount1/kml-input/file.kml",
+            blob_name="file.kml",
+            content_length=123,
+            container="kml-input",
+        )


### PR DESCRIPTION
## Summary\nFixes Event Grid trigger wiring and hardens local load test tooling so webhook auth/config failures are explicit and test-covered.\n\n## Changes\n- Infra: update Event Grid subscription endpoint to use \n- Scripts: add  and  support\n- Scripts: fail fast on webhook rejection instead of long timeout masking\n- Tests: add regression tests for webhook URL/key and 401 rejection behavior\n- Docs: document  for local baseline runs\n\n## Validation\n- E902 No such file or directory (os error 2)
--> ...:1:1

Found 1 error. passed\n- ============================= test session starts ==============================
platform linux -- Python 3.12.7, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/opr/projects/kml-satellites
configfile: pyproject.toml
plugins: asyncio-1.3.0, anyio-4.12.1, cov-7.0.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 4 items

tests/test_simulate_upload.py ..                                         [ 50%]
tests/test_launch_readiness.py ..                                        [100%]

============================== 4 passed in 0.31s =============================== passed\n\n## Notes\nThis unblocks valid load-baseline measurement once the key is supplied in local/dev environments.