### PR TITLE
fix: patch base image CVEs and centralise GHCR image paths

### DIFF
--- a/.github/image-config.env
+++ b/.github/image-config.env
@@ -1,0 +1,7 @@
+# Single source of truth for container image names.
+# Sourced by base-image.yml, ci.yml, and deploy.yml.
+#
+# Owner is resolved dynamically via GITHUB_REPOSITORY_OWNER
+# so forks publish to their own GHCR namespace.
+BASE_IMAGE_REPO="treesight-base"
+APP_IMAGE_REPO="treesight"

--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Set image tags
         id: meta
         run: |
-          # Lowercase repo owner for GHCR compatibility
-          IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/treesight-base"
+          source .github/image-config.env
+          IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${BASE_IMAGE_REPO}"
           DATE_TAG="$(date -u +%Y%m%d)-${GITHUB_SHA::8}"
           echo "date_tag=${DATE_TAG}" >> "$GITHUB_OUTPUT"
           echo "image_latest=${IMAGE_NAME}:latest" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,8 @@ jobs:
 
       - name: Build app image
         run: |
-          BASE_IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}/treesight-base:latest"
+          source .github/image-config.env
+          BASE_IMAGE="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${BASE_IMAGE_REPO}:latest"
           docker build \
             --build-arg BASE_IMAGE="${BASE_IMAGE}" \
             -t treesight:ci-check .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,8 @@ jobs:
       - name: Set image tag
         id: meta
         run: |
-          IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY,,}/treesight"
+          source .github/image-config.env
+          IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${APP_IMAGE_REPO}"
           TAG="${{ github.sha }}"
           echo "image_name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
           echo "image_uri=${IMAGE_NAME}:${TAG}" >> "$GITHUB_OUTPUT"
@@ -65,7 +66,8 @@ jobs:
         env:
           IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
         run: |
-          BASE_IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}/treesight-base:latest"
+          source .github/image-config.env
+          BASE_IMAGE="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${BASE_IMAGE_REPO}:latest"
           docker build \
             --build-arg BASE_IMAGE="${BASE_IMAGE}" \
             -t "${IMAGE_NAME}:${{ github.sha }}" \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -105,6 +105,7 @@ LABEL org.opencontainers.image.source="https://github.com/Hardcoreprawn/azure-wo
 # Uses Microsoft's official install script for latest 8.0.x.
 # libexpat1 — required by GDAL native libs (rasterio, fiona)
 RUN apt-get update -qq && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends ca-certificates curl libexpat1 && \
     curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh && \
     bash /tmp/dotnet-install.sh \


### PR DESCRIPTION
## Problem

Two issues blocking CI:

1. **Trivy CVE gate** — `Dockerfile.base` didn't run `apt-get upgrade`, so Debian packages with known HIGH-severity CVEs (libc6, systemd, ncurses, libpng, libtiff) blocked the base image push to GHCR.

2. **GHCR path mismatch** — `base-image.yml` pushes to `ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/treesight-base` but `ci.yml` and `deploy.yml` were pulling from `ghcr.io/${GITHUB_REPOSITORY,,}/treesight-base` (which includes the repo name in the path). The image could never be found.

## Fix

- Add `apt-get upgrade -y` to `Dockerfile.base` to pull Debian security patches
- Create `.github/image-config.env` as single source of truth for image repo names (`BASE_IMAGE_REPO`, `APP_IMAGE_REPO`)
- All three workflows (`base-image`, `ci`, `deploy`) now `source .github/image-config.env` — push and pull paths can't diverge

## Files Changed

| File | Change |
|------|--------|
| `Dockerfile.base` | Add `apt-get upgrade` |
| `.github/image-config.env` | New — image name constants |
| `.github/workflows/base-image.yml` | Source config for push path |
| `.github/workflows/ci.yml` | Source config for pull path |
| `.github/workflows/deploy.yml` | Source config for both paths |