### PR TITLE
fix: patch libpng16-16 CVEs blocking base image push

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build base image
         run: |
-          docker build \
+          docker build --no-cache \
             -f Dockerfile.base \
             -t "${{ steps.meta.outputs.image_latest }}" \
             -t "${{ steps.meta.outputs.image_dated }}" \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -104,9 +104,11 @@ LABEL org.opencontainers.image.source="https://github.com/Hardcoreprawn/azure-wo
 # Install .NET 8 ASP.NET runtime — required by the Functions host.
 # Uses Microsoft's official install script for latest 8.0.x.
 # libexpat1 — required by GDAL native libs (rasterio, fiona)
+# libpng16-16 — explicitly upgraded for CVE-2026-33416/33636
 RUN apt-get update -qq && \
     apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends ca-certificates curl libexpat1 && \
+    apt-get install -y --no-install-recommends \
+      ca-certificates curl libexpat1 libpng16-16 && \
     curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh && \
     bash /tmp/dotnet-install.sh \
       --runtime aspnetcore \


### PR DESCRIPTION
## Problem

The base-image workflow Trivy gate is blocking on two HIGH CVEs in `libpng16-16`:
- **CVE-2026-33416** — installed `1.6.39-2+deb12u3`, fix in `deb12u4`
- **CVE-2026-33636** — same package

Despite `apt-get upgrade -y` being present in `Dockerfile.base`, the GitHub Actions runner's Docker layer cache served a stale apt layer, so the fix version was never pulled.

## Changes

1. **`Dockerfile.base`**: Add `libpng16-16` to the explicit `apt-get install` list, ensuring the patched version is pulled even if the base image ships an older one.
2. **`base-image.yml`**: Add `--no-cache` to `docker build` so apt layers are always rebuilt fresh — security-critical for a base image that gates on Trivy.

## Impact

Once merged, the base-image workflow should pass Trivy, push to GHCR, and unblock CI Docker builds on main.