### PR TITLE
fix: limit Trivy SARIF to CRITICAL/HIGH severities only

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -85,6 +85,7 @@ jobs:
           ignore-unfixed: true
           trivyignores: .trivyignore
           exit-code: "1"        # block on findings — base must be clean
+          limit-severities-for-sarif: true  # only CRITICAL/HIGH in SARIF; prevents LOW/MEDIUM triggering exit code
 
       - name: Upload Trivy SARIF
         if: always()

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -172,6 +172,7 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           exit-code: "1"
+          limit-severities-for-sarif: true
 
       - name: Upload Trivy FS SARIF
         if: always()


### PR DESCRIPTION
## Summary

Fixes the Base Image workflow failing on every run due to LOW/MEDIUM pip CVEs triggering Trivy's exit code.

### Root cause

The Trivy GitHub Action with `format: sarif` includes **all severity levels** in the SARIF output regardless of the `severity:` filter. The `exit-code: "1"` then fires on any finding — including LOW/MEDIUM pip CVEs that are below our threshold.

### Changes

- **base-image.yml**: Add `limit-severities-for-sarif: true` to Trivy container scan step
- **security.yml**: Add `limit-severities-for-sarif: true` to Trivy FS scan step (preventative)

### Evidence

- Local Trivy scan: 0 CRITICAL/HIGH findings, exit 0
- CI SARIF upload: 2 findings (both LOW/MEDIUM pip CVEs — CVE-2026-1703, CVE-2025-8869)

Fixes #371