### PR TITLE
fix: resolve SSRF domain bypass and log injection scanning alerts

### DIFF
--- a/blueprints/demo.py
+++ b/blueprints/demo.py
@@ -209,9 +209,16 @@ _PROXY_MAX_RESPONSE_BYTES = 5 * 1024 * 1024  # 5 MiB
 
 def _is_domain_allowed(domain: str) -> bool:
     """Exact match or subdomain match against the allowlist."""
-    return domain in PROXY_ALLOWED_DOMAINS or any(
-        domain.endswith("." + allowed) for allowed in PROXY_ALLOWED_DOMAINS
-    )
+    if not domain or "@" in domain:
+        return False
+    for allowed in PROXY_ALLOWED_DOMAINS:
+        if domain == allowed:
+            return True
+        # Subdomain check: must be exactly `<sub>.<allowed>` — the dot
+        # prefix prevents `evil-environment.data.gov.uk` from matching.
+        if domain.endswith(f".{allowed}") and len(domain) > len(allowed) + 1:
+            return True
+    return False
 
 
 @bp.route(route="proxy", methods=["GET", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
@@ -241,7 +248,7 @@ def cors_proxy(req: func.HttpRequest) -> func.HttpResponse:
         parsed = urlparse(target_url)
         if parsed.scheme not in ("http", "https"):
             return error_response(400, "Only http/https URLs are allowed", req=req)
-        domain = parsed.netloc.lower().split(":")[0]  # strip port
+        domain = (parsed.hostname or "").lower()
         if not _is_domain_allowed(domain):
             return error_response(403, "Domain not whitelisted", req=req)
     except Exception:

--- a/treesight/log.py
+++ b/treesight/log.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import contextvars
 import json
 import logging
+import re
 import time
 from typing import Any
 
@@ -17,6 +18,14 @@ from typing import Any
 correlation_id: contextvars.ContextVar[str] = contextvars.ContextVar("correlation_id", default="")
 
 logger = logging.getLogger("treesight")
+
+# Strip control characters (newlines, tabs, etc.) to prevent log injection.
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+
+def _sanitise(value: object) -> str:
+    """Return a log-safe string with control characters removed."""
+    return _CONTROL_CHAR_RE.sub("", str(value))
 
 
 class JsonFormatter(logging.Formatter):
@@ -59,6 +68,9 @@ def log_phase(
     **extra: object,
 ) -> str:
     """Build a structured log line and emit it at INFO level."""
+    phase, step = _sanitise(phase), _sanitise(step)
+    instance_id = _sanitise(instance_id)
+    blob_name = _sanitise(blob_name)
     props: dict[str, Any] = {"phase": phase, "step": step}
     if instance_id:
         props["instance_id"] = instance_id
@@ -73,7 +85,7 @@ def log_phase(
     if instance_id:
         parts.append(f"instance={instance_id}")
     for k, v in extra.items():
-        parts.append(f"{k}={v}")
+        parts.append(f"{_sanitise(k)}={_sanitise(v)}")
     if blob_name:
         parts.append(f"blob={blob_name}")
     msg = " | ".join(parts)
@@ -89,6 +101,9 @@ def log_error(
     **extra: object,
 ) -> None:
     """Build a structured log line and emit it at ERROR level."""
+    phase, step = _sanitise(phase), _sanitise(step)
+    error = _sanitise(error)
+    instance_id = _sanitise(instance_id)
     props: dict[str, Any] = {"phase": phase, "step": step, "error": error}
     if instance_id:
         props["instance_id"] = instance_id
@@ -100,7 +115,7 @@ def log_error(
     if instance_id:
         parts.append(f"instance={instance_id}")
     for k, v in extra.items():
-        parts.append(f"{k}={v}")
+        parts.append(f"{_sanitise(k)}={_sanitise(v)}")
     parts.append(f"error={error}")
     logger.error(" | ".join(parts), extra={"custom_properties": props})
 


### PR DESCRIPTION
## Summary

Fixes two code scanning alerts from CodeQL/Semgrep.

Fixes #377

## Changes

### Alert #64 — SSRF / Incomplete URL substring sanitization

**File:** `blueprints/demo.py`

**Problem:** The CORS proxy's domain validation used `parsed.netloc.split(":")[0]` which doesn't strip userinfo (e.g. `user:pass@evil.com`). The `endswith()` domain check was also flagged as incomplete URL substring sanitization.

**Fix:**
- Use `parsed.hostname` (which correctly strips auth and port) instead of manual `netloc` splitting
- Reject domains containing `@`
- Replace one-liner `any(endswith(...))` with explicit loop and exact-match-or-subdomain check with length validation

### Alert #2757 — Log injection (CWE-117) — 58+ call sites

**File:** `treesight/log.py`

**Problem:** `log_phase()` and `log_error()` interpolate user-controlled values (blob names, KML feature names, exception messages) into log messages via f-strings without sanitising control characters. Newlines/carriage returns could forge log entries or corrupt audit trails.

**Fix:**
- Added `_sanitise()` function that strips all C0 and C1 control characters (`\x00-\x1f`, `\x7f-\x9f`) using a compiled regex
- Applied `_sanitise()` to all named parameters (`phase`, `step`, `instance_id`, `blob_name`, `error`) and all `**extra` key-value pairs before message interpolation
- This fixes every downstream call site (58+) without requiring changes to callers

## Testing

All 824 tests pass (0 failures, 28 skipped, 3 warnings).