### PR TITLE
Potential fix for code scanning alert no. 64: Partial server-side request forgery

### DIFF
--- a/scripts/dev_server.py
+++ b/scripts/dev_server.py
@@ -14,6 +14,8 @@ import os
 import socketserver
 import urllib.error
 import urllib.request
+import posixpath
+from urllib.parse import urlparse, urlunparse, unquote
 
 
 class DevProxyHandler(http.server.SimpleHTTPRequestHandler):
@@ -50,9 +52,7 @@ class DevProxyHandler(http.server.SimpleHTTPRequestHandler):
     # --- proxy logic ---
 
     def _proxy(self) -> None:
-        from urllib.parse import urlparse
-
-        # Validate the path is a safe relative path (no host/scheme injection)
+        # Validate and normalize the path to prevent host/scheme or path traversal issues
         parsed = urlparse(self.path)
         if parsed.scheme or parsed.netloc:
             self.send_response(400)
@@ -61,7 +61,26 @@ class DevProxyHandler(http.server.SimpleHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(b'{"error":"Invalid path"}')
             return
-        target = f"{self.func_origin}{self.path}"
+
+        # Normalize the path and ensure it stays under /api/
+        raw_path = parsed.path or "/"
+        decoded_path = unquote(raw_path)
+        normalized_path = posixpath.normpath(decoded_path)
+        if not normalized_path.startswith("/"):
+            normalized_path = "/" + normalized_path
+
+        # Enforce that all proxied requests remain under the /api/ prefix
+        if not normalized_path.startswith("/api/"):
+            self.send_response(400)
+            self.send_header("Content-Type", "application/json")
+            self._cors_headers()
+            self.end_headers()
+            self.wfile.write(b'{"error":"Invalid API path"}')
+            return
+
+        # Reconstruct the URL suffix with the sanitized path plus original query/fragment
+        safe_suffix = urlunparse(("", "", normalized_path, "", parsed.query, parsed.fragment))
+        target = f"{self.func_origin}{safe_suffix}"
 
         # Read request body (for POST)
         content_length = int(self.headers.get("Content-Length", 0))


### PR DESCRIPTION
Potential fix for [https://github.com/Hardcoreprawn/azure-workflow-for-kml-satellite/security/code-scanning/64](https://github.com/Hardcoreprawn/azure-workflow-for-kml-satellite/security/code-scanning/64)

General approach: keep the proxy behavior but sanitize the user-controlled request path before combining it with `func_origin`. For a partial SSRF, the main risks are path traversal (`..`), encoded traversal (`%2e%2e`), and attempts to escape the intended `/api/` prefix. We should normalize and validate the path so it always remains under `/api/` and reject anything invalid, instead of directly concatenating `self.path`.

Best concrete fix: in `_proxy`, after parsing `self.path` to ensure no scheme/host, also normalize the path component, enforce that it starts with `/api/`, and block path traversal. We can use `urllib.parse.urlparse`, `urllib.parse.urlunparse`, and `posixpath.normpath` (safe and standard) to reconstruct a canonical path, then recombine it with any query string and fragment. If the normalized path is invalid (does not start with `/api/` or contains attempts to climb above that root), return `400` with a small JSON error. Finally, build `target` using this sanitized URL part instead of `self.path`. This keeps existing behavior for valid `/api/...` requests while addressing all variants of the alert.

Concretely in `scripts/dev_server.py`:

- Add imports for `posixpath` and for `urlparse`, `urlunparse`, `unquote` at the top (or adjust existing intra-function import).
- In `_proxy`, replace the current `from urllib.parse import urlparse` and subsequent validation/`target` construction with:
  - parse `self.path`;
  - reject if `scheme` or `netloc` is present;
  - decode the path (`unquote`) and normalize via `posixpath.normpath`;
  - enforce that it starts with `/api/` and has no traversal above `/api`;
  - rebuild a sanitized URL suffix with `urlunparse(( "", "", normalized_path, "", parsed.query, parsed.fragment ))`;
  - set `target = f"{self.func_origin}{safe_suffix}"`.
- Use the same error-handling style as the existing 400-path block to remain consistent.

No other behavior (headers, timeouts, methods) changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
