### PR TITLE
Potential fix for code scanning alert no. 2757: Incomplete URL substring sanitization

### DIFF
--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pytest
 
@@ -297,8 +298,16 @@ class TestCspAppInsights:
         connect_match = re.search(r"connect-src\s+([^;]+)", csp)
         assert connect_match, "CSP missing connect-src"
         connect_src = connect_match.group(1)
-        assert (
-            "applicationinsights.azure.com" in connect_src or "visualstudio.com" in connect_src
+        sources = connect_src.split()
+
+        def allows_app_insights_telemetry(src: str) -> bool:
+            # Handle bare hosts and scheme/host URLs.
+            parsed = urlparse(src)
+            host = parsed.hostname or src
+            return host == "applicationinsights.azure.com" or host.endswith(".visualstudio.com")
+
+        assert any(
+            allows_app_insights_telemetry(src) for src in sources
         ), "CSP connect-src must allow App Insights telemetry ingestion endpoint"
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/Hardcoreprawn/azure-workflow-for-kml-satellite/security/code-scanning/2757](https://github.com/Hardcoreprawn/azure-workflow-for-kml-satellite/security/code-scanning/2757)

In general, the fix is to stop using substring searches over the whole CSP `connect-src` directive and instead check the individual source tokens (hosts / URLs) so that we only match actual hosts or origins, not arbitrary substrings embedded inside other hosts or data. For CSP, this can be done by splitting the directive’s value on whitespace into source expressions and then checking membership/ending conditions on each token, or by parsing tokens that are URLs with `urllib.parse.urlparse` and checking their hostnames.

For this specific test, we can preserve the intended functionality (accept any CSP that allows either `applicationinsights.azure.com` or a `visualstudio.com` endpoint) by: (1) extracting the `connect-src` value as currently done, (2) splitting it into tokens on whitespace, and (3) checking that at least one token either equals `applicationinsights.azure.com` or equals/points to a host under `visualstudio.com`. A minimal low-impact change is to replace the existing substring check with a small helper expression that iterates over `connect_src.split()` and performs more precise checks on each token. Since this is test code, we should avoid introducing heavy dependencies; using Python’s standard library (`urllib.parse`) is sufficient. Concretely, we will: import `urllib.parse.urlparse` near the top (without removing existing imports) and rewrite the assertion in `test_connect_src_allows_telemetry_endpoint` to parse each token and validate its hostname or the bare token. Functionality remains: any CSP that genuinely permits a `visualstudio.com` telemetry endpoint still makes the test pass, while spurious substrings in unrelated tokens no longer satisfy the test.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
