### PR TITLE
feat: safe deploy with automatic rollback on readiness failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -208,9 +208,32 @@ jobs:
           ARM_USE_OIDC: "true"
         run: tofu apply -auto-approve tfplan
 
+      # Capture the current container image so we can rollback if the
+      # new image fails readiness checks.
+      - name: Capture current container image
+        id: current-image
+        working-directory: infra/tofu
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_USE_OIDC: "true"
+        run: |
+          FUNC_RG=$(tofu output -raw resource_group_name)
+          FUNC_NAME=$(tofu output -raw function_app_name)
+          CURRENT_IMAGE=$(az functionapp config container show \
+            --name "$FUNC_NAME" \
+            --resource-group "$FUNC_RG" \
+            --query '[?name==`DOCKER_CUSTOM_IMAGE_NAME`].value' -o tsv 2>/dev/null || echo "")
+          echo "image=${CURRENT_IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "func_rg=${FUNC_RG}" >> "$GITHUB_OUTPUT"
+          echo "func_name=${FUNC_NAME}" >> "$GITHUB_OUTPUT"
+          echo "Previous image: ${CURRENT_IMAGE:-<none>}"
+
       # azapi v2 crashes when updating the function app body (identity bug).
       # So tofu ignores body changes and we apply mutable config via CLI.
       - name: Configure Function App
+        id: configure-app
         working-directory: infra/tofu
         env:
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -277,6 +300,7 @@ jobs:
           echo "connection_string=$(tofu output -raw appinsights_connection_string)" >> "$GITHUB_OUTPUT"
 
       - name: Verify runtime readiness
+        id: verify-readiness
         working-directory: infra/tofu
         env:
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -336,6 +360,45 @@ jobs:
           echo "  - Container image failed to start (check Container Apps logs)"
           echo "  - Route registration lag exceeded timeout"
           echo "  - The function app hostname has changed"
+          exit 1
+
+      # ── Safe deploy: rollback to previous image on readiness failure ──
+      - name: Rollback to previous image
+        if: failure() && steps.configure-app.outcome == 'success' && steps.current-image.outputs.image != ''
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_USE_OIDC: "true"
+        run: |
+          PREV_IMAGE="${{ steps.current-image.outputs.image }}"
+          FUNC_NAME="${{ steps.current-image.outputs.func_name }}"
+          FUNC_RG="${{ steps.current-image.outputs.func_rg }}"
+
+          echo "⚠️ Readiness checks failed — rolling back to previous image."
+          echo "  Previous: ${PREV_IMAGE}"
+          echo "  Failed:   ${{ needs.build-image.outputs.image_uri }}"
+
+          az functionapp config container set \
+            --name "$FUNC_NAME" \
+            --resource-group "$FUNC_RG" \
+            --image "$PREV_IMAGE"
+
+          # Wait for the rollback to take effect
+          echo "Waiting for rolled-back container to become healthy..."
+          HOSTNAME="${{ steps.hostname.outputs.hostname }}"
+          BASE_URL="https://${HOSTNAME}"
+          for i in $(seq 1 12); do
+            sleep 10
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "${BASE_URL}/api/health" 2>/dev/null || echo "000")
+            echo "  [${i}0s] health=${code}"
+            if [ "$code" = "200" ]; then
+              echo "✅ Rollback successful — previous image is healthy."
+              exit 0
+            fi
+          done
+          echo "⚠️ Rollback applied but health check did not recover within 120s."
+          echo "  Manual intervention may be required."
           exit 1
 
   # ── 3. Deploy static website ───────────────────────────────


### PR DESCRIPTION
## Problem

When a deploy produces a broken container image, the readiness checks fail but the broken image **stays deployed** — leaving the live site down until someone manually intervenes. This happened in deploy runs #23945001646 and #23945935719 (stale base image missing `NuGet.Packaging.dll` and `Microsoft.CodeAnalysis.dll`).

## Solution

Add automatic rollback to the deploy workflow:

1. **Before** changing the container image, capture the currently-running image
2. **After** readiness checks fail, automatically restore the previous image
3. **Verify** the rolled-back image is healthy (polls for up to 120s)

### Rollback triggers only when:
- The container image was actually changed (`Configure Function App` step succeeded)
- Readiness checks timed out or failed
- A previous image exists to roll back to

This means infrastructure-only failures (like the DNS CNAME issue) don't trigger a spurious rollback.

### Deploy flow (before → after):

```
BEFORE: Build → Push → Tofu → Apply Image → Check Health → ❌ (broken image stays)
AFTER:  Build → Push → Tofu → Capture Prev → Apply Image → Check Health → ❌ → Rollback → Verify
```

## Also found

The latest deploy (run #23976303287) failed at **Tofu Apply** because the rebrand changed `custom_domain` from `treesight.hrdcrprwn.com` to `canopex.hrdcrprwn.com` but the DNS CNAME record doesn't exist yet. Tofu already destroyed the old binding. **Action needed**: create CNAME `canopex.hrdcrprwn.com → polite-glacier-0d6885003.4.azurestaticapps.net`, then re-deploy.