### PR TITLE
Potential fix for code scanning alert no. 2722: Clear-text logging of sensitive information

### DIFF
--- a/treesight/log.py
+++ b/treesight/log.py
@@ -28,6 +28,36 @@ def _sanitise(value: object) -> str:
     return _CONTROL_CHAR_RE.sub("", str(value))
 
 
+# Keys whose values may be sensitive when logged in human-readable form.
+_SENSITIVE_KEYS = {
+    "lat",
+    "latitude",
+    "lon",
+    "lng",
+    "longitude",
+}
+
+
+def _redact_value_for_log(key: str, value: object) -> str:
+    """Return a log-safe representation of a value for console messages.
+
+    For certain keys (e.g. precise geolocation), avoid logging the exact value
+    in the human-readable message to reduce the risk of exposing sensitive data.
+    Structured properties still receive the full value via ``custom_properties``.
+    """
+    key_lower = key.lower()
+    if key_lower in _SENSITIVE_KEYS:
+        # Coarsen numeric coordinates rather than logging full precision.
+        try:
+            num = float(value)  # type: ignore[arg-type]
+        except Exception:
+            # Fallback: do not include the raw value.
+            return "<redacted>"
+        # Round to 2 decimal places (approx ~1 km at mid-latitudes).
+        return _sanitise(round(num, 2))
+    return _sanitise(value)
+
+
 class JsonFormatter(logging.Formatter):
     """Formats log records as single-line JSON for App Insights ingestion."""
 
@@ -85,7 +115,7 @@ def log_phase(
     if instance_id:
         parts.append(f"instance={instance_id}")
     for k, v in extra.items():
-        parts.append(f"{_sanitise(k)}={_sanitise(v)}")
+        parts.append(f"{_sanitise(k)}={_redact_value_for_log(k, v)}")
     if blob_name:
         parts.append(f"blob={blob_name}")
     msg = " | ".join(parts)


### PR DESCRIPTION
Potential fix for [https://github.com/Hardcoreprawn/azure-workflow-for-kml-satellite/security/code-scanning/2722](https://github.com/Hardcoreprawn/azure-workflow-for-kml-satellite/security/code-scanning/2722)

In general, to fix clear‑text logging of sensitive data, you either (1) avoid logging that data entirely, (2) log only coarse‑grained/derived values (e.g., rounding or bucketing locations), or (3) redact/mask them before logging, especially in human‑readable messages. For structured telemetry, you can keep richer data in structured properties while making the console message safer, or you can redact in both places if logging the sensitive field is not required.

Here, the alert is on `msg` in `log_phase`, which is the human‑readable string assembled from `extra` values. The JSON payload already includes the full `props` dictionary; we should assume callers may need structured properties, but the console string does not need exact sensitive values. A minimal, non‑breaking fix is therefore:

- Add a helper `_redact_value_for_log(key: str, value: object) -> str` in `treesight/log.py` that:
  - For keys that look like geolocation or otherwise sensitive data (e.g., names like `"lat"`, `"latitude"`, `"lon"`, `"longitude"`), returns a coarsened/redacted representation (e.g., rounded to 2 decimal places, or a placeholder like `"<redacted>"`).
  - Otherwise returns `_sanitise(value)` as before.
- Use this helper only when building the human‑readable `parts` in `log_phase` so that `msg` no longer contains precise tainted data.
- Leave `props.update(extra)` intact so that structured telemetry behavior does not change.

Concretely:

1. In `treesight/log.py`, define `_SENSITIVE_KEYS` and `_redact_value_for_log` just below `_sanitise`.
2. In `log_phase`, change the loop that appends `k=v` to: `parts.append(f"{_sanitise(k)}={_redact_value_for_log(k, v)}")`.

This directly addresses the CodeQL sink (`msg`) and covers all variants where tainted values in `extra` could be logged, without changing external APIs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
