### PR TITLE
Suppress CodeQL alert 2722: clear-text logging false positive

### DIFF
--- a/treesight/log.py
+++ b/treesight/log.py
@@ -88,7 +88,7 @@ def log_phase(
         parts.append(f"{_sanitise(k)}={_sanitise(v)}")
     if blob_name:
         parts.append(f"blob={blob_name}")
-    msg = " | ".join(parts)
+    msg = " | ".join(parts)  # lgtm[py/clear-text-logging-sensitive-data]
     logger.info(msg, extra={"custom_properties": props})
     return msg
 


### PR DESCRIPTION
## Summary\n\nAdds `# lgtm[py/clear-text-logging-sensitive-data]` suppression to the `log_phase` function to dismiss CodeQL alert #2722.\n\n## Rationale\n\nThe flagged values are **AOI centroids** derived from user-uploaded KML files — they are geographic bounding-box centres, not user PII. The values are already sanitised via `_sanitise()` to prevent log injection, and the structured telemetry in `custom_properties` is intentionally full-precision for debugging.\n\nThe Copilot Autofix PR (#391) was reviewed and rejected because:\n- Its key matching (`lat`, `lon`) wouldn't catch the actual keys used (`center_lat`, `center_lon`)\n- It only patched `log_phase`, not `log_error`\n- It had no test coverage\n- The source branch was already deleted\n\nSuppressing the alert is the correct action for a false positive.\n\nSupersedes #391.