### PR TITLE
fix: add OPTIONS preflight to submission endpoints

### DIFF
--- a/blueprints/pipeline/submission.py
+++ b/blueprints/pipeline/submission.py
@@ -14,7 +14,7 @@ from typing import Any
 import azure.durable_functions as df
 import azure.functions as func
 
-from blueprints._helpers import check_auth, cors_headers, error_response
+from blueprints._helpers import check_auth, cors_headers, cors_preflight, error_response
 from treesight.constants import DEFAULT_INPUT_CONTAINER, DEFAULT_PROVIDER, MAX_KML_FILE_SIZE_BYTES
 from treesight.security.quota import consume_quota, release_quota
 from treesight.security.rate_limit import demo_limiter, get_client_ip
@@ -31,23 +31,27 @@ def _safe_release_quota(user_id: str) -> None:
         logging.exception("Failed to release quota for user=%s", user_id)
 
 
-@bp.route(route="demo-process", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
+@bp.route(route="demo-process", methods=["POST", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
 @bp.durable_client_input(client_name="client")
 async def demo_process(
     req: func.HttpRequest,
     client: df.DurableOrchestrationClient,
 ) -> func.HttpResponse:
     """POST /api/demo-process — anonymous demo submission with tier limits."""
+    if req.method == "OPTIONS":
+        return cors_preflight(req)
     return await _submit_demo_request(req, client)
 
 
-@bp.route(route="analysis/submit", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
+@bp.route(route="analysis/submit", methods=["POST", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
 @bp.durable_client_input(client_name="client")
 async def analysis_submit(
     req: func.HttpRequest,
     client: df.DurableOrchestrationClient,
 ) -> func.HttpResponse:
     """POST /api/analysis/submit — authenticated analysis submission."""
+    if req.method == "OPTIONS":
+        return cors_preflight(req)
     return await _submit_analysis_request(req, client, blob_prefix="analysis")
 
 

--- a/tests/test_submission_cors.py
+++ b/tests/test_submission_cors.py
@@ -38,6 +38,49 @@ def _make_request(
     return req
 
 
+class TestSubmissionCORSPreflight:
+    """Both submission endpoints must respond to OPTIONS preflight requests.
+
+    The ``@bp.durable_client_input`` decorator makes it hard to call the
+    endpoint directly in tests, so we verify:
+      1. cors_preflight produces the expected 204 with full CORS headers,
+      2. the route source contains the OPTIONS guard (structural assertion).
+    """
+
+    def test_cors_preflight_returns_204_with_headers(self):
+        from blueprints._helpers import cors_preflight
+
+        req = MagicMock()
+        req.headers = {"Origin": TEST_ORIGIN}
+
+        resp = cors_preflight(req)
+
+        assert resp.status_code == 204
+        assert resp.headers["Access-Control-Allow-Origin"] == TEST_ORIGIN
+        assert "POST" in resp.headers["Access-Control-Allow-Methods"]
+        assert "Authorization" in resp.headers["Access-Control-Allow-Headers"]
+
+    def test_analysis_submit_has_options_guard(self):
+        import inspect
+
+        import blueprints.pipeline.submission as mod
+
+        src = inspect.getsource(mod)
+        # Route must accept OPTIONS
+        assert 'methods=["POST", "OPTIONS"]' in src or "methods=['POST', 'OPTIONS']" in src, (
+            "analysis/submit route must accept OPTIONS for CORS preflight"
+        )
+
+    def test_demo_process_has_options_guard(self):
+        import inspect
+
+        import blueprints.pipeline.submission as mod
+
+        src = inspect.getsource(mod)
+        # Both routes must call cors_preflight on OPTIONS
+        assert "cors_preflight" in src, "submission endpoints must call cors_preflight"
+
+
 class TestAnalysisSubmitCORS:
     """_submit_analysis_request must include CORS headers on every response."""
 


### PR DESCRIPTION
## Problem

Submission endpoints (`/api/demo-process` and `/api/analysis/submit`) only accept `POST`, but in production the frontend runs cross-origin:

- **Frontend**: `https://canopex.hrdcrprwn.com` (Static Web App)
- **API**: `https://func-kmlsat-dev.politebush-dbd595e5.uksouth.azurecontainerapps.io` (Function App on Container Apps)

The deploy pipeline injects `api-config.json` with the Function App hostname, so all API calls are cross-origin. The browser sends an `OPTIONS` preflight request before any `POST` with `Content-Type: application/json` + `Authorization` header. Without an OPTIONS handler, the preflight request fails → browser blocks the POST → `fetch()` throws → frontend shows generic "Could not queue analysis request."

Other endpoints (diagnostics, enrichment) already handle OPTIONS correctly.

## Fix

- Add `"OPTIONS"` to the `methods` list for both `demo_process` and `analysis_submit`
- Import `cors_preflight` and return it on `OPTIONS` requests (matching the pattern in diagnostics.py)
- Add regression tests:
  - `cors_preflight` returns 204 with correct CORS headers
  - Both endpoints have OPTIONS guard in source (structural assertions)

## Testing

940 tests pass, 28 skipped.