### PR TITLE
Potential fix for code scanning alert no. 2722: Clear-text logging of sensitive information

### DIFF
--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -21,7 +21,15 @@ class TestLogPhase:
         msg = log_phase("ingestion", "parse_kml", feature_count=5)
         assert "phase=ingestion" in msg
         assert "step=parse_kml" in msg
-        assert "feature_count=5" in msg
+        # Extras must NOT appear in the clear-text msg (security: CodeQL #2722)
+        assert "feature_count" not in msg
+
+    def test_extras_in_custom_properties(self, caplog):
+        with caplog.at_level(logging.INFO, logger="treesight"):
+            log_phase("ingestion", "parse_kml", feature_count=5)
+        record = caplog.records[-1]
+        props = record.custom_properties
+        assert props["feature_count"] == 5
 
     def test_includes_instance_id(self):
         msg = log_phase("pipeline", "start", instance_id="abc-123")
@@ -121,7 +129,8 @@ class TestLogDuration:
         started = time.monotonic() - 0.150  # simulate 150ms ago
         with caplog.at_level(logging.INFO, logger="treesight"):
             msg = log_duration("enrichment", "ndvi", started)
-        assert "duration_ms=" in msg
+        # duration_ms is an extra — must NOT appear in clear-text msg
+        assert "duration_ms=" not in msg
         props = caplog.records[0].custom_properties  # type: ignore[attr-defined]
         assert props["duration_ms"] >= 100  # at least ~150ms
 

--- a/treesight/log.py
+++ b/treesight/log.py
@@ -81,13 +81,14 @@ def log_phase(
     if cid:
         props["correlation_id"] = cid
     # Human-readable message for console / backward compat.
+    # Extra kwargs are deliberately excluded from the clear-text msg to
+    # avoid logging potentially sensitive data (CodeQL alert #2722).
+    # They remain available in structured custom_properties above.
     parts = [f"phase={phase} step={step}"]
     if instance_id:
         parts.append(f"instance={instance_id}")
     if blob_name:
         parts.append(f"blob={blob_name}")
-    for k, v in extra.items():
-        parts.append(f"{_sanitise(k)}={_sanitise(v)}")
     msg = " | ".join(parts)
     logger.info(msg, extra={"custom_properties": props})
     return msg


### PR DESCRIPTION
Potential fix for [https://github.com/Hardcoreprawn/azure-workflow-for-kml-satellite/security/code-scanning/2722](https://github.com/Hardcoreprawn/azure-workflow-for-kml-satellite/security/code-scanning/2722)

General approach: Avoid including potentially sensitive or unbounded `extra` data in the human‑readable `msg` string, while still attaching it as structured properties (`custom_properties`) for the JSON logger. The structured payload is typically more controlled and access‑managed; the console‑style `msg` is where clear‑text leaks are more problematic and what CodeQL flags.

Best concrete fix without changing existing functionality: Change `log_phase` so that the human‑readable `msg` only contains the non‑sensitive core fields (`phase`, `step`, `instance_id`, `blob_name`) and drops the loop that appends all `extra` key/value pairs. The `props` dict should continue to include `extra` so that structured JSON logging remains unchanged. This directly removes the tainted flow into `msg` and covers all current and future variants of this alert, while leaving the logging API and JSON output intact.

Code changes (all in `treesight/log.py`):
- In `log_phase`, remove the `for k, v in extra.items(): ...` block from building `parts`, so `extra` is no longer copied into the clear‑text message.
- Keep `props.update(extra)` so the structured `custom_properties` still carry the additional context.
- No changes needed in `log_error` or in the enrichment modules for this particular alert, since the taint path terminates at `log_phase`’s string formatting.

No new imports or helper functions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
