### PR TITLE
fix: require sign-in for pipeline submissions and clean preview UX

### DIFF
--- a/blueprints/monitoring.py
+++ b/blueprints/monitoring.py
@@ -148,8 +148,6 @@ def _process_monitor(monitor: Any) -> None:
 # --- HTTP endpoints: monitoring CRUD -----------------------------------
 
 
-@bp.route(route="monitoring", methods=["GET", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
-@require_auth
 def list_monitors_endpoint(
     req: func.HttpRequest, *, auth_claims: dict, user_id: str
 ) -> func.HttpResponse:
@@ -169,8 +167,6 @@ def list_monitors_endpoint(
     )
 
 
-@bp.route(route="monitoring", methods=["POST", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
-@require_auth
 def create_monitor_endpoint(
     req: func.HttpRequest, *, auth_claims: dict, user_id: str
 ) -> func.HttpResponse:
@@ -245,6 +241,23 @@ def create_monitor_endpoint(
         mimetype="application/json",
         headers=cors_headers(req),
     )
+
+
+@bp.route(
+    route="monitoring", methods=["GET", "POST", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS
+)
+@require_auth
+def monitoring_endpoint(
+    req: func.HttpRequest, *, auth_claims: dict, user_id: str
+) -> func.HttpResponse:
+    """Dispatch `/api/monitoring` reads and creates through one registered route."""
+    if req.method == "OPTIONS":
+        return cors_preflight(req)
+    if req.method == "GET":
+        return list_monitors_endpoint(req, auth_claims=auth_claims, user_id=user_id)
+    if req.method == "POST":
+        return create_monitor_endpoint(req, auth_claims=auth_claims, user_id=user_id)
+    return error_response(405, "Method not allowed", req=req)
 
 
 def _apply_patch(

--- a/blueprints/pipeline/blob_trigger.py
+++ b/blueprints/pipeline/blob_trigger.py
@@ -5,6 +5,7 @@ See blueprints/pipeline/__init__.py for details.
 """
 
 import logging
+from pathlib import PurePosixPath
 
 import azure.durable_functions as df
 import azure.functions as func
@@ -14,6 +15,16 @@ from treesight.models.blob_event import BlobEvent
 from . import bp
 from ._helpers import _extract_blob_name, _extract_container, _validate_blob_event
 
+logger = logging.getLogger(__name__)
+
+
+_DIRECT_SUBMISSION_PREFIXES = {"analysis", "demo"}
+
+
+def _is_direct_submission_blob(blob_name: str) -> bool:
+    parts = PurePosixPath(blob_name).parts
+    return bool(parts) and parts[0] in _DIRECT_SUBMISSION_PREFIXES
+
 
 @bp.event_grid_trigger(arg_name="event")
 @bp.durable_client_input(client_name="client")
@@ -22,12 +33,26 @@ async def blob_trigger(
     client: df.DurableOrchestrationClient,
 ) -> None:
     """Event Grid BlobCreated → validate → start orchestration (§4.2)."""
+    await _process_blob_trigger(event, client)
+
+
+async def _process_blob_trigger(
+    event: func.EventGridEvent,
+    client: df.DurableOrchestrationClient,
+) -> None:
+    """Process a blob-created event after bindings have been resolved."""
     data = event.get_json()
     blob_url = data.get("url", "")
     container_name = _extract_container(blob_url)
     blob_name = _extract_blob_name(blob_url)
 
     _validate_blob_event(blob_name, container_name, data)
+
+    if _is_direct_submission_blob(blob_name):
+        logger.info(
+            "Skipping blob-triggered orchestration for direct submission blob=%s", blob_name
+        )
+        return
 
     blob_event = BlobEvent(
         blob_url=blob_url,
@@ -52,4 +77,4 @@ async def blob_trigger(
         instance_id=instance_id,
         client_input=orchestrator_input,
     )
-    logging.info("Started orchestration instance=%s blob=%s", instance_id, blob_name)
+    logger.info("Started orchestration instance=%s blob=%s", instance_id, blob_name)

--- a/blueprints/pipeline/diagnostics.py
+++ b/blueprints/pipeline/diagnostics.py
@@ -28,13 +28,16 @@ async def orchestrator_status(
     client: df.DurableOrchestrationClient,
 ) -> func.HttpResponse:
     """GET /api/orchestrator/{instance_id} — direct JSON diagnostics (§4.3)."""
+    return await _build_orchestrator_status_response(req, client)
+
+
+async def _build_orchestrator_status_response(
+    req: func.HttpRequest,
+    client: df.DurableOrchestrationClient,
+) -> func.HttpResponse:
+    """Build the anonymous orchestration status response after bindings resolve."""
     if req.method == "OPTIONS":
         return cors_preflight(req)
-
-    try:
-        check_auth(req)
-    except ValueError as exc:
-        return error_response(401, str(exc), req=req)
 
     if not pipeline_limiter.is_allowed(get_client_ip(req)):
         return error_response(429, "Rate limit exceeded — try again later", req=req)

--- a/blueprints/pipeline/submission.py
+++ b/blueprints/pipeline/submission.py
@@ -91,6 +91,9 @@ async def _submit_analysis_request(
     except ValueError as exc:
         return error_response(401, str(exc), req=req)
 
+    if user_id == "anonymous":
+        return error_response(401, "Authentication is required for pipeline submissions", req=req)
+
     # Consume quota upfront (atomic reservation).  If storage is
     # transiently unavailable we log the error but still allow the
     # submission so a temporary outage doesn't block users.

--- a/blueprints/pipeline/submission.py
+++ b/blueprints/pipeline/submission.py
@@ -1,10 +1,9 @@
-"""Submission HTTP endpoints: demo and authenticated analysis requests.
+"""Submission HTTP endpoints for signed-in analysis requests.
 
 NOTE: Do NOT add ``from __future__ import annotations`` to this module.
 See blueprints/pipeline/__init__.py for details.
 """
 
-import hashlib
 import json
 import logging
 import uuid
@@ -16,11 +15,13 @@ import azure.functions as func
 
 from blueprints._helpers import check_auth, cors_headers, cors_preflight, error_response
 from treesight.constants import DEFAULT_INPUT_CONTAINER, DEFAULT_PROVIDER, MAX_KML_FILE_SIZE_BYTES
+from treesight.security.billing import get_effective_subscription, plan_capabilities
 from treesight.security.quota import consume_quota, release_quota
-from treesight.security.rate_limit import demo_limiter, get_client_ip
 
 from . import bp
 from .history import _extract_submission_context, _persist_submission_record
+
+logger = logging.getLogger(__name__)
 
 
 def _safe_release_quota(user_id: str) -> None:
@@ -28,19 +29,42 @@ def _safe_release_quota(user_id: str) -> None:
     try:
         release_quota(user_id)
     except Exception:
-        logging.exception("Failed to release quota for user=%s", user_id)
+        logger.exception("Failed to release quota for user=%s", user_id)
 
 
-@bp.route(route="demo-process", methods=["POST", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
-@bp.durable_client_input(client_name="client")
-async def demo_process(
-    req: func.HttpRequest,
-    client: df.DurableOrchestrationClient,
-) -> func.HttpResponse:
-    """POST /api/demo-process — anonymous demo submission with tier limits."""
-    if req.method == "OPTIONS":
-        return cors_preflight(req)
-    return await _submit_demo_request(req, client)
+def _submission_plan_overrides(user_id: str) -> dict[str, Any]:
+    """Return orchestration input overrides for the signed-in user's tier."""
+    try:
+        subscription = get_effective_subscription(user_id)
+        plan = plan_capabilities(subscription.get("tier"))
+    except Exception:
+        logger.exception(
+            "Billing lookup unavailable for user=%s — defaulting to free-tier controls",
+            user_id,
+        )
+        plan = plan_capabilities("free")
+
+    tier = plan.get("tier", "free")
+    overrides: dict[str, Any] = {"tier": tier}
+    if tier in {"free", "demo"}:
+        overrides["cadence"] = plan.get("temporal_cadence", "seasonal")
+        max_history_years = plan.get("max_history_years")
+        if max_history_years is not None:
+            overrides["max_history_years"] = max_history_years
+    return overrides
+
+
+def _validated_kml_bytes(req: func.HttpRequest, body: Any) -> bytes | func.HttpResponse:
+    """Return validated KML bytes or an error response."""
+    kml_content = body.get("kml_content", "") if isinstance(body, dict) else ""
+    if not isinstance(kml_content, str) or not kml_content.strip():
+        return error_response(400, "kml_content is required", req=req)
+
+    kml_bytes = kml_content.encode("utf-8")
+    if len(kml_bytes) > MAX_KML_FILE_SIZE_BYTES:
+        return error_response(400, f"KML exceeds {MAX_KML_FILE_SIZE_BYTES} bytes", req=req)
+
+    return kml_bytes
 
 
 @bp.route(route="analysis/submit", methods=["POST", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
@@ -49,52 +73,19 @@ async def analysis_submit(
     req: func.HttpRequest,
     client: df.DurableOrchestrationClient,
 ) -> func.HttpResponse:
-    """POST /api/analysis/submit — authenticated analysis submission."""
+    """POST /api/analysis/submit — signed-in KML submission entry point."""
     if req.method == "OPTIONS":
         return cors_preflight(req)
-    return await _submit_analysis_request(req, client, blob_prefix="analysis")
-
-
-async def _submit_demo_request(
-    req: func.HttpRequest,
-    client: df.DurableOrchestrationClient,
-) -> func.HttpResponse:
-    """Validate, persist, and enqueue an anonymous demo KML submission."""
-    client_ip = get_client_ip(req)
-
-    if not demo_limiter.is_allowed(client_ip):
-        return error_response(429, "Demo rate limit exceeded — try again later", req=req)
-
-    try:
-        body = req.get_json()
-    except ValueError:
-        return error_response(400, "Invalid JSON body", req=req)
-
-    ip_hash = hashlib.sha256(client_ip.encode()).hexdigest()[:12]
-    demo_user_id = f"demo:{ip_hash}"
-
-    return await _submit_kml(
-        req,
-        client,
-        body,
-        blob_prefix="demo",
-        extra_input={
-            "cadence": "seasonal",
-            "max_history_years": 2,
-            "user_id": demo_user_id,
-            "tier": "demo",
-        },
-        log_tag=f"Demo process started user={demo_user_id}",
-    )
+    return await _submit_analysis_request(req, client)
 
 
 async def _submit_analysis_request(
     req: func.HttpRequest,
     client: df.DurableOrchestrationClient,
     *,
-    blob_prefix: str,
+    blob_prefix: str = "analysis",
 ) -> func.HttpResponse:
-    """Validate, persist, and enqueue a KML analysis submission."""
+    """Validate, persist, and enqueue a signed-in KML analysis submission."""
     try:
         _claims, user_id = check_auth(req)
     except ValueError as exc:
@@ -111,7 +102,7 @@ async def _submit_analysis_request(
         # Quota genuinely exhausted — hard block.
         return error_response(403, str(exc), req=req)
     except Exception:
-        logging.exception("Quota storage unavailable for user=%s — allowing submission", user_id)
+        logger.exception("Quota storage unavailable for user=%s — allowing submission", user_id)
 
     try:
         body = req.get_json()
@@ -120,16 +111,27 @@ async def _submit_analysis_request(
             _safe_release_quota(user_id)
         return error_response(400, "Invalid JSON body", req=req)
 
+    kml_bytes = _validated_kml_bytes(req, body)
+    if isinstance(kml_bytes, func.HttpResponse):
+        if quota_consumed:
+            _safe_release_quota(user_id)
+        return kml_bytes
+
     submission_context = _extract_submission_context(body)
 
     effective_provider = submission_context.get("provider_name", DEFAULT_PROVIDER)
+    plan_overrides = _submission_plan_overrides(user_id)
 
     resp = await _submit_kml(
         req,
         client,
         body,
         blob_prefix=blob_prefix,
-        extra_input={"provider_name": effective_provider, "user_id": user_id},
+        extra_input={
+            "provider_name": effective_provider,
+            "user_id": user_id,
+            **plan_overrides,
+        },
         log_tag=f"Analysis process started prefix={blob_prefix}",
     )
 
@@ -173,13 +175,9 @@ async def _submit_kml(
     log_tag: str = "",
 ) -> func.HttpResponse:
     """Shared KML validation, upload, and orchestrator start."""
-    kml_content = body.get("kml_content", "") if isinstance(body, dict) else ""
-    if not isinstance(kml_content, str) or not kml_content.strip():
-        return error_response(400, "kml_content is required", req=req)
-
-    kml_bytes = kml_content.encode("utf-8")
-    if len(kml_bytes) > MAX_KML_FILE_SIZE_BYTES:
-        return error_response(400, f"KML exceeds {MAX_KML_FILE_SIZE_BYTES} bytes", req=req)
+    kml_bytes = _validated_kml_bytes(req, body)
+    if isinstance(kml_bytes, func.HttpResponse):
+        return kml_bytes
 
     submission_id = str(uuid.uuid4())
     safe_prefix = blob_prefix.strip("/") or "analysis"
@@ -196,7 +194,7 @@ async def _submit_kml(
             content_type="application/vnd.google-earth.kml+xml",
         )
     except Exception:
-        logging.exception("KML upload failed for %s", kml_blob_name)
+        logger.exception("KML upload failed for %s", kml_blob_name)
         return error_response(
             502,
             "Storage service temporarily unavailable — please retry in a moment.",
@@ -224,14 +222,14 @@ async def _submit_kml(
             client_input=orchestrator_input,
         )
     except Exception:
-        logging.exception("Orchestrator start failed for %s", submission_id)
+        logger.exception("Orchestrator start failed for %s", submission_id)
         return error_response(
             502,
             "Pipeline service temporarily unavailable — please retry in a moment.",
             req=req,
         )
 
-    logging.info("%s instance=%s", log_tag, submission_id)
+    logger.info("%s instance=%s", log_tag, submission_id)
 
     return func.HttpResponse(
         json.dumps({"instance_id": submission_id, "submission_prefix": safe_prefix}),

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -8,6 +8,8 @@ Issue: #18
 2. Deploy infrastructure and app via GitHub Actions deploy workflow.
 3. Verify Function host readiness using /api/health.
 4. Verify Event Grid subscription reconciliation succeeds.
+5. `/api/analysis/submit` must reject unauthenticated callers before any upload or orchestration work begins.
+6. For direct `analysis/` uploads created by `/api/analysis/submit`, rely on the HTTP submission path as the authoritative orchestration start; BlobCreated automation should only start storage-native uploads outside that prefix.
 
 Reference: .github/workflows/deploy.yml and infra/tofu/README.md.
 
@@ -76,11 +78,21 @@ Primary telemetry:
 - Durable orchestration status endpoint
 - Azure Monitor alerts for failed requests and latency
 
+Expected Canopex application log shape in App Insights traces:
+
+- Single-line JSON for the `treesight`, `blueprints`, and `function_app` logger families
+- Stable top-level keys: `timestamp`, `level`, `logger`, `message`
+- Optional correlation keys: `correlation_id`, `properties`, `exception`
+- Pipeline helper fields appear under `properties`, including values such as `phase`, `step`, `instance_id`, and `blob_name`
+
 Operational checks:
 
 1. Query failed orchestration runs by instance_id.
 2. Correlate instance_id with activity logs.
 3. Verify artifact presence in output blob container.
+
+If startup evidence is missing, query for `logger=function_app` first to confirm
+the startup logging installer ran before config validation and replay-store setup.
 
 ## Troubleshoot Common Failures
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,7 @@
 **Single source of truth for what to build next.**
 Issues hold the detail. This list holds the order.
 
-Last updated: 2026-04-04
+Last updated: 2026-04-05
 
 ---
 
@@ -25,6 +25,7 @@ Last updated: 2026-04-04
 |----|--------|---------|
 | #393 | `fix/blob-storage-managed-identity` | Blob storage managed identity fix |
 | #394 | `feature/scheduled-monitoring` | 3.1 — Scheduled monitoring + change alerts |
+| #413 | `fix/signed-in-pipeline-preview` | Enforce signed-in pipeline submission, prevent duplicate starts, and clean the free-plan preview UX |
 
 ---
 

--- a/docs/SYSTEM_SPEC.md
+++ b/docs/SYSTEM_SPEC.md
@@ -373,10 +373,11 @@ All endpoints return JSON unless otherwise specified.
 **Trigger behaviour:**
 
 1. Receives Event Grid BlobCreated event for `*-input` containers
-2. Validates: blob name non-empty, `.kml` extension, container ends with `-input`, 0 < size ≤ 10 MiB
-3. Builds canonical orchestrator input (BlobEvent → OrchestratorInput dict)
-4. Starts durable orchestration with `instance_id = correlation_id`
-5. Returns orchestration management URLs
+2. Ignores direct submission prefixes (`analysis/`, `demo/`) because `/api/analysis/submit` already starts those orchestrations synchronously
+3. Validates: blob name non-empty, `.kml` extension, container ends with `-input`, 0 < size ≤ 10 MiB
+4. Builds canonical orchestrator input (BlobEvent → OrchestratorInput dict)
+5. Starts durable orchestration with `instance_id = correlation_id`
+6. Returns orchestration management URLs
 
 ### 4.3 Orchestration Status
 
@@ -449,38 +450,37 @@ All endpoints return JSON unless otherwise specified.
 
 **Response:** 200 with `{"status": "received", "submission_id": "..."}`
 
-### 4.6 Demo Submission
+### 4.6 Unified Submission
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| POST | `/api/demo-submit` | anonymous | Accepts email + KML for demo processing |
-| OPTIONS | `/api/demo-submit` | anonymous | Returns 204 (CORS preflight) |
+| POST | `/api/analysis/submit` | bearer | Accepts KML content and queues a signed-in analysis run |
+| OPTIONS | `/api/analysis/submit` | anonymous | Returns 204 (CORS preflight) |
 
 **Request body:**
 
 ```json
 {
-    "email": "string (required, validated)",
     "kml_content": "string (required, non-empty KML text)"
 }
 ```
 
 **Behaviour:**
 
-1. Validates email format and KML content presence
+1. Validates KML content presence
 2. Generates `submission_id` (UUID v4)
-3. Stores KML to: `kml-input/demo/{submission_id}.kml`
-4. Stores submission record to: `pipeline-payloads/demo-submissions/{submission_id}.json`
-5. Returns 200 with `{"status": "submitted", "submission_id": "..."}`
+3. Requires a valid bearer token before any pipeline work begins
+4. Stores KML to `kml-input/analysis/{submission_id}.kml`, applies accounting/quota, and persists analysis history metadata
+5. Applies low-cost submission controls for the signed-in free tier (`seasonal` cadence, `max_history_years = 2`)
+6. Starts the durable orchestration immediately and returns 202 with `{"instance_id": "...", "submission_prefix": "analysis"}`
 
 **Submission record shape:**
 
 ```json
 {
     "submission_id": "string",
-    "email": "string",
     "submitted_at": "ISO 8601",
-    "kml_blob_name": "demo/{submission_id}.kml",
+    "kml_blob_name": "analysis/{submission_id}.kml",
     "kml_size_bytes": 0,
     "status": "submitted"
 }
@@ -827,11 +827,29 @@ When a download fails, the error dict has 13 fields:
 
 ### 10.1 Structured Logging
 
-All log messages use structured format:
+Deployed/runtime-hosted Canopex application logs use a single-line JSON envelope.
+The startup path installs JSON logging for the `treesight`, `blueprints`, and
+`function_app` logger families so startup warnings and pipeline logs share the
+same structure in App Insights.
 
-```text
-phase={phase} step={step} | instance={id} | {key}={value} | blob={name}
+```json
+{
+    "timestamp": "2026-04-05 13:20:47,123",
+    "level": "INFO",
+    "logger": "treesight.pipeline.fulfilment",
+    "message": "phase=fulfilment step=download_complete | instance=abc-123 | blob=demo/file.kml",
+    "correlation_id": "abc-123",
+    "properties": {
+        "phase": "fulfilment",
+        "step": "download_complete",
+        "instance_id": "abc-123",
+        "blob_name": "demo/file.kml"
+    }
+}
 ```
+
+Local development may still surface the helper-generated human-readable message
+format when the startup installer is not enabled.
 
 **Phase-level logging:**
 
@@ -873,7 +891,7 @@ Every pipeline run carries a `correlation_id` (sourced from Event Grid event ID)
 | Health/readiness | Anonymous |
 | Contract | Anonymous |
 | Contact form | Anonymous |
-| Demo submit | Anonymous |
+| Pipeline submit | Bearer |
 | Orchestrator diagnostics | Anonymous |
 | Demo valet token minting | Function key |
 | Demo artifact download | Valet token (query parameter) |
@@ -917,14 +935,14 @@ Every pipeline run carries a `correlation_id` (sourced from Event Grid event ID)
 
 1. **Hero** — status badge (polls `/api/readiness`), CTA buttons
 2. **Problem/Solution** — 4-card grid + 6-feature capability grid
-3. **Live Demo** — email + KML textarea form → `/api/demo-submit`; timelapse visualiser (Leaflet.js map with animated AOI overlays)
+3. **Free Plan Preview** — signed-in workspace preview, KML guidance, and sample locations before authentication; real pipeline runs still require sign-in
 4. **Timeline** — 6-step workflow visualisation
 5. **FAQ** — 8 Q&A pairs
 6. **Early Access** — org + use case + email → `/api/contact-form`
 
 ### 12.3 API Integration
 
-- **Contract enforcement**: On load, fetches `/api/contract` and checks `api_version == "2026-03-15.1"`. Disables demo submit button on mismatch.
+- **Contract enforcement**: On load, fetches `/api/contract` and checks `api_version == "2026-03-15.1"`. Keeps preview messaging aligned with the live API contract.
 - **Fallback origin**: If relative `/api/*` fails, falls back to hardcoded Function App URL (`DEFAULT_FALLBACK_ORIGIN`)
 - **Status badge**: Polls `/api/readiness`, shows "Online"/"Offline" badge with animation
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -138,15 +138,21 @@ paths:
                     example: v1
                 required: [api_version]
 
-  # ── Demo ──────────────────────────────────────────────────
-  /demo-submit:
+  # ── Submission ────────────────────────────────────────────
+  /analysis/submit:
     post:
-      operationId: demoSubmit
-      summary: Submit a KML for demo pipeline processing
+      operationId: submitAnalysis
+      summary: Submit a KML for signed-in analysis processing
       description: |
         Accepts raw KML text, uploads it to blob storage and triggers
-        the analysis pipeline.  Consumes one quota unit per call.
-      tags: [demo]
+        the analysis pipeline.
+
+        Every pipeline submission requires a valid Authorization header.
+        Signed-in users participate in quota/history accounting, and free-tier
+        accounts are routed through the cheaper seasonal two-year pipeline.
+      tags: [analysis]
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -157,6 +163,9 @@ paths:
                 kml_content:
                   type: string
                   description: Raw KML/KMZ XML content
+                submission_context:
+                  type: object
+                  description: Optional signed-in submission metadata for analysis history
               required: [kml_content]
       responses:
         "202":
@@ -166,16 +175,13 @@ paths:
               schema:
                 type: object
                 properties:
-                  submission_id:
-                    type: string
-                    description: Unique identifier for this submission
                   instance_id:
                     type: string
                     description: Durable Functions orchestration instance ID
-                  status:
+                  submission_prefix:
                     type: string
-                    example: accepted
-                required: [submission_id, instance_id, status]
+                    example: analysis
+                required: [instance_id, submission_prefix]
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -184,46 +190,12 @@ paths:
           $ref: "#/components/responses/QuotaExhausted"
         "429":
           $ref: "#/components/responses/TooManyRequests"
-
-  /demo-process:
-    post:
-      operationId: demoProcess
-      summary: Start a demo pipeline run
-      description: |
-        Triggers a pipeline run for a previously uploaded KML.
-        Consumes one quota unit.
-      tags: [demo]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                blob_name:
-                  type: string
-                  description: Blob name of the uploaded KML
-              required: [blob_name]
-      responses:
-        "202":
-          description: Pipeline started
+        "502":
+          description: Upstream storage or orchestration startup is temporarily unavailable
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  instance_id:
-                    type: string
-                  status:
-                    type: string
-                    example: accepted
-                required: [instance_id, status]
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "403":
-          $ref: "#/components/responses/QuotaExhausted"
+                $ref: "#/components/schemas/Error"
 
   /demo-valet-tokens:
     post:
@@ -317,6 +289,7 @@ paths:
         Returns the current status of a Durable Functions orchestration,
         including progress updates and final output when complete.
       tags: [pipeline]
+      security: []
       parameters:
         - $ref: "#/components/parameters/instanceId"
       responses:
@@ -337,8 +310,6 @@ paths:
                     description: Final pipeline output (present when Completed)
                     $ref: "#/components/schemas/PipelineSummary"
                 required: [runtimeStatus]
-        "401":
-          $ref: "#/components/responses/Unauthorized"
         "404":
           description: Instance not found
           content:

--- a/tests/test_analysis_submission_endpoints.py
+++ b/tests/test_analysis_submission_endpoints.py
@@ -170,6 +170,25 @@ class TestAnalysisSubmissionRoutes:
         assert client.calls[0]["client_input"]["cadence"] == "seasonal"
         assert client.calls[0]["client_input"]["max_history_years"] == 2
 
+    def test_analysis_submit_rejects_anonymous_auth_fallback(self):
+        from blueprints.pipeline.submission import _submit_analysis_request
+
+        client = _FakeDurableClient()
+        req = _make_req("/api/analysis/submit")
+
+        with (
+            patch("blueprints.pipeline.submission.check_auth", return_value=({}, "anonymous")),
+            patch("blueprints.pipeline.submission.consume_quota") as mock_consume_quota,
+        ):
+            resp = asyncio.run(_submit_analysis_request(req, client))
+
+        assert resp.status_code == 401
+        assert json.loads(resp.get_body()) == {
+            "error": "Authentication is required for pipeline submissions"
+        }
+        mock_consume_quota.assert_not_called()
+        assert client.calls == []
+
     def test_orchestrator_status_allows_anonymous_access(self):
         from blueprints.pipeline.diagnostics import _build_orchestrator_status_response
 

--- a/tests/test_analysis_submission_endpoints.py
+++ b/tests/test_analysis_submission_endpoints.py
@@ -1,10 +1,10 @@
-"""Tests for signed-in and demo analysis submission endpoints."""
+"""Tests for signed-in analysis submission endpoints."""
 
 import asyncio
 import json
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import azure.functions as func
 
@@ -20,6 +20,7 @@ def _make_req(
     *,
     method: str = "POST",
     params: dict[str, str] | None = None,
+    auth_header: str | None = "Bearer fake-token",
 ) -> func.HttpRequest:
     payload = body if body is not None else {"kml_content": "<kml></kml>"}
     return make_test_request(
@@ -28,6 +29,7 @@ def _make_req(
         body=payload,
         params=params,
         origin=TEST_LOCAL_ORIGIN,
+        auth_header=auth_header,
     )
 
 
@@ -78,7 +80,7 @@ class TestAnalysisSubmissionRoutes:
     def test_pipeline_declares_production_named_analysis_route(self):
         source = (PIPELINE_PKG / "submission.py").read_text()
         assert 'route="analysis/submit"' in source
-        assert 'route="demo-process"' in source
+        assert 'route="demo-process"' not in source
 
     def test_analysis_submit_uses_analysis_prefix(self):
         from blueprints.pipeline.submission import _submit_analysis_request
@@ -138,28 +140,68 @@ class TestAnalysisSubmissionRoutes:
         assert client.calls[0]["client_input"]["blob_name"].startswith("analysis/")
         assert client.calls[0]["client_input"]["user_id"] == "user-123"
 
-    def test_demo_process_keeps_demo_prefix(self):
+    def test_free_tier_submit_uses_analysis_prefix_and_limited_pipeline(self):
         from blueprints.pipeline.submission import _submit_analysis_request
 
         client = _FakeDurableClient()
-        req = _make_req("/api/demo-process")
+        req = _make_req("/api/analysis/submit")
 
         with (
             patch("blueprints.pipeline.submission.check_auth", return_value=({}, "user-123")),
             patch("blueprints.pipeline.submission.consume_quota", return_value=5),
+            patch(
+                "blueprints.pipeline.submission.get_effective_subscription",
+                return_value={"tier": "free", "status": "none"},
+            ),
             patch("treesight.storage.client.BlobStorageClient") as mock_storage_cls,
         ):
-            resp = asyncio.run(_submit_analysis_request(req, client, blob_prefix="demo"))
+            resp = asyncio.run(_submit_analysis_request(req, client))
 
         assert resp.status_code == 202
         data = json.loads(resp.get_body())
-        assert data["submission_prefix"] == "demo"
+        assert data["submission_prefix"] == "analysis"
 
         upload_args, _upload_kwargs = mock_storage_cls.return_value.upload_bytes.call_args
         assert upload_args[0] == DEFAULT_INPUT_CONTAINER
-        assert upload_args[1].startswith("demo/")
-        assert client.calls[0]["client_input"]["blob_name"].startswith("demo/")
-        mock_storage_cls.return_value.upload_json.assert_not_called()
+        assert upload_args[1].startswith("analysis/")
+        assert client.calls[0]["client_input"]["blob_name"].startswith("analysis/")
+        assert client.calls[0]["client_input"]["user_id"] == "user-123"
+        assert client.calls[0]["client_input"]["tier"] == "free"
+        assert client.calls[0]["client_input"]["cadence"] == "seasonal"
+        assert client.calls[0]["client_input"]["max_history_years"] == 2
+
+    def test_orchestrator_status_allows_anonymous_access(self):
+        from blueprints.pipeline.diagnostics import _build_orchestrator_status_response
+
+        client = _HistoryDurableClient(
+            {
+                "demo-run": _FakeDurableStatus(
+                    "demo-run",
+                    runtime_status="Completed",
+                    created_time=datetime(2026, 4, 5, 15, 11, 0, tzinfo=UTC),
+                    last_updated_time=datetime(2026, 4, 5, 15, 13, 0, tzinfo=UTC),
+                    output={"status": "completed", "message": "done"},
+                )
+            }
+        )
+        req = func.HttpRequest(
+            method="GET",
+            url="/api/orchestrator/demo-run",
+            headers={"Origin": TEST_LOCAL_ORIGIN},
+            params={},
+            route_params={"instance_id": "demo-run"},
+            body=b"",
+        )
+
+        with patch(
+            "blueprints.pipeline.diagnostics.pipeline_limiter.is_allowed", return_value=True
+        ):
+            resp = asyncio.run(_build_orchestrator_status_response(req, client))
+
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["instanceId"] == "demo-run"
+        assert data["runtimeStatus"] == "Completed"
 
     def test_analysis_history_returns_recent_runs_and_active_run(self):
         from blueprints.pipeline.history import _build_analysis_history_response
@@ -269,6 +311,42 @@ class TestAnalysisSubmissionRoutes:
             "postProcess": 1,
         }
         assert data["runs"][1]["artifactCount"] == 1
+
+
+class TestBlobTriggerIngress:
+    def _make_blob_event(self, blob_name: str, event_id: str) -> MagicMock:
+        event = MagicMock()
+        event.id = event_id
+        event.event_time = datetime(2026, 4, 5, 15, 11, 35, tzinfo=UTC)
+        event.get_json.return_value = {
+            "url": f"https://devstoreaccount1.blob.core.windows.net/kml-input/{blob_name}",
+            "contentLength": 42,
+            "contentType": "application/vnd.google-earth.kml+xml",
+        }
+        return event
+
+    def test_blob_trigger_skips_direct_submission_blobs(self):
+        from blueprints.pipeline.blob_trigger import _process_blob_trigger
+
+        client = _FakeDurableClient()
+        event = self._make_blob_event("analysis/test-run.kml", "evt-analysis")
+
+        asyncio.run(_process_blob_trigger(event, client))
+
+        assert client.calls == []
+
+    def test_blob_trigger_starts_storage_native_uploads(self):
+        from blueprints.pipeline.blob_trigger import _process_blob_trigger
+
+        client = _FakeDurableClient()
+        event = self._make_blob_event("uploads/test-run.kml", "evt-upload")
+
+        asyncio.run(_process_blob_trigger(event, client))
+
+        assert len(client.calls) == 1
+        assert client.calls[0]["name"] == "treesight_orchestrator"
+        assert client.calls[0]["instance_id"] == "evt-upload"
+        assert client.calls[0]["client_input"]["blob_name"] == "uploads/test-run.kml"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_demo_tier.py
+++ b/tests/test_demo_tier.py
@@ -4,7 +4,7 @@ Covers:
 - PLAN_CATALOG demo tier configuration
 - build_frame_plan() cadence filtering (seasonal, monthly, maximum)
 - build_frame_plan() max_history_years capping
-- _submit_demo_request rate limiting and anonymous access
+- signed-in free/demo submission tier controls
 """
 
 from __future__ import annotations
@@ -64,6 +64,9 @@ class TestDemoTierCatalog:
         assert caps["tier"] == "demo"
         assert caps["run_limit"] == 3
         assert caps["export"] is False
+
+    def test_free_max_history_years_matches_cost_control_window(self):
+        assert PLAN_CATALOG["free"]["max_history_years"] == 2
 
 
 class TestAllTiersHaveNewFields:
@@ -218,37 +221,42 @@ class TestBuildFramePlanMaxHistory:
 # ---------------------------------------------------------------------------
 
 
-class TestDemoSubmitEndpoint:
-    """Test _submit_demo_request behaviour via the demo_process route."""
+class TestSignedInLowCostSubmission:
+    """Test signed-in free/demo submission behaviour through the unified route."""
 
     def _make_request(
         self,
         body: dict[str, Any] | None = None,
-        *,
-        ip: str = "192.168.1.1",
     ) -> MagicMock:
         req = MagicMock()
         req.method = "POST"
-        req.headers = {"X-Forwarded-For": ip}
+        req.headers = {"Authorization": "Bearer fake-token"}
         if body is not None:
             req.get_json.return_value = body
         else:
             req.get_json.side_effect = ValueError("no json")
         return req
 
-    @patch("blueprints.pipeline.submission.demo_limiter")
-    @patch("blueprints.pipeline.submission.get_client_ip", return_value="127.0.0.1")
+    @patch("blueprints.pipeline.submission.get_effective_subscription")
+    @patch("blueprints.pipeline.submission.consume_quota", return_value=5)
+    @patch("blueprints.pipeline.submission.check_auth", return_value=({}, "user-123"))
     @patch("treesight.storage.client.BlobStorageClient")
     @pytest.mark.asyncio
-    async def test_valid_submission_returns_202(self, mock_storage_cls, mock_get_ip, mock_limiter):
-        from blueprints.pipeline.submission import _submit_demo_request
+    async def test_free_tier_submission_returns_202(
+        self,
+        mock_storage_cls,
+        mock_auth,
+        mock_quota,
+        mock_effective_subscription,
+    ):
+        from blueprints.pipeline.submission import _submit_analysis_request
 
-        mock_limiter.is_allowed.return_value = True
+        mock_effective_subscription.return_value = {"tier": "free", "status": "none"}
 
         client = AsyncMock()
         req = self._make_request({"kml_content": "<kml>test</kml>"})
 
-        resp = await _submit_demo_request(req, client)
+        resp = await _submit_analysis_request(req, client)
 
         assert resp.status_code == 202
         client.start_new.assert_awaited_once()
@@ -256,92 +264,52 @@ class TestDemoSubmitEndpoint:
         orch_input = call_kwargs.kwargs.get("client_input", call_kwargs[1].get("client_input"))
         assert orch_input["cadence"] == "seasonal"
         assert orch_input["max_history_years"] == 2
-        assert orch_input["tier"] == "demo"
-        assert orch_input["user_id"].startswith("demo:")
+        assert orch_input["tier"] == "free"
+        assert orch_input["user_id"] == "user-123"
+        upload_call = mock_storage_cls.return_value.upload_bytes.call_args
+        assert upload_call[0][1].startswith("analysis/")
 
-    @patch("blueprints.pipeline.submission.demo_limiter")
-    @patch("blueprints.pipeline.submission.get_client_ip", return_value="127.0.0.1")
-    @pytest.mark.asyncio
-    async def test_rate_limited_returns_429(self, mock_get_ip, mock_limiter):
-        from blueprints.pipeline.submission import _submit_demo_request
-
-        mock_limiter.is_allowed.return_value = False
-
-        client = AsyncMock()
-        req = self._make_request({"kml_content": "<kml>test</kml>"})
-
-        resp = await _submit_demo_request(req, client)
-
-        assert resp.status_code == 429
-
-    @patch("blueprints.pipeline.submission.demo_limiter")
-    @patch("blueprints.pipeline.submission.get_client_ip", return_value="127.0.0.1")
-    @pytest.mark.asyncio
-    async def test_invalid_json_returns_400(self, mock_get_ip, mock_limiter):
-        from blueprints.pipeline.submission import _submit_demo_request
-
-        mock_limiter.is_allowed.return_value = True
-
-        client = AsyncMock()
-        req = self._make_request()  # no body → ValueError
-
-        resp = await _submit_demo_request(req, client)
-
-        assert resp.status_code == 400
-
-    @patch("blueprints.pipeline.submission.demo_limiter")
-    @patch("blueprints.pipeline.submission.get_client_ip", return_value="127.0.0.1")
-    @pytest.mark.asyncio
-    async def test_empty_kml_returns_400(self, mock_get_ip, mock_limiter):
-        from blueprints.pipeline.submission import _submit_demo_request
-
-        mock_limiter.is_allowed.return_value = True
-
-        client = AsyncMock()
-        req = self._make_request({"kml_content": ""})
-
-        resp = await _submit_demo_request(req, client)
-
-        assert resp.status_code == 400
-
-    @patch("blueprints.pipeline.submission.demo_limiter")
-    @patch("blueprints.pipeline.submission.get_client_ip", return_value="10.0.0.1")
+    @patch("blueprints.pipeline.submission.get_effective_subscription")
+    @patch("blueprints.pipeline.submission.consume_quota", return_value=5)
+    @patch("blueprints.pipeline.submission.check_auth", return_value=({}, "user-123"))
     @patch("treesight.storage.client.BlobStorageClient")
     @pytest.mark.asyncio
-    async def test_user_id_is_ip_hash(self, mock_storage_cls, mock_get_ip, mock_limiter):
-        from blueprints.pipeline.submission import _submit_demo_request
+    async def test_demo_emulation_uses_demo_controls(
+        self,
+        mock_storage_cls,
+        mock_auth,
+        mock_quota,
+        mock_effective_subscription,
+    ):
+        from blueprints.pipeline.submission import _submit_analysis_request
 
-        mock_limiter.is_allowed.return_value = True
+        mock_effective_subscription.return_value = {"tier": "demo", "status": "active"}
 
         client = AsyncMock()
         req = self._make_request({"kml_content": "<kml>test</kml>"})
 
-        resp = await _submit_demo_request(req, client)
+        resp = await _submit_analysis_request(req, client)
 
         assert resp.status_code == 202
         call_kwargs = client.start_new.call_args
         orch_input = call_kwargs.kwargs.get("client_input", call_kwargs[1].get("client_input"))
-        user_id = orch_input["user_id"]
-        assert user_id.startswith("demo:")
-        # Hash portion should be 12 hex chars
-        assert len(user_id.split(":")[1]) == 12
+        assert orch_input["tier"] == "demo"
+        assert orch_input["cadence"] == "seasonal"
+        assert orch_input["max_history_years"] == 2
+        upload_call = mock_storage_cls.return_value.upload_bytes.call_args
+        assert upload_call[0][1].startswith("analysis/")
 
-    @patch("blueprints.pipeline.submission.demo_limiter")
-    @patch("blueprints.pipeline.submission.get_client_ip", return_value="127.0.0.1")
-    @patch("treesight.storage.client.BlobStorageClient")
+    @patch(
+        "blueprints.pipeline.submission.check_auth",
+        side_effect=ValueError("Missing or malformed Authorization header"),
+    )
     @pytest.mark.asyncio
-    async def test_blob_uploaded_to_demo_prefix(self, mock_storage_cls, mock_get_ip, mock_limiter):
-        from blueprints.pipeline.submission import _submit_demo_request
-
-        mock_limiter.is_allowed.return_value = True
-        mock_storage = mock_storage_cls.return_value
+    async def test_missing_auth_returns_401(self, mock_auth):
+        from blueprints.pipeline.submission import _submit_analysis_request
 
         client = AsyncMock()
         req = self._make_request({"kml_content": "<kml>test</kml>"})
 
-        await _submit_demo_request(req, client)
+        resp = await _submit_analysis_request(req, client)
 
-        upload_call = mock_storage.upload_bytes.call_args
-        blob_name = upload_call[0][1]
-        assert blob_name.startswith("demo/")
-        assert blob_name.endswith(".kml")
+        assert resp.status_code == 401

--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -5,7 +5,7 @@ accidentally removed or misconfigured.  They cover:
 
 1. Container Apps scaling limits (maxReplicas)
 2. App Insights browser analytics on all pages
-3. Rate limiting on demo-process endpoint
+3. Auth enforcement on pipeline submission endpoint
 4. REQUIRE_AUTH wired into production app settings
 5. Log Analytics daily ingestion cap
 6. detect-secrets in CI security workflow
@@ -135,43 +135,37 @@ class TestBrowserAnalytics:
 
 
 # ---------------------------------------------------------------------------
-# 3. Rate limiter on demo-process
+# 3. Submission auth enforcement
 # ---------------------------------------------------------------------------
 
 
-class TestDemoProcessRateLimiter:
-    """Ensure the demo-process endpoint has rate limiting to prevent abuse."""
+class TestSubmissionAuthRequirement:
+    """Ensure pipeline execution cannot proceed anonymously."""
 
-    def test_demo_process_imports_limiter(self):
+    def test_submission_imports_auth_check(self):
         src = (ROOT / "blueprints" / "pipeline" / "submission.py").read_text()
-        assert "demo_limiter" in src, (
-            "submission.py must import demo_limiter to rate-limit demo-process"
+        assert "check_auth" in src, (
+            "submission.py must import check_auth so pipeline submission requires sign-in"
         )
 
-    def test_demo_process_calls_rate_limiter(self):
+    def test_analysis_submit_routes_to_signed_in_handler(self):
         src = (ROOT / "blueprints" / "pipeline" / "submission.py").read_text()
         func_match = re.search(
-            r"def _submit_demo_request\(.*?\n(.*?)(?=\ndef |\Z)",
+            r"def analysis_submit\(.*?\n(.*?)(?=\ndef |\Z)",
             src,
             re.DOTALL,
         )
-        assert func_match, "_submit_demo_request function not found"
+        assert func_match, "analysis_submit function not found"
         body = func_match.group(1)
-        assert "demo_limiter.is_allowed" in body, (
-            "_submit_demo_request must call demo_limiter.is_allowed() before processing"
+        assert "_submit_analysis_request" in body, (
+            "analysis_submit must delegate to the signed-in submission handler"
         )
 
-    def test_rate_limit_returns_429(self):
-        """Rate-limited requests must get a 429 response."""
+    def test_no_anonymous_submit_handler_remains(self):
         src = (ROOT / "blueprints" / "pipeline" / "submission.py").read_text()
-        func_match = re.search(
-            r"def _submit_demo_request\(.*?\n(.*?)(?=\ndef |\Z)",
-            src,
-            re.DOTALL,
+        assert "_submit_demo_request" not in src, (
+            "submission.py must not keep an anonymous pipeline submission path"
         )
-        assert func_match
-        body = func_match.group(1)
-        assert "429" in body, "_submit_demo_request must return HTTP 429 when rate limited"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -399,17 +399,17 @@ class TestAlertSending:
 
 class TestMonitoringEndpoints:
     def test_list_monitors_empty(self, _mock_cosmos, _mock_auth):
-        from blueprints.monitoring import list_monitors_endpoint
+        from blueprints.monitoring import monitoring_endpoint
 
         req = make_test_request("/api/monitoring", method="GET")
-        resp = list_monitors_endpoint(req)
+        resp = monitoring_endpoint(req)
         assert resp.status_code == 200
         data = json.loads(resp.get_body())
         assert data["count"] == 0
         assert data["monitors"] == []
 
     def test_create_monitor_success(self, _mock_cosmos, _mock_auth, _mock_pro_subscription):
-        from blueprints.monitoring import create_monitor_endpoint
+        from blueprints.monitoring import monitoring_endpoint
 
         body = {
             "aoi_name": "Test Forest",
@@ -417,7 +417,7 @@ class TestMonitoringEndpoints:
             "cadence_days": 30,
         }
         req = make_test_request("/api/monitoring", method="POST", body=body)
-        resp = create_monitor_endpoint(req)
+        resp = monitoring_endpoint(req)
         assert resp.status_code == 201
         data = json.loads(resp.get_body())
         assert data["aoi_name"] == "Test Forest"
@@ -425,23 +425,23 @@ class TestMonitoringEndpoints:
         assert data["enabled"] is True
 
     def test_create_monitor_no_aoi_name(self, _mock_cosmos, _mock_auth, _mock_pro_subscription):
-        from blueprints.monitoring import create_monitor_endpoint
+        from blueprints.monitoring import monitoring_endpoint
 
         body = {"aoi_geometry": _SAMPLE_GEOMETRY}
         req = make_test_request("/api/monitoring", method="POST", body=body)
-        resp = create_monitor_endpoint(req)
+        resp = monitoring_endpoint(req)
         assert resp.status_code == 400
 
     def test_create_monitor_no_geometry(self, _mock_cosmos, _mock_auth, _mock_pro_subscription):
-        from blueprints.monitoring import create_monitor_endpoint
+        from blueprints.monitoring import monitoring_endpoint
 
         body = {"aoi_name": "Test"}
         req = make_test_request("/api/monitoring", method="POST", body=body)
-        resp = create_monitor_endpoint(req)
+        resp = monitoring_endpoint(req)
         assert resp.status_code == 400
 
     def test_create_monitor_invalid_cadence(self, _mock_cosmos, _mock_auth, _mock_pro_subscription):
-        from blueprints.monitoring import create_monitor_endpoint
+        from blueprints.monitoring import monitoring_endpoint
 
         body = {
             "aoi_name": "Test",
@@ -449,11 +449,11 @@ class TestMonitoringEndpoints:
             "cadence_days": 0,
         }
         req = make_test_request("/api/monitoring", method="POST", body=body)
-        resp = create_monitor_endpoint(req)
+        resp = monitoring_endpoint(req)
         assert resp.status_code == 400
 
     def test_create_monitor_free_tier_rejected(self, _mock_cosmos, _mock_auth):
-        from blueprints.monitoring import create_monitor_endpoint
+        from blueprints.monitoring import monitoring_endpoint
 
         with patch(
             "blueprints.monitoring.get_effective_subscription",
@@ -464,11 +464,11 @@ class TestMonitoringEndpoints:
                 "aoi_geometry": _SAMPLE_GEOMETRY,
             }
             req = make_test_request("/api/monitoring", method="POST", body=body)
-            resp = create_monitor_endpoint(req)
+            resp = monitoring_endpoint(req)
             assert resp.status_code == 403
 
     def test_get_monitor_detail(self, _mock_cosmos, _mock_auth, _mock_pro_subscription):
-        from blueprints.monitoring import create_monitor_endpoint, monitor_detail_endpoint
+        from blueprints.monitoring import monitor_detail_endpoint, monitoring_endpoint
 
         # Create first
         body = {
@@ -476,7 +476,7 @@ class TestMonitoringEndpoints:
             "aoi_geometry": _SAMPLE_GEOMETRY,
         }
         req = make_test_request("/api/monitoring", method="POST", body=body)
-        resp = create_monitor_endpoint(req)
+        resp = monitoring_endpoint(req)
         data = json.loads(resp.get_body())
         monitor_id = data["id"]
 
@@ -498,12 +498,12 @@ class TestMonitoringEndpoints:
         assert detail["aoi_name"] == "Detail Test"
 
     def test_patch_monitor(self, _mock_cosmos, _mock_auth, _mock_pro_subscription):
-        from blueprints.monitoring import create_monitor_endpoint, monitor_detail_endpoint
+        from blueprints.monitoring import monitor_detail_endpoint, monitoring_endpoint
 
         # Create
         body = {"aoi_name": "Patch Test", "aoi_geometry": _SAMPLE_GEOMETRY}
         req = make_test_request("/api/monitoring", method="POST", body=body)
-        resp = create_monitor_endpoint(req)
+        resp = monitoring_endpoint(req)
         data = json.loads(resp.get_body())
         monitor_id = data["id"]
 
@@ -528,12 +528,12 @@ class TestMonitoringEndpoints:
         assert updated["enabled"] is False
 
     def test_delete_monitor(self, _mock_cosmos, _mock_auth, _mock_pro_subscription):
-        from blueprints.monitoring import create_monitor_endpoint, monitor_detail_endpoint
+        from blueprints.monitoring import monitor_detail_endpoint, monitoring_endpoint
 
         # Create
         body = {"aoi_name": "Delete Test", "aoi_geometry": _SAMPLE_GEOMETRY}
         req = make_test_request("/api/monitoring", method="POST", body=body)
-        resp = create_monitor_endpoint(req)
+        resp = monitoring_endpoint(req)
         data = json.loads(resp.get_body())
         monitor_id = data["id"]
 
@@ -639,8 +639,8 @@ class TestMonitoringScheduler:
             _process_monitor(m)
 
     def test_cors_preflight_monitoring(self, _mock_auth):
-        from blueprints.monitoring import list_monitors_endpoint
+        from blueprints.monitoring import monitoring_endpoint
 
         req = make_test_request("/api/monitoring", method="OPTIONS")
-        resp = list_monitors_endpoint(req)
+        resp = monitoring_endpoint(req)
         assert resp.status_code == 204

--- a/tests/test_submission_cors.py
+++ b/tests/test_submission_cors.py
@@ -39,7 +39,7 @@ def _make_request(
 
 
 class TestSubmissionCORSPreflight:
-    """Both submission endpoints must respond to OPTIONS preflight requests.
+    """The submission endpoint must respond to OPTIONS preflight requests.
 
     The ``@bp.durable_client_input`` decorator makes it hard to call the
     endpoint directly in tests, so we verify:
@@ -71,13 +71,12 @@ class TestSubmissionCORSPreflight:
             "analysis/submit route must accept OPTIONS for CORS preflight"
         )
 
-    def test_demo_process_has_options_guard(self):
+    def test_submit_route_uses_cors_preflight(self):
         import inspect
 
         import blueprints.pipeline.submission as mod
 
         src = inspect.getsource(mod)
-        # Both routes must call cors_preflight on OPTIONS
         assert "cors_preflight" in src, "submission endpoints must call cors_preflight"
 
 
@@ -187,27 +186,6 @@ class TestAnalysisSubmitCORS:
         assert "Access-Control-Allow-Origin" in resp.headers, (
             "CORS headers missing on 400 missing kml_content"
         )
-
-
-class TestDemoSubmitCORSParity:
-    """Demo endpoint already has CORS — verify it stays that way (regression guard)."""
-
-    @patch("blueprints.pipeline.submission.demo_limiter")
-    @patch("blueprints.pipeline.submission.get_client_ip", return_value="127.0.0.1")
-    @patch("treesight.storage.client.BlobStorageClient")
-    @pytest.mark.asyncio
-    async def test_demo_success_has_cors_headers(self, mock_storage_cls, mock_get_ip, mock_limiter):
-        from blueprints.pipeline.submission import _submit_demo_request
-
-        mock_limiter.is_allowed.return_value = True
-
-        client = AsyncMock()
-        req = _make_request({"kml_content": "<kml>test</kml>"}, auth_header=None)
-
-        resp = await _submit_demo_request(req, client)
-
-        assert resp.status_code == 202
-        assert "Access-Control-Allow-Origin" in resp.headers
 
 
 class TestErrorResponseCORS:

--- a/treesight/security/billing.py
+++ b/treesight/security/billing.py
@@ -51,7 +51,7 @@ PLAN_CATALOG: dict[str, dict[str, Any]] = {
         "export": False,
         "retention_days": 30,
         "temporal_cadence": "seasonal",
-        "max_history_years": None,
+        "max_history_years": 2,
         "overage_rate": None,
     },
     "starter": {

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -53,7 +53,7 @@
   <div id="app-demo-banner" class="app-demo-banner" hidden>
     <div class="container">
       <span class="app-demo-banner-icon">&#127919;</span>
-      <span class="app-demo-banner-text">You're using the free demo &mdash; 1 AOI, seasonal snapshots, no exports.</span>
+      <span class="app-demo-banner-text">You're previewing the signed-in free plan &mdash; seasonal snapshots, a 2-year history window, and no exports.</span>
       <a class="btn btn-sm btn-primary" href="/app/" onclick="event.preventDefault(); document.getElementById('auth-login-btn').click();">Sign In</a>
       <a class="btn btn-sm btn-secondary" href="/#pricing">View Plans</a>
       <button class="app-demo-banner-close" onclick="this.parentElement.parentElement.hidden=true" aria-label="Dismiss">&#10005;</button>
@@ -67,7 +67,7 @@
         <p>A Canopex account is required to upload KML, queue analysis runs, and view your results. Sign in to get started.</p>
         <div class="app-gate-actions">
           <button class="btn btn-primary" id="app-sign-in-btn" type="button">Sign In</button>
-          <a class="btn btn-secondary" href="/app/?mode=demo">Try the Public Demo</a>
+          <a class="btn btn-secondary" href="/app/?mode=demo">Preview the Free Plan</a>
           <a class="btn btn-secondary" href="/">Back to site</a>
         </div>
       </div>
@@ -105,7 +105,7 @@
             <div class="app-first-run-actions">
               <a class="btn btn-primary" id="app-first-run-cta" href="#app-analysis-card">Start Your First Analysis</a>
               <a class="btn btn-secondary" href="/docs/kml-guide.html">KML Guide</a>
-              <a class="btn btn-secondary" href="/app/?mode=demo">Try the Public Demo</a>
+              <a class="btn btn-secondary" href="/app/?mode=demo">Preview the Free Plan</a>
             </div>
           </div>
           <div class="app-first-run-checklist">
@@ -285,10 +285,10 @@
           <div class="app-analysis-auth-gate" id="app-analysis-auth-gate" hidden>
             <div class="app-panel">
               <h4>Sign in to run your own analysis</h4>
-              <p>You need to be signed in to upload KML and queue analysis runs. Demo mode is available without an account.</p>
+              <p>You need to be signed in to upload KML and queue analysis runs. Demo mode previews the free plan, but it does not run the pipeline anonymously.</p>
               <div class="app-gate-actions">
                 <button class="btn btn-primary" id="app-analysis-sign-in-btn" type="button">Sign In</button>
-                <a class="btn btn-secondary" href="/app/?mode=demo">Try the Public Demo</a>
+                <a class="btn btn-secondary" id="app-analysis-auth-secondary-link" href="/app/?mode=demo">Preview the Free Plan</a>
               </div>
             </div>
           </div>
@@ -332,7 +332,7 @@
           </div>
           <div class="app-select-row app-analysis-actions">
             <button class="btn btn-primary" id="app-analysis-submit-btn" type="button">Queue Analysis</button>
-            <a class="btn btn-secondary" href="/app/?mode=demo">View Public Demo</a>
+            <a class="btn btn-secondary" href="/app/?mode=demo">Preview the Free Plan</a>
           </div>
           </div><!-- /app-analysis-form-fields -->
           <div class="app-callout" id="app-analysis-status" hidden></div>

--- a/website/index.html
+++ b/website/index.html
@@ -63,12 +63,12 @@
 <section id="see-it-action">
   <div class="container">
     <div class="section-label">Experience</div>
-    <h2>Try the Live Demo</h2>
-    <p style="color:var(--c-muted);max-width:560px;margin-bottom:24px">Upload a KML file or use one of our sample locations to explore satellite imagery, NDVI analysis, and historical change detection. No sign-up required.</p>
+    <h2>Preview the Free Plan</h2>
+    <p style="color:var(--c-muted);max-width:560px;margin-bottom:24px">Preview the signed-in free plan, then sign in to upload a KML or use one of our sample locations for a real analysis run.</p>
     <div style="text-align:center">
-      <a href="/app/?mode=demo" class="btn btn-primary" style="padding:14px 32px;font-size:1rem">Open Free Demo</a>
+      <a href="/app/?mode=demo" class="btn btn-primary" style="padding:14px 32px;font-size:1rem">Preview Free Plan</a>
     </div>
-    <p style="font-size:.8rem;color:var(--c-muted);text-align:center;margin-top:24px;max-width:640px;margin-left:auto;margin-right:auto">Demo includes 3 free analysis runs. Analysed data is retained for 30 days. <a href="/docs/kml-guide.html">Learn how to create KML files.</a></p>
+    <p style="font-size:.8rem;color:var(--c-muted);text-align:center;margin-top:24px;max-width:640px;margin-left:auto;margin-right:auto">Sign in to use the free plan's low-cost seasonal pipeline. <a href="/docs/kml-guide.html">Learn how to create KML files.</a></p>
   </div>
 </section>
 

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -291,6 +291,18 @@
     }
   }
 
+  function clearDemoModeQueryParam() {
+    try {
+      var url = new URL(window.location.href);
+      if (url.searchParams.get('mode') !== 'demo') return;
+      url.searchParams.delete('mode');
+      var nextUrl = url.pathname + (url.search || '') + (url.hash || '');
+      window.history.replaceState({}, '', nextUrl || '/app/');
+    } catch {
+      /* ignore */
+    }
+  }
+
   async function discoverApiBase() {
     if (runningOnLocalDevOrigin()) {
       try {
@@ -658,6 +670,16 @@
     var modeEl = document.getElementById('app-hero-mode');
     var modeNoteEl = document.getElementById('app-hero-mode-note');
     if (!planEl || !planNoteEl || !runsEl || !runsNoteEl || !modeEl || !modeNoteEl) return;
+
+    if (data.preview_mode) {
+      planEl.textContent = 'Free plan preview';
+      planNoteEl.textContent = 'Sign in to turn this preview into a real workspace.';
+      runsEl.textContent = data.runs_remaining == null ? '—' : String(data.runs_remaining);
+      runsNoteEl.textContent = 'Free-plan limits shown here only activate after sign-in.';
+      modeEl.textContent = capabilityHeadline(caps);
+      modeNoteEl.textContent = role.label + ' • ' + preference.label + ' • Preview mode only until you authenticate.';
+      return;
+    }
 
     planEl.textContent = (caps.label || data.tier || 'Free') + (data.tier_source === 'emulated' ? ' (emulated)' : '');
     planNoteEl.textContent = data.tier_source === 'emulated'
@@ -2501,7 +2523,7 @@
   }
 
   async function submitAnalysis() {
-    if (!demoMode && !currentAccount) {
+    if (!currentAccount) {
       login();
       return;
     }
@@ -2536,7 +2558,7 @@
 
     try {
       await apiDiscoveryReady;
-      var endpoint = demoMode ? '/api/demo-process' : '/api/analysis/submit';
+      var endpoint = '/api/analysis/submit';
       var requestBody = { kml_content: kmlContent };
       if (!demoMode) {
         var submissionContext = preflight ? {
@@ -2840,6 +2862,10 @@
     }
 
     if (currentAccount) {
+      if (demoMode) {
+        demoMode = false;
+        clearDemoModeQueryParam();
+      }
       var displayName = currentAccount.name || currentAccount.username || 'User';
       var identifier = currentAccount.username || currentAccount.name || 'Signed in';
       userSpan.textContent = displayName;
@@ -2853,8 +2879,14 @@
       accountNote.textContent = 'This is now the dedicated signed-in home for Canopex. Choose the role view and work preference that match the job at hand.';
       var analysisAuthGate = document.getElementById('app-analysis-auth-gate');
       var analysisFormFields = document.getElementById('app-analysis-form-fields');
+      var demoBanner = document.getElementById('app-demo-banner');
+      var samplePicker = document.getElementById('app-demo-sample-picker');
+      var historyCard = document.getElementById('app-history-card');
       if (analysisAuthGate) analysisAuthGate.hidden = true;
       if (analysisFormFields) analysisFormFields.hidden = false;
+      if (demoBanner) demoBanner.hidden = true;
+      if (samplePicker) samplePicker.hidden = true;
+      if (historyCard) historyCard.hidden = false;
       if (!analysisHistoryLoaded && !latestAnalysisRun) {
         setHeroRunSummary('Checking recent runs', 'Restoring signed-in history and active run state.');
         updateHistorySummary(null);
@@ -2873,8 +2905,13 @@
       billingBtn.style.display = 'none';
       var unauthGate = document.getElementById('app-analysis-auth-gate');
       var unauthFormFields = document.getElementById('app-analysis-form-fields');
+      var analysisAuthSecondaryLink = document.getElementById('app-analysis-auth-secondary-link');
       if (unauthGate) unauthGate.hidden = false;
       if (unauthFormFields) unauthFormFields.hidden = true;
+      if (analysisAuthSecondaryLink) {
+        analysisAuthSecondaryLink.textContent = 'Preview the Free Plan';
+        analysisAuthSecondaryLink.href = '/app/?mode=demo';
+      }
       analysisHistoryRuns = [];
       analysisHistoryLoaded = false;
       selectedAnalysisRunId = null;
@@ -2892,37 +2929,44 @@
     var logoutBtn = document.getElementById('auth-logout-btn');
     var userSpan = document.getElementById('auth-user');
     var userName = document.getElementById('app-user-name');
+    var accountIdentifier = document.getElementById('app-account-identifier');
     var accountNote = document.getElementById('app-account-note');
     var billingBtn = document.getElementById('app-manage-billing-btn');
+    var analysisAuthSecondaryLink = document.getElementById('app-analysis-auth-secondary-link');
 
-    // Skip auth gate — show dashboard
+    // Skip the outer auth gate so demo mode can preview the signed-in workspace.
     gate.hidden = true;
     dashboard.hidden = false;
 
-    // In demo mode, show the analysis form (no auth gate)
+    // Demo mode previews the free plan, but still requires sign-in before spend.
     var analysisAuthGate = document.getElementById('app-analysis-auth-gate');
     var analysisFormFields = document.getElementById('app-analysis-form-fields');
-    if (analysisAuthGate) analysisAuthGate.hidden = true;
-    if (analysisFormFields) analysisFormFields.hidden = false;
+    if (analysisAuthGate) analysisAuthGate.hidden = false;
+    if (analysisFormFields) analysisFormFields.hidden = true;
 
     // Show sign-in button instead of logout
     loginBtn.style.display = 'inline';
     logoutBtn.style.display = 'none';
-    userSpan.textContent = 'Demo';
+    userSpan.textContent = 'Preview';
     userSpan.style.display = 'inline';
-    userName.textContent = 'Demo visitor';
-    accountNote.textContent = 'Free demo — 1 AOI, seasonal snapshots, no exports. Sign in for full access.';
+    userName.textContent = 'Free plan preview';
+    if (accountIdentifier) accountIdentifier.textContent = 'Sign in required';
+    accountNote.textContent = 'Preview the free plan before you authenticate. No pipeline run starts until you sign in.';
     billingBtn.style.display = 'none';
+    if (analysisAuthSecondaryLink) {
+      analysisAuthSecondaryLink.textContent = 'View Plans';
+      analysisAuthSecondaryLink.href = '/#pricing';
+    }
 
-    // Apply demo billing status
+    // Apply free-plan preview status
     var demoCaps = {
-      label: 'Demo', tier: 'demo', run_limit: 3, aoi_limit: 1,
+      label: 'Free', tier: 'free', run_limit: 5, aoi_limit: 5,
       concurrency: 1, ai_insights: false, api_access: false,
-      export: false, retention_days: 0
+      export: false, retention_days: 30
     };
     latestBillingStatus = {
-      tier: 'demo', status: 'active', runs_remaining: 3,
-      capabilities: demoCaps, billing_configured: false
+      tier: 'free', status: 'preview', runs_remaining: 5,
+      capabilities: demoCaps, billing_configured: false, preview_mode: true
     };
 
     // Populate billing display
@@ -2930,10 +2974,10 @@
     var statusEl = document.getElementById('app-subscription-status');
     var remainingEl = document.getElementById('app-runs-remaining');
     var billingNoteEl = document.getElementById('app-billing-note');
-    if (tierEl) tierEl.textContent = 'Demo';
-    if (statusEl) statusEl.textContent = 'demo';
-    if (remainingEl) remainingEl.textContent = '3';
-    if (billingNoteEl) billingNoteEl.textContent = 'Sign in to unlock full features and billing';
+    if (tierEl) tierEl.textContent = 'Free preview';
+    if (statusEl) statusEl.textContent = 'preview';
+    if (remainingEl) remainingEl.textContent = '5';
+    if (billingNoteEl) billingNoteEl.textContent = 'Sign in to activate your free-plan quota and queue a run';
 
     updateHeroSummary(latestBillingStatus);
     updateCapabilityFields(demoCaps);
@@ -2942,7 +2986,7 @@
     var emulationCard = document.getElementById('app-tier-emulation-card');
     if (emulationCard) emulationCard.hidden = true;
 
-    // Show demo banner and sample picker
+    // Show preview banner and sample picker
     var demoBanner = document.getElementById('app-demo-banner');
     if (demoBanner) demoBanner.hidden = false;
     var samplePicker = document.getElementById('app-demo-sample-picker');
@@ -2986,11 +3030,6 @@
       }
     } catch { /* ignore */ }
 
-    if (demoMode) {
-      enterDemoMode();
-      return;
-    }
-
     if (!authEnabled()) {
       updateAuthUI();
       return;
@@ -3017,9 +3056,17 @@
         login();
         return;
       }
+      if (!currentAccount && demoMode) {
+        enterDemoMode();
+        return;
+      }
       updateAuthUI();
     }).catch(function(err) {
       console.warn('MSAL redirect error:', err);
+      if (demoMode) {
+        enterDemoMode();
+        return;
+      }
       updateAuthUI();
     });
   }


### PR DESCRIPTION
**Superseded by #417** — consolidated into a single clean PR based on current `main`.\n\nOriginal scope (signed-in pipeline + preview UX) is fully included in the consolidated PR.