### PR TITLE
docs: add release-safety guardrails and rollout planning

### DIFF
--- a/.github/agents/code-review-critic.agent.md
+++ b/.github/agents/code-review-critic.agent.md
@@ -1,0 +1,37 @@
+---
+name: "Code Review Critic"
+description: "Use when reviewing a PR, diff, issue implementation, or risky code change for bugs, regressions, missing tests, weak assumptions, or behavioral risk. Prefer for a second-opinion review pass after local validation."
+tools: [read, search]
+model: ['Claude Sonnet 4.5 (copilot)', 'GPT-5 (copilot)']
+agents: []
+user-invocable: true
+argument-hint: "PR, diff, issue implementation, or changed files"
+---
+
+# Code Review Critic
+
+You are the Canopex implementation critic.
+
+Your job is to perform a read-only engineering review that finds correctness risk, behavioral regression risk, and missing validation before code goes to PR review.
+
+## Constraints
+
+- DO NOT implement or edit code.
+- DO NOT focus on style, naming, or formatting unless it causes a concrete defect.
+- DO NOT duplicate release-safety or docs-drift audits unless they directly affect the finding.
+- DO NOT produce a changelog or summary-first review.
+
+## Approach
+
+1. Start from the claimed changed surface, issue, or PR summary.
+2. Inspect the owning code path and the nearest tests.
+3. Look for defects, regressions, missing guardrails, edge cases, and gaps between code and validation.
+4. Prefer findings that could break production behavior, operator confidence, or persona outcomes.
+5. If no findings exist, say so explicitly and note any residual testing gaps.
+
+## Output Format
+
+- Findings first, ordered by severity
+- Each finding should include the affected file or surface and the concrete risk
+- Then open questions or assumptions
+- Then residual risks or testing gaps if no findings are present

--- a/.github/agents/contract-docs-keeper.agent.md
+++ b/.github/agents/contract-docs-keeper.agent.md
@@ -1,0 +1,34 @@
+---
+name: "Contract and Docs Keeper"
+description: "Use when checking docs drift, API contract drift, roadmap status drift, runbook drift, or whether a PR changed behavior without updating the matching docs and tests."
+tools: [read, search]
+agents: []
+user-invocable: true
+argument-hint: "PR, issue, feature, workflow, or changed surface"
+---
+
+# Contract And Docs Keeper
+
+You are the Canopex contract-and-docs drift reviewer.
+
+Your job is to identify where behavior, rollout, or public interfaces have moved without the matching documentation and tests moving with them.
+
+## Constraints
+
+- DO NOT provide a broad style review.
+- DO NOT focus on implementation details unless they change user-visible or operator-visible behavior.
+- DO NOT treat docs as optional follow-up when a contract or rollout expectation changed.
+
+## Approach
+
+1. Identify the changed surface: API, auth, billing, deploy, export, monitoring, or product flow.
+2. Compare the likely behavior against the source-of-truth docs in `docs/ROADMAP.md`, `docs/API_INTERFACE_REFERENCE.md`, `docs/OPERATIONS_RUNBOOK.md`, `docs/openapi.yaml`, and `README.md` when relevant.
+3. Check whether matching tests or contract tests moved with the behavior.
+4. Flag missing docs, stale docs, or stale roadmap status explicitly.
+
+## Output Format
+
+- Drift summary
+- Missing or stale docs by file
+- Missing or stale tests by surface
+- Merge blockers vs follow-up items

--- a/.github/agents/persona-auditor.agent.md
+++ b/.github/agents/persona-auditor.agent.md
@@ -1,0 +1,35 @@
+---
+name: "Persona Auditor"
+description: "Use when checking whether a feature, issue, PR, or redesign actually serves the conservation, ESG/EUDR, or agricultural-advisor personas described in the repo docs."
+tools: [read, search]
+agents: []
+user-invocable: true
+argument-hint: "Feature, issue, PR, or user journey to audit"
+---
+
+# Persona Auditor
+
+You are the Canopex persona-fit critic.
+
+Your job is to assess whether a proposed change materially improves the product for the intended persona.
+
+## Constraints
+
+- DO NOT review code style or implementation details unless they affect persona outcomes.
+- DO NOT invent new personas.
+- DO NOT mark work as a win unless the user-facing outcome is concrete.
+
+## Approach
+
+1. Identify the intended persona and the job-to-be-done.
+2. Compare the change against the persona evidence in `docs/PERSONA_DEEP_DIVE.md`.
+3. Call out where the change improves speed, confidence, auditability, evidence quality, or batch usability.
+4. Identify the remaining gap between the proposed change and the persona's actual need.
+
+## Output Format
+
+- Primary persona
+- Fit assessment: strong, partial, or weak
+- What gets better for the persona
+- What still blocks product-need fit
+- Suggested acceptance criteria or follow-up slices

--- a/.github/agents/release-safety-guard.agent.md
+++ b/.github/agents/release-safety-guard.agent.md
@@ -1,0 +1,35 @@
+---
+name: "Release Safety Guard"
+description: "Use when reviewing deploy workflows, infrastructure changes, rollout controls, observability, smoke checks, environment separation, or production-promotion safety."
+tools: [read, search]
+agents: []
+user-invocable: true
+argument-hint: "Workflow, PR, issue, or rollout change to audit"
+---
+
+# Release Safety Guard
+
+You are the Canopex release-safety reviewer.
+
+Your job is to find rollout, environment, observability, and promotion risks before they become live incidents.
+
+## Constraints
+
+- DO NOT provide a broad code review; focus on release and promotion risk.
+- DO NOT assume dev-only changes are harmless if they can affect the promotion path.
+- DO NOT ignore documentation or operational drift.
+
+## Approach
+
+1. Identify which environment and promotion path the change touches.
+2. Check whether the artifact is built once and promoted safely.
+3. Check smoke coverage, rollback paths, structured logging, and operational diagnostics.
+4. Flag any accidental exposure of PR branches to shared environments.
+5. Call out missing docs or runbook updates.
+
+## Output Format
+
+- Risk summary
+- Findings ordered by severity
+- Required gates before merge or deploy
+- Residual risks after merge

--- a/.github/agents/roadmap-orchestrator.agent.md
+++ b/.github/agents/roadmap-orchestrator.agent.md
@@ -1,0 +1,37 @@
+---
+name: "Roadmap Orchestrator"
+description: "Use when breaking a roadmap item, GitHub issue, or product overhaul into ordered execution slices with dependencies, persona impact, rollout risks, and validation gates."
+tools: [read, search, todo]
+agents: []
+user-invocable: true
+argument-hint: "Issue number, roadmap item, or overhaul target"
+---
+
+# Roadmap Orchestrator
+
+You are the Canopex roadmap execution planner.
+
+Your job is to turn a roadmap item or issue into the smallest defensible execution plan for this repository.
+
+## Constraints
+
+- DO NOT propose broad, unordered workstreams.
+- DO NOT ignore roadmap stage sequencing.
+- DO NOT assume a feature is valid without naming the persona and job-to-be-done it improves.
+- DO NOT edit files or implement code.
+
+## Approach
+
+1. Identify the roadmap stage, issue, and dependency chain.
+2. Name the primary persona and the user outcome being improved.
+3. Break the work into 3-5 ordered slices with the owning code or docs surfaces.
+4. Define validation and rollout gates for each slice.
+5. Flag blockers, risky assumptions, or sequencing conflicts.
+
+## Output Format
+
+- Stage and issue context
+- Primary persona and JTBD
+- Ordered execution slices
+- Validation and rollout gates
+- Risks, blockers, and recommended next action

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,41 @@
+# Canopex Copilot Instructions
+
+## Source Of Truth
+
+- Treat `docs/ROADMAP.md` as the order-of-work source of truth.
+- Treat `docs/PERSONA_DEEP_DIVE.md` as the source of truth for conservation, ESG/EUDR, and agricultural-advisor needs.
+- Use `docs/PID.md` for product scope and system intent.
+- Use `docs/ARCHITECTURE_OVERVIEW.md`, `docs/API_INTERFACE_REFERENCE.md`, and `docs/OPERATIONS_RUNBOOK.md` when changing runtime behavior, contracts, or operations.
+
+## Prioritization
+
+- Finish Stage 2A release-safety work before opening more broad-exposure Stage 3 or Stage 4 implementation, unless the user explicitly overrides that priority.
+- For every substantial task, identify the primary persona, the job-to-be-done being improved, and the acceptance signal.
+- Prefer thin vertical slices over broad refactors that move several roadmap stages at once.
+
+## Delivery Workflow
+
+- Start planned work from a GitHub issue whenever practical.
+- Keep pull requests narrow, stage-aligned, and traceable to a roadmap item or issue.
+- Update `docs/ROADMAP.md` when PR state, stage status, or milestone status changes.
+- When behavior, contracts, or rollout expectations change, update the relevant tests and docs in the same change.
+
+## Release Safety
+
+- For deploy, infra, auth, billing, and rollout work, prefer build-once/promote semantics and avoid accidental PR-branch deploys to shared environments.
+- Treat readiness checks, post-deploy smoke, structured logging, and rollback paths as part of the feature, not follow-up work.
+- Do not weaken quota, auth, billing, or security gates just to make a change pass.
+
+## Persona Lens
+
+- Conservation work should reduce time from AOI upload to usable evidence or monitoring action.
+- ESG/EUDR work should improve auditability, reproducibility, or compliance confidence.
+- Agriculture work should improve batch parcel handling, defensible decisions, or export usability.
+- Keep the product usable for non-GIS operators. KML/KMZ remains a first-class input, not a temporary workaround.
+
+## Validation
+
+- Run the narrowest meaningful executable validation first.
+- Prefer behavior-scoped tests over broad suite runs when iterating.
+- For cross-cutting, deploy, auth, billing, API, or runtime changes, run the `Code Review Critic` after local validation and before requesting PR review.
+- Call out residual rollout risk when runtime validation is unavailable.

--- a/.github/hooks/docs-sync.json
+++ b/.github/hooks/docs-sync.json
@@ -1,0 +1,11 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "type": "command",
+        "command": "python3 .github/hooks/scripts/docs_sync_hook.py",
+        "timeout": 15
+      }
+    ]
+  }
+}

--- a/.github/hooks/release-safety.json
+++ b/.github/hooks/release-safety.json
@@ -1,0 +1,11 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": "python3 .github/hooks/scripts/release_safety_hook.py",
+        "timeout": 15
+      }
+    ]
+  }
+}

--- a/.github/hooks/scripts/docs_sync_hook.py
+++ b/.github/hooks/scripts/docs_sync_hook.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Emit advisory docs-sync reminders after relevant tool actions."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+DOC_RULES = {
+    "blueprints/": ["docs/API_INTERFACE_REFERENCE.md", "docs/openapi.yaml", "tests/"],
+    ".github/workflows/": ["docs/OPERATIONS_RUNBOOK.md", "docs/ROADMAP.md"],
+    "infra/tofu/": ["docs/OPERATIONS_RUNBOOK.md", "docs/ROADMAP.md"],
+    "scripts/reconcile_eventgrid_subscription.py": ["docs/OPERATIONS_RUNBOOK.md"],
+    "scripts/validate_dev_infra_gate.py": ["docs/OPERATIONS_RUNBOOK.md"],
+    "website/": ["docs/ROADMAP.md", "README.md"],
+}
+
+
+def flatten_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        strings: list[str] = []
+        for item in value.values():
+            strings.extend(flatten_strings(item))
+        return strings
+    if isinstance(value, list):
+        strings: list[str] = []
+        for item in value:
+            strings.extend(flatten_strings(item))
+        return strings
+    return []
+
+
+def main() -> int:
+    payload = json.load(sys.stdin)
+    haystack = "\n".join(flatten_strings(payload)).lower()
+
+    reminders: list[str] = []
+    for marker, docs in DOC_RULES.items():
+        if marker.lower() in haystack:
+            reminders.extend(docs)
+
+    if not reminders:
+        return 0
+
+    ordered = sorted(dict.fromkeys(reminders))
+    json.dump(
+        {
+            "continue": True,
+            "systemMessage": (
+                "Docs-sync advisory: this change may also require updates in "
+                + ", ".join(ordered)
+                + ". Check matching tests, roadmap status, API docs, or runbooks before finishing."
+            ),
+        },
+        sys.stdout,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/hooks/scripts/release_safety_hook.py
+++ b/.github/hooks/scripts/release_safety_hook.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Require an explicit approval step before release-critical tool actions proceed."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+RELEASE_PATH_MARKERS = [
+    ".github/workflows/",
+    "infra/tofu/",
+    "docs/OPERATIONS_RUNBOOK.md",
+    "scripts/reconcile_eventgrid_subscription.py",
+    "scripts/validate_dev_infra_gate.py",
+]
+
+RELEASE_COMMAND_MARKERS = [
+    "tofu apply",
+    "gh pr merge",
+    "gh workflow run",
+    "az functionapp",
+    "az staticwebapp",
+]
+
+
+def flatten_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        strings: list[str] = []
+        for item in value.values():
+            strings.extend(flatten_strings(item))
+        return strings
+    if isinstance(value, list):
+        strings: list[str] = []
+        for item in value:
+            strings.extend(flatten_strings(item))
+        return strings
+    return []
+
+
+def main() -> int:
+    payload = json.load(sys.stdin)
+    haystack = "\n".join(flatten_strings(payload)).lower()
+
+    should_gate = any(marker.lower() in haystack for marker in RELEASE_PATH_MARKERS)
+    should_gate = should_gate or any(
+        marker.lower() in haystack for marker in RELEASE_COMMAND_MARKERS
+    )
+
+    if not should_gate:
+        return 0
+
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "ask",
+                "permissionDecisionReason": (
+                    "This action touches release-critical workflow, infra, or deployment surfaces. "
+                    "Confirm environment scope, validation, and rollback intent before proceeding."
+                ),
+            }
+        },
+        sys.stdout,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/instructions/api-contracts.instructions.md
+++ b/.github/instructions/api-contracts.instructions.md
@@ -1,0 +1,20 @@
+---
+description: "Use when editing API endpoints, auth behavior, request or response payloads, OpenAPI definitions, contract tests, or public integration docs."
+name: "API Contract Discipline"
+applyTo:
+  - "blueprints/**"
+  - "docs/openapi.yaml"
+  - "docs/API_INTERFACE_REFERENCE.md"
+---
+# API Contract Guidelines
+
+- Keep code, tests, and contract docs aligned. If endpoint behavior changes, update the matching tests and docs in the same change.
+- Preserve backward compatibility unless the issue explicitly authorizes a breaking change.
+- Make auth, quota, and billing effects explicit in both code review and docs.
+- Prefer explicit validation and typed request/response handling over loose payload parsing.
+
+## Required Checks
+
+- Update endpoint tests or integration tests for any behavior change.
+- Reconcile public docs with live route and auth behavior.
+- Call out migration or client-impact risk in the PR description when request or response shapes move.

--- a/.github/instructions/persona-product.instructions.md
+++ b/.github/instructions/persona-product.instructions.md
@@ -1,0 +1,22 @@
+---
+description: "Use when designing user-facing flows, onboarding, dashboard behavior, exports, monitoring features, EUDR/compliance features, pricing-adjacent UX, or any feature intended to improve conservation, ESG, or agricultural-advisor outcomes."
+name: "Persona Product Lens"
+---
+# Persona Product Guidelines
+
+- Start by naming the primary persona: conservation, ESG/EUDR, or agricultural advisor.
+- State the job-to-be-done in operational terms: evidence generation, compliance proof, or batch field decision support.
+- Prefer simpler non-GIS workflows over technically clever expert workflows. Users should not need to think like remote-sensing specialists to succeed.
+- Make the value legible. A user-facing change should clearly improve speed, confidence, repeatability, or exportability.
+
+## Persona-Specific Biases
+
+- Conservation: optimize for evidence that can trigger action, not just imagery display.
+- ESG/EUDR: optimize for auditability, reproducibility, and defensible outputs over visual novelty.
+- Agriculture: optimize for batch handling, clear parcel-level outputs, and operational decision support.
+
+## Anti-Patterns
+
+- Do not add jargon-heavy UX when a plain-language explanation would work.
+- Do not ship a feature that looks powerful but still leaves the persona doing manual stitching in spreadsheets or GIS tools.
+- Do not treat free-tier upload success as enough; identify what paid-tier outcome becomes more compelling.

--- a/.github/instructions/release-safety.instructions.md
+++ b/.github/instructions/release-safety.instructions.md
@@ -1,0 +1,23 @@
+---
+description: "Use when editing GitHub Actions workflows, OpenTofu infrastructure, deployment scripts, rollout controls, runtime readiness checks, or observability tied to dev/prod promotion and release safety."
+name: "Release Safety"
+applyTo:
+  - ".github/workflows/**"
+  - "infra/tofu/**"
+  - "scripts/reconcile_eventgrid_subscription.py"
+  - "scripts/validate_dev_infra_gate.py"
+  - "docs/OPERATIONS_RUNBOOK.md"
+---
+# Release Safety Guidelines
+
+- Preserve the distinction between build, deploy, and promote. Production should promote the same built artifact, not rebuild ad hoc.
+- Do not introduce shared-environment deploy paths for PR branches unless the user explicitly wants a break-glass path.
+- Every rollout change should answer four questions: what is deployed, how it is validated, how it is rolled back, and who owns the decision to proceed.
+- Keep deploy evidence trustworthy: structured logs, runtime smoke checks, and explicit failure messages matter as much as the happy path.
+- When changing deploy or infra behavior, update the matching runbook or roadmap note in the same change.
+
+## Required Checks
+
+- Name the target environment and whether the change affects dev, prod, or promotion between them.
+- Add or update the narrowest test, validation script, or workflow assertion that proves the intended behavior.
+- Call out any security, billing, or feature-exposure side effects explicitly.

--- a/.github/prompts/code-review-sweep.prompt.md
+++ b/.github/prompts/code-review-sweep.prompt.md
@@ -1,0 +1,15 @@
+---
+name: "Code Review Sweep"
+description: "Run a second-opinion engineering review on a PR, diff, or risky change using the Code Review Critic agent."
+argument-hint: "PR, issue implementation, diff summary, or changed files"
+agent: "Code Review Critic"
+---
+
+# Code Review Sweep
+
+Review the supplied change as a read-only engineering critic.
+
+- Focus on bugs, regressions, missing tests, edge cases, and weak assumptions.
+- Prefer behavioral and operational risk over style commentary.
+- Findings must come first, ordered by severity.
+- If the change looks clean, say so and name any residual risk or validation gaps.

--- a/.github/prompts/docs-drift-audit.prompt.md
+++ b/.github/prompts/docs-drift-audit.prompt.md
@@ -1,0 +1,15 @@
+---
+name: "Docs Drift Audit"
+description: "Audit a PR, issue, or feature for docs, contract, and roadmap drift using the Contract and Docs Keeper agent."
+argument-hint: "PR, issue, feature, or changed files"
+agent: "Contract and Docs Keeper"
+---
+
+# Docs Drift Audit
+
+Audit the supplied change for docs and contract drift.
+
+- Identify which source-of-truth docs should have moved.
+- Flag missing updates to roadmap status, API reference, runbook, OpenAPI, README, or tests.
+- Separate hard blockers from acceptable follow-up work.
+- End with the exact files that should be updated before merge.

--- a/.github/prompts/persona-gap-audit.prompt.md
+++ b/.github/prompts/persona-gap-audit.prompt.md
@@ -1,0 +1,16 @@
+---
+name: "Persona Gap Audit"
+description: "Audit a feature, issue, PR, or user flow against Canopex persona needs using the Persona Auditor agent."
+argument-hint: "Feature, PR, issue, or user journey"
+agent: "Persona Auditor"
+---
+
+# Persona Gap Audit
+
+Audit the supplied feature or slice against Canopex persona needs.
+
+- Identify the intended persona.
+- Judge whether the change is a strong, partial, or weak fit.
+- State what gets easier, faster, or more defensible for that persona.
+- Identify the remaining gap to real product-need fit.
+- Suggest the next smallest follow-up slice if the fit is only partial.

--- a/.github/prompts/release-gate-audit.prompt.md
+++ b/.github/prompts/release-gate-audit.prompt.md
@@ -1,0 +1,16 @@
+---
+name: "Release Gate Audit"
+description: "Audit a workflow, PR, or deployment-related change for rollout and promotion safety using the Release Safety Guard agent."
+argument-hint: "Workflow, PR, issue, or deploy change"
+agent: "Release Safety Guard"
+---
+
+# Release Gate Audit
+
+Audit the supplied deployment or promotion change for release safety.
+
+- Identify which environments and promotion paths it touches.
+- Check for artifact-promotion, smoke-test, rollback, and observability gaps.
+- Call out accidental PR-branch exposure to shared environments.
+- List the gates that should be required before merge or deploy.
+- End with a go/no-go recommendation and the reason.

--- a/.github/prompts/roadmap-slice.prompt.md
+++ b/.github/prompts/roadmap-slice.prompt.md
@@ -1,0 +1,17 @@
+---
+name: "Roadmap Slice"
+description: "Create an execution brief for a roadmap item, issue, or overhaul using the Roadmap Orchestrator agent."
+argument-hint: "Issue number, roadmap item, or target capability"
+agent: "Roadmap Orchestrator"
+---
+
+# Roadmap Slice
+
+Build an execution brief for the supplied roadmap item or capability.
+
+- Identify the roadmap stage and dependency chain.
+- Name the primary persona and job-to-be-done.
+- Break the work into 3-5 ordered slices.
+- Include owning code or docs surfaces for each slice.
+- Define validation, rollout, and documentation gates.
+- Flag if Stage 2A sequencing should block the work.

--- a/.github/skills/roadmap-execution/SKILL.md
+++ b/.github/skills/roadmap-execution/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: roadmap-execution
+description: 'Use for roadmap items, product overhauls, stage planning, issue execution briefs, or persona-led delivery planning. Runs the Canopex workflow from roadmap slice to persona audit, release gate, docs drift, implementation plan, and PR readiness.'
+argument-hint: 'Roadmap item, issue number, or overhaul target'
+user-invocable: true
+---
+
+# Roadmap Execution
+
+Use this skill when you need one repeatable workflow for turning a roadmap item or overhaul target into an execution-ready slice.
+
+## When To Use
+
+- A roadmap item needs to be turned into an issue brief
+- A large capability needs to be broken into thin vertical slices
+- A proposed change needs persona, release-safety, and docs-drift checks before implementation
+- You want a consistent workflow for moving from planning to PR readiness
+
+## Procedure
+
+1. Read the source-of-truth docs first:
+   - `docs/ROADMAP.md`
+   - `docs/PERSONA_DEEP_DIVE.md`
+   - `docs/PID.md`
+   - `docs/ARCHITECTURE_OVERVIEW.md`
+2. Fill the [execution brief template](./assets/execution-brief-template.md).
+3. Run the `Roadmap Orchestrator` agent or `/Roadmap Slice` prompt to produce ordered slices.
+4. Run the `Persona Auditor` agent or `/Persona Gap Audit` prompt to verify the slice materially serves the intended persona.
+5. If the work touches deployment, runtime config, auth, billing, or rollout, run the `Release Safety Guard` agent or `/Release Gate Audit` prompt.
+6. If the work changes public behavior, contracts, operations, or status, run the `Contract and Docs Keeper` agent or `/Docs Drift Audit` prompt.
+7. Only then implement the smallest slice that can be validated narrowly.
+8. Before PR merge, ensure the roadmap, docs, and tests are updated and request Copilot review.
+
+## Stage Gates
+
+- Use the [persona and stage gates](./references/persona-and-stage-gates.md) to decide whether the slice should proceed now or wait for Stage 2A completion.
+- Do not open broad Stage 3 or Stage 4 implementation while Stage 2A release-safety work remains materially incomplete, unless the user explicitly overrides that sequencing.
+
+## Output Expectations
+
+- Named persona and JTBD
+- Ordered thin slices
+- Validation gates
+- Rollout and docs gates
+- Explicit next action

--- a/.github/skills/roadmap-execution/assets/execution-brief-template.md
+++ b/.github/skills/roadmap-execution/assets/execution-brief-template.md
@@ -1,0 +1,38 @@
+# Execution Brief Template
+
+## Context
+
+- Roadmap stage:
+- Issue or target:
+- Primary persona:
+- Job-to-be-done:
+
+## User Problem
+
+- What the user cannot do today:
+- Why it matters operationally:
+- What evidence will show the problem is improved:
+
+## Owning Surfaces
+
+- Primary code paths:
+- Primary docs or contract files:
+- Runtime or rollout surfaces:
+
+## Ordered Slices
+
+1. Slice one:
+2. Slice two:
+3. Slice three:
+
+## Validation Gates
+
+- Narrow executable validation per slice:
+- Release or rollout checks:
+- Docs or contract checks:
+
+## Risks
+
+- Main implementation risk:
+- Main rollout risk:
+- Main persona-fit risk:

--- a/.github/skills/roadmap-execution/references/persona-and-stage-gates.md
+++ b/.github/skills/roadmap-execution/references/persona-and-stage-gates.md
@@ -1,0 +1,21 @@
+# Persona And Stage Gates
+
+## Stage Gate
+
+- Stage 2A work takes priority over broad Stage 3 and Stage 4 implementation.
+- If a slice touches deploy, promotion, auth, quota, billing, or rollout exposure, treat it as release-safety work even if it also unlocks product value.
+
+## Persona Gates
+
+- Conservation: does this reduce time from AOI upload to usable evidence or monitoring action?
+- ESG/EUDR: does this improve auditability, reproducibility, or compliance confidence?
+- Agriculture: does this improve batch parcel handling, defensible decisions, or export usability?
+
+## Merge Gate
+
+- Issue linked
+- Persona named
+- Thin slice defined
+- Narrow validation run
+- Matching docs/tests updated
+- Rollout risk called out when relevant

--- a/docs/PRODUCTION_ROLLOUT_SPEC.md
+++ b/docs/PRODUCTION_ROLLOUT_SPEC.md
@@ -24,12 +24,12 @@ This is a repo-specific implementation plan, not a generic feature-flag overview
 
 The current repository already contains useful rollout building blocks:
 
-- Live health and readiness checks with rollback in [.github/workflows/deploy.yml](.github/workflows/deploy.yml).
-- Per-user persisted state patterns in [treesight/security/billing.py](treesight/security/billing.py) and [treesight/security/quota.py](treesight/security/quota.py).
-- A narrow env-based feature gate in [treesight/security/feature_gate.py](treesight/security/feature_gate.py).
-- Structured logging and correlation fields in [treesight/log.py](treesight/log.py).
-- Production telemetry and alerts in [infra/tofu/main.tf](infra/tofu/main.tf).
-- Local end-to-end trigger scripts in [scripts/simulate_upload.py](scripts/simulate_upload.py) and [scripts/load_baseline.py](scripts/load_baseline.py).
+- Live health and readiness checks with rollback in [.github/workflows/deploy.yml](../.github/workflows/deploy.yml).
+- Per-user persisted state patterns in [treesight/security/billing.py](../treesight/security/billing.py) and [treesight/security/quota.py](../treesight/security/quota.py).
+- A narrow env-based feature gate in [treesight/security/feature_gate.py](../treesight/security/feature_gate.py).
+- Structured logging and correlation fields in [treesight/log.py](../treesight/log.py).
+- Production telemetry and alerts in [infra/tofu/main.tf](../infra/tofu/main.tf).
+- Local end-to-end trigger scripts in [scripts/simulate_upload.py](../scripts/simulate_upload.py) and [scripts/load_baseline.py](../scripts/load_baseline.py).
 
 The current gaps are:
 
@@ -114,7 +114,7 @@ Fallback path when Cosmos is unavailable:
 - `pipeline-payloads/feature-flags/{feature_name}.json`
 - `pipeline-payloads/feature-flag-overrides/{user_id}.json`
 
-This mirrors the existing Cosmos-or-blob fallback pattern used in [treesight/security/billing.py](treesight/security/billing.py) and [treesight/security/quota.py](treesight/security/quota.py).
+This mirrors the existing Cosmos-or-blob fallback pattern used in [treesight/security/billing.py](../treesight/security/billing.py) and [treesight/security/quota.py](../treesight/security/quota.py).
 
 ### 5.2 Feature flag document
 
@@ -219,7 +219,7 @@ Minimum fields:
 
 ## 6. Feature Evaluation Rules
 
-Feature evaluation will be implemented in a shared runtime module that generalises the current logic in [treesight/security/feature_gate.py](treesight/security/feature_gate.py).
+Feature evaluation will be implemented in a shared runtime module that generalises the current logic in [treesight/security/feature_gate.py](../treesight/security/feature_gate.py).
 
 ### 6.1 Inputs
 
@@ -295,7 +295,7 @@ The local-only emulation endpoint in [blueprints/billing.py](blueprints/billing.
 
 ## 8. Post-Deploy Functional Smoke
 
-Current deployment already verifies `health` and `readiness` and rolls back the container on failure in [.github/workflows/deploy.yml](.github/workflows/deploy.yml).
+Current deployment already verifies `health` and `readiness` and rolls back the container on failure in [.github/workflows/deploy.yml](../.github/workflows/deploy.yml).
 
 This specification extends deploy with a second gate: a real functional smoke transaction.
 
@@ -397,7 +397,7 @@ Per feature and environment, the controller must query:
 
 ### 9.4 Existing infra reuse
 
-The design must reuse existing Application Insights and Azure Monitor plumbing already defined in [infra/tofu/main.tf](infra/tofu/main.tf), adding queries and alerts rather than introducing a second observability stack.
+The design must reuse existing Application Insights and Azure Monitor plumbing already defined in [infra/tofu/main.tf](../infra/tofu/main.tf), adding queries and alerts rather than introducing a second observability stack.
 
 ---
 
@@ -469,11 +469,11 @@ The rollout system must fail closed.
 - No public endpoint may allow arbitrary feature enablement.
 - Override writes must be authenticated and auditable.
 - Telemetry must avoid leaking raw PII where not operationally required.
-- Preview-user assignment must use stable authenticated user ids from [treesight/security/auth.py](treesight/security/auth.py).
+- Preview-user assignment must use stable authenticated user ids from [treesight/security/auth.py](../treesight/security/auth.py).
 
 ### 11.3 Protected surface checks
 
-Deploy smoke must verify that protected runtime endpoints remain protected after rollout, consistent with the intent already documented in [docs/OPERATIONS_RUNBOOK.md](docs/OPERATIONS_RUNBOOK.md).
+Deploy smoke must verify that protected runtime endpoints remain protected after rollout, consistent with the intent already documented in [OPERATIONS_RUNBOOK.md](OPERATIONS_RUNBOOK.md).
 
 ---
 
@@ -487,11 +487,11 @@ Deploy smoke must verify that protected runtime endpoints remain protected after
 
 ### 12.2 Changes to existing modules
 
-- Generalise [treesight/security/feature_gate.py](treesight/security/feature_gate.py) or replace it with the new feature evaluator.
+- Generalise [treesight/security/feature_gate.py](../treesight/security/feature_gate.py) or replace it with the new feature evaluator.
 - Update feature-owning endpoints to call the shared evaluator.
-- Extend [treesight/log.py](treesight/log.py) call sites to include rollout fields.
-- Extend [.github/workflows/deploy.yml](.github/workflows/deploy.yml) with post-readiness functional smoke.
-- Add Cosmos containers and outputs in [infra/tofu/main.tf](infra/tofu/main.tf).
+- Extend [treesight/log.py](../treesight/log.py) call sites to include rollout fields.
+- Extend [.github/workflows/deploy.yml](../.github/workflows/deploy.yml) with post-readiness functional smoke.
+- Add Cosmos containers and outputs in [infra/tofu/main.tf](../infra/tofu/main.tf).
 
 ### 12.3 New scripts
 

--- a/docs/PRODUCTION_ROLLOUT_SPEC.md
+++ b/docs/PRODUCTION_ROLLOUT_SPEC.md
@@ -1,0 +1,600 @@
+# Production Rollout Specification
+
+**Date:** 2026-04-05  
+**Status:** Proposed implementation spec  
+**Scope:** Production deployment safeguards, preview-user feature rollout, live smoke validation, and automated promotion/demotion
+
+---
+
+## 1. Purpose
+
+This specification defines how Canopex will:
+
+1. verify a fresh production deployment with a real functional transaction before broad user exposure,
+2. expose new features only to preview users or controlled rollout cohorts,
+3. collect evidence about feature success and failure in production,
+4. automatically stop promoting or actively disable failing features, and
+5. promote features to normal users only after repeated successful live validation.
+
+This is a repo-specific implementation plan, not a generic feature-flag overview. It is written against the current codebase, deployment workflow, and Azure topology.
+
+---
+
+## 2. Current State
+
+The current repository already contains useful rollout building blocks:
+
+- Live health and readiness checks with rollback in [.github/workflows/deploy.yml](.github/workflows/deploy.yml).
+- Per-user persisted state patterns in [treesight/security/billing.py](treesight/security/billing.py) and [treesight/security/quota.py](treesight/security/quota.py).
+- A narrow env-based feature gate in [treesight/security/feature_gate.py](treesight/security/feature_gate.py).
+- Structured logging and correlation fields in [treesight/log.py](treesight/log.py).
+- Production telemetry and alerts in [infra/tofu/main.tf](infra/tofu/main.tf).
+- Local end-to-end trigger scripts in [scripts/simulate_upload.py](scripts/simulate_upload.py) and [scripts/load_baseline.py](scripts/load_baseline.py).
+
+The current gaps are:
+
+- Feature control is not generalised. It is one feature, one env variable.
+- Deployment checks stop at process readiness, not real business-function validation.
+- There is no first-class preview-user or cohort rollout model.
+- There is no feature-specific success/failure evidence model for production promotion decisions.
+- Automatic rollback exists for container readiness, but not for feature rollout state.
+
+---
+
+## 3. Goals
+
+### 3.1 Functional goals
+
+The system must:
+
+1. keep new features off for normal users by default,
+2. allow explicit enablement for preview users,
+3. support gradual percentage rollout after preview,
+4. verify a real production transaction after deployment,
+5. record deployment- and feature-scoped outcomes in production telemetry,
+6. automatically demote a feature when evidence indicates regression, and
+7. promote a feature only after repeatable success.
+
+### 3.2 Safety goals
+
+The system must fail closed:
+
+- if rollout state cannot be loaded, features remain off,
+- if post-deploy functional smoke fails, the deployment is treated as unsafe,
+- if telemetry queries fail, the controller must not promote features,
+- if override state is malformed, affected features remain off.
+
+### 3.3 Non-goals
+
+This specification does not introduce:
+
+- a public self-serve feature toggle UI for end users,
+- A/B experimentation for marketing optimisation,
+- cross-region active/active traffic shaping,
+- blue/green website hosting beyond current deploy topology.
+
+---
+
+## 4. Architectural Approach
+
+The rollout system will have four layers:
+
+1. request-time feature evaluation in the app,
+2. operator-managed preview and override state,
+3. post-deploy live functional smoke execution,
+4. a scheduled rollout controller that promotes or demotes features based on evidence.
+
+### 4.1 Design principle
+
+Evaluation is synchronous and conservative. Promotion is asynchronous and evidence-driven.
+
+The request path should answer only this question:
+
+"Is feature X enabled for this request right now?"
+
+The rollout controller answers a separate question:
+
+"Should feature X be promoted, held, or demoted based on live evidence?"
+
+---
+
+## 5. Rollout Data Model
+
+Rollout state will live in storage, not environment variables.
+
+### 5.1 Containers
+
+Add two Cosmos containers when Cosmos is enabled:
+
+- `feature_flags`
+- `feature_flag_overrides`
+
+Fallback path when Cosmos is unavailable:
+
+- `pipeline-payloads/feature-flags/{feature_name}.json`
+- `pipeline-payloads/feature-flag-overrides/{user_id}.json`
+
+This mirrors the existing Cosmos-or-blob fallback pattern used in [treesight/security/billing.py](treesight/security/billing.py) and [treesight/security/quota.py](treesight/security/quota.py).
+
+### 5.2 Feature flag document
+
+Each feature has one canonical document keyed by feature name.
+
+```json
+{
+  "id": "scheduled-monitoring-v2",
+  "feature_name": "scheduled-monitoring-v2",
+  "status": "off",
+  "variant": "control",
+  "description": "Next iteration of scheduled monitoring workflow",
+  "default_value": false,
+  "allow_anonymous": false,
+  "preview_enabled": true,
+  "rollout_pct": 0,
+  "cohort_seed": "user_id",
+  "kill_switch": false,
+  "requires_smoke_success": true,
+  "min_successful_smokes": 3,
+  "max_error_rate_pct": 2.0,
+  "max_p95_latency_ms": 8000,
+  "min_preview_sample_size": 20,
+  "evaluation_mode": "server",
+  "created_at": "2026-04-05T00:00:00Z",
+  "updated_at": "2026-04-05T00:00:00Z",
+  "updated_by": "github-actions/deploy"
+}
+```
+
+### 5.3 Status values
+
+Supported `status` values:
+
+- `off`
+- `preview_only`
+- `percentage_rollout`
+- `on`
+- `blocked`
+
+`blocked` means automatic promotion is disabled until a human explicitly clears the feature.
+
+### 5.4 Override document
+
+Each override document is keyed by user id.
+
+```json
+{
+  "id": "user-123",
+  "user_id": "user-123",
+  "features": {
+    "scheduled-monitoring-v2": {
+      "enabled": true,
+      "variant": "preview",
+      "reason": "internal-preview",
+      "expires_at": "2026-05-01T00:00:00Z"
+    }
+  },
+  "updated_at": "2026-04-05T00:00:00Z",
+  "updated_by": "operator"
+}
+```
+
+Expired overrides are ignored at evaluation time.
+
+### 5.5 Smoke run record
+
+Each production smoke run produces a durable evidence record.
+
+Storage path:
+
+- `pipeline-payloads/deploy-smoke/{deploy_sha}/{run_id}.json`
+
+Minimum fields:
+
+```json
+{
+  "run_id": "20260405T101500Z-main-abc1234",
+  "deploy_sha": "abc1234",
+  "environment": "prd",
+  "base_url": "https://func-kmlsat-prd.azurewebsites.net",
+  "started_at": "2026-04-05T10:15:00Z",
+  "completed_at": "2026-04-05T10:17:12Z",
+  "success": true,
+  "instance_id": "f3f0f8b0-...",
+  "checks": {
+    "health": true,
+    "readiness": true,
+    "submit": true,
+    "orchestrator_completed": true,
+    "artifacts_present": true
+  },
+  "artifacts": {
+    "metadata": "...",
+    "manifest": "..."
+  },
+  "failure_reason": ""
+}
+```
+
+---
+
+## 6. Feature Evaluation Rules
+
+Feature evaluation will be implemented in a shared runtime module that generalises the current logic in [treesight/security/feature_gate.py](treesight/security/feature_gate.py).
+
+### 6.1 Inputs
+
+The evaluator must accept:
+
+- `feature_name`
+- `user_id`
+- request metadata where needed
+- deployment metadata such as git sha
+
+### 6.2 Evaluation order
+
+Evaluation order is strict:
+
+1. If `kill_switch` is true, return disabled.
+2. If feature document is missing or unreadable, return disabled.
+3. If a valid per-user override exists, return the override decision.
+4. If `status` is `off` or `blocked`, return disabled.
+5. If `status` is `preview_only`, return enabled only for explicit preview overrides.
+6. If `status` is `percentage_rollout`, enable deterministically for users whose rollout bucket falls within `rollout_pct`.
+7. If `status` is `on`, return enabled.
+
+### 6.3 Bucketing
+
+Percentage rollout must be deterministic.
+
+Bucket input:
+
+- `sha256("{feature_name}:{user_id}") % 100`
+
+This ensures that a given user stays in or out of the same rollout cohort unless the percentage changes.
+
+### 6.4 Anonymous users
+
+Anonymous users are not eligible for preview-only features unless a feature explicitly declares `allow_anonymous=true`.
+
+### 6.5 Failure mode
+
+If any storage read fails unexpectedly, the evaluator returns disabled and logs a structured `feature_eval_failed` event.
+
+---
+
+## 7. Operator Control Surface
+
+Preview assignment and rollout updates must not be performed through a public user endpoint.
+
+### 7.1 Phase 1 control surface
+
+Initial implementation uses operator-only scripts or GitHub Actions.
+
+Required scripts:
+
+- `scripts/feature_flag_upsert.py`
+- `scripts/feature_flag_override.py`
+- `scripts/feature_flag_clear_override.py`
+
+These scripts must authenticate using the same environment model already used by deployment automation.
+
+### 7.2 Future control surface
+
+If an API is later introduced, it must:
+
+- require strong operator/admin authentication,
+- record `updated_by`,
+- reject wildcard or bulk changes without explicit confirmation,
+- never be callable by ordinary product users.
+
+### 7.3 Billing emulation precedent
+
+The local-only emulation endpoint in [blueprints/billing.py](blueprints/billing.py) is a useful storage pattern reference, but it must not be reused as the production admin surface because it is intentionally limited to development origins.
+
+---
+
+## 8. Post-Deploy Functional Smoke
+
+Current deployment already verifies `health` and `readiness` and rolls back the container on failure in [.github/workflows/deploy.yml](.github/workflows/deploy.yml).
+
+This specification extends deploy with a second gate: a real functional smoke transaction.
+
+### 8.1 Smoke flow
+
+After readiness passes, deploy must:
+
+1. upload or submit a fixed known-good KML,
+2. trigger the production workflow,
+3. record the returned instance id,
+4. poll [blueprints/pipeline/diagnostics.py](blueprints/pipeline/diagnostics.py) until terminal state,
+5. require `runtimeStatus=Completed`,
+6. validate required artifact paths in storage,
+7. persist the smoke evidence record,
+8. continue deployment only if the smoke succeeds.
+
+### 8.2 Smoke path selection
+
+Preferred production smoke path:
+
+- submit through the same public app path that real users use,
+- avoid hidden bypasses,
+- use a dedicated smoke identity or smoke tenant,
+- tag the run as `smoke=true` in structured telemetry.
+
+If public submission cannot yet be used in production automation, an interim script may trigger through the existing blob/event path, but the target state is user-path validation.
+
+### 8.3 Required checks
+
+Minimum deploy smoke assertions:
+
+1. `GET /api/health` returns 200.
+2. `GET /api/readiness` returns 200.
+3. smoke submission returns accepted/success.
+4. orchestration reaches `Completed`.
+5. output artifact paths are present.
+6. no protected admin/runtime endpoint becomes anonymously accessible.
+
+### 8.4 Failure handling
+
+If functional smoke fails:
+
+- mark deployment unsafe,
+- rollback container image using the existing rollback path,
+- leave all new feature documents at `off` or `blocked`,
+- write the failure evidence record,
+- emit a high-severity alert.
+
+---
+
+## 9. Telemetry and Evidence Model
+
+The rollout system is only as good as its evidence. Every feature decision and every smoke run must be observable.
+
+### 9.1 Required structured fields
+
+Add these structured properties where applicable:
+
+- `feature_name`
+- `feature_status`
+- `feature_variant`
+- `feature_enabled`
+- `preview_user`
+- `rollout_pct`
+- `deploy_sha`
+- `environment`
+- `instance_id`
+- `correlation_id`
+- `smoke`
+- `user_id_hash`
+
+`user_id_hash` must be a one-way hash. Raw user ids must not be emitted into broad telemetry unless already required for operational reasons.
+
+### 9.2 Event types
+
+Required event classes:
+
+- `feature_evaluated`
+- `feature_eval_failed`
+- `deploy_smoke_started`
+- `deploy_smoke_completed`
+- `deploy_smoke_failed`
+- `feature_promoted`
+- `feature_demoted`
+- `feature_blocked`
+
+### 9.3 Metrics used by rollout controller
+
+Per feature and environment, the controller must query:
+
+- request count,
+- success count,
+- failure count,
+- error rate,
+- p50 latency,
+- p95 latency,
+- count of smoke successes,
+- count of smoke failures.
+
+### 9.4 Existing infra reuse
+
+The design must reuse existing Application Insights and Azure Monitor plumbing already defined in [infra/tofu/main.tf](infra/tofu/main.tf), adding queries and alerts rather than introducing a second observability stack.
+
+---
+
+## 10. Automated Promotion and Demotion
+
+Promotion and demotion happen in a scheduled controller, not inline with user requests.
+
+### 10.1 Controller execution model
+
+Run on a schedule, initially via GitHub Actions or a Timer Trigger.
+
+Frequency:
+
+- every 15 minutes for smoke result ingestion,
+- hourly for feature promotion/demotion evaluation.
+
+### 10.2 Promotion rules
+
+A feature may move from `preview_only` to `percentage_rollout` only if all of the following are true:
+
+1. `requires_smoke_success` is satisfied,
+2. there are at least `min_successful_smokes` consecutive successful deploy smokes,
+3. preview cohort error rate is below `max_error_rate_pct`,
+4. preview cohort p95 latency is below `max_p95_latency_ms`,
+5. preview sample size is at least `min_preview_sample_size`.
+
+Initial promotion ladder:
+
+- `preview_only`
+- `percentage_rollout` at 5%
+- `percentage_rollout` at 25%
+- `percentage_rollout` at 50%
+- `on`
+
+### 10.3 Demotion rules
+
+Automatic demotion must occur if any of the following are true:
+
+- latest deploy smoke failed,
+- feature error rate exceeds threshold,
+- feature p95 latency exceeds threshold,
+- repeated feature evaluation failures indicate storage/config breakage.
+
+Demotion path:
+
+- `on` -> `percentage_rollout` at previous safe level,
+- `percentage_rollout` -> `preview_only`,
+- `preview_only` -> `blocked` if the failure is severe or repeated.
+
+### 10.4 Human override
+
+Operators must be able to:
+
+- block a feature immediately,
+- clear a block after investigation,
+- set rollout percentage explicitly,
+- disable automatic promotion for a specific feature.
+
+---
+
+## 11. Security Requirements
+
+### 11.1 Default posture
+
+The rollout system must fail closed.
+
+### 11.2 Data handling
+
+- No public endpoint may allow arbitrary feature enablement.
+- Override writes must be authenticated and auditable.
+- Telemetry must avoid leaking raw PII where not operationally required.
+- Preview-user assignment must use stable authenticated user ids from [treesight/security/auth.py](treesight/security/auth.py).
+
+### 11.3 Protected surface checks
+
+Deploy smoke must verify that protected runtime endpoints remain protected after rollout, consistent with the intent already documented in [docs/OPERATIONS_RUNBOOK.md](docs/OPERATIONS_RUNBOOK.md).
+
+---
+
+## 12. Repository Changes Required
+
+### 12.1 New runtime modules
+
+- `treesight/security/feature_flags.py`
+- `treesight/security/feature_flag_store.py`
+- `treesight/security/feature_flag_models.py`
+
+### 12.2 Changes to existing modules
+
+- Generalise [treesight/security/feature_gate.py](treesight/security/feature_gate.py) or replace it with the new feature evaluator.
+- Update feature-owning endpoints to call the shared evaluator.
+- Extend [treesight/log.py](treesight/log.py) call sites to include rollout fields.
+- Extend [.github/workflows/deploy.yml](.github/workflows/deploy.yml) with post-readiness functional smoke.
+- Add Cosmos containers and outputs in [infra/tofu/main.tf](infra/tofu/main.tf).
+
+### 12.3 New scripts
+
+- `scripts/feature_flag_upsert.py`
+- `scripts/feature_flag_override.py`
+- `scripts/feature_flag_clear_override.py`
+- `scripts/production_smoke_test.py`
+
+### 12.4 Tests
+
+Required test areas:
+
+- feature evaluation precedence,
+- deterministic percentage bucketing,
+- expired override handling,
+- fail-closed storage errors,
+- deploy smoke success path,
+- deploy smoke failure path and rollback behavior,
+- controller promotion and demotion logic,
+- endpoint enforcement when UI hides but backend must still reject.
+
+---
+
+## 13. Implementation Phases
+
+### Phase A - Shared rollout engine
+
+Deliverables:
+
+- storage-backed feature definitions,
+- per-user preview overrides,
+- shared evaluator,
+- unit tests.
+
+Acceptance:
+
+- current billing gate can be expressed using the new system,
+- storage failure keeps billing disabled,
+- preview user can be enabled without env changes.
+
+### Phase B - Production smoke gate
+
+Deliverables:
+
+- production smoke script,
+- deploy workflow integration,
+- smoke evidence record,
+- rollback-on-functional-failure.
+
+Acceptance:
+
+- deploy does not complete after readiness alone,
+- failed smoke leaves the previous image live,
+- successful smoke leaves an evidence artifact tied to deploy sha.
+
+### Phase C - Telemetry and controller
+
+Deliverables:
+
+- feature-scoped telemetry,
+- rollout controller,
+- promotion/demotion rules,
+- alerts.
+
+Acceptance:
+
+- controller can promote a feature from preview to 5%,
+- controller can demote a feature automatically after regression,
+- operator can block promotion manually.
+
+### Phase D - Feature adoption
+
+Deliverables:
+
+- migrate current gates to shared engine,
+- add rollout metadata to new risky features by default,
+- update operational docs.
+
+Acceptance:
+
+- no new high-risk feature ships without a rollout document and kill switch,
+- runbook matches the implemented deploy smoke behavior.
+
+---
+
+## 14. Open Questions
+
+These do not block Phase A but must be resolved before full rollout automation:
+
+1. Should production smoke use the public authenticated submission path immediately, or use the current blob/event path as an interim step?
+2. Should rollout control live in GitHub Actions only, or also in a Timer Trigger inside the app?
+3. Which features are mandatory to register in the rollout system from day one beyond billing?
+4. Should website-only features remain flag-gated inside the current static site, or require a distinct staging website before launch?
+
+---
+
+## 15. Acceptance Summary
+
+This specification is satisfied when all of the following are true:
+
+1. Deploy validates a real production transaction after readiness.
+2. New features default to off and can be granted to preview users without code or env changes.
+3. Feature enablement is enforced server-side.
+4. Rollout decisions are backed by production telemetry, not intuition.
+5. Failing features can be automatically demoted or blocked.
+6. Normal users do not receive new features until the system has repeated evidence that they work.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,7 @@
 **Single source of truth for what to build next.**
 Issues hold the detail. This list holds the order.
 
-Last updated: 2026-04-04
+Last updated: 2026-04-05
 
 ---
 
@@ -12,10 +12,19 @@ Last updated: 2026-04-04
 | Milestone | Summary |
 |-----------|---------|
 | **M1 — Deployable Product** | CI/CD, Azure deployment, App Insights, cost alerts, AI Foundry, KMZ support |
-| **M2 — Free Tier Launch** | Auth (Entra CIAM), onboarding, KML guide, file upload, terms/privacy, structured logging |
+| **M2 — Free Tier Launch** | Auth (Entra CIAM), onboarding, KML guide, file upload, terms/privacy, structured logging helpers |
 | **M3 — Core Analysis Value** | NDVI, weather overlay, AI summaries, change detection, multi-polygon KML, enrichment split, site review fixes |
 | **M4 — Revenue (12/13)** | Stripe billing, quota enforcement, pricing page, export (PDF/GeoJSON/CSV), EUDR mode, WorldCover, WDPA, circuit breaker |
 | **Stage 1 — Launch Readiness** | Cosmos state migration, billing gate, user dashboard, pipeline modularisation, SSO providers, branding due diligence |
+
+---
+
+## Recently Landed
+
+| PR | Summary | Why It Matters |
+|----|---------|----------------|
+| #394 | Scheduled monitoring + change alerts (#310) | First Stage 3 capability landed, but subsequent risky growth work should ship behind the Stage 2A rollout model rather than directly to the live site. |
+| #393 | Blob storage + replay store managed identity | Important runtime hardening for storage access and multi-instance token replay; useful foundation for a clean redeploy/rebuild check. |
 
 ---
 
@@ -23,8 +32,13 @@ Last updated: 2026-04-04
 
 | PR | Branch | Feature |
 |----|--------|---------|
-| #393 | `fix/blob-storage-managed-identity` | Blob storage managed identity fix |
-| #394 | `feature/scheduled-monitoring` | 3.1 — Scheduled monitoring + change alerts |
+| #413 | `fix/signed-in-pipeline-preview` | Require sign-in for pipeline submissions and clean preview UX |
+| #414 | `infra-gate-dev-redeploy` | Harden dev infra gate validation and rollback |
+| #415 | `fix/startup-json-logging` | Install startup JSON logging for Canopex app families |
+
+**Priority call:** finish work already close to merge, but do not start more broad-exposure Stage 3 or Stage 4 work until the release-safety stage below is substantially complete. For Canopex, production should validate and gradually expose the same built artifact, not be the first unrestricted place we discover whether it works.
+
+**Infra gate before Stage 2A execution:** the live estate is still a single `dev` environment. `canopex.hrdcrprwn.com` is bound to `stapp-kmlsat-dev-site`, the checked-in deploy workflow still applies `environments/dev.tfvars` only, and the live Event Grid system topic currently has no event subscription even though the upload pipeline depends on `blob_trigger`. Before Stage 2A.1 is considered underway, prove a clean-slate `dev` recreate from OpenTofu state, restore verified ingestion wiring, and make `prd` a real promotion target.
 
 ---
 
@@ -62,13 +76,32 @@ Handle bulk workloads (200+ AOIs). Build once, then ship product features on top
 
 ---
 
+## Stage 2A — Release Safety & Promotion
+
+Make production safe to promote into. Build once in CI, promote the same immutable artifact dev -> prod, verify it live, then expose features gradually.
+
+| Order | Issue | Title | Depends On | Notes |
+|-------|-------|-------|------------|-------|
+| 2A.1 | #401 | Separate dev and prod deployment flows while promoting one immutable artifact | — | Start by proving a clean-slate `dev` rebuild and explicit domain cutover path. Prod should promote the same built image/site bundle, not rebuild. |
+| 2A.2 | #404 | Install structured JSON logging at Azure Functions startup | — | Make App Insights evidence and rollout telemetry trustworthy. |
+| 2A.3 | #405 | Reduce Function App config drift between OpenTofu and az CLI patching | #401 | Clarify ownership of live runtime config before prod promotion becomes stricter. |
+| 2A.4 | #402 | Gate production deploys on security workflow results and blocking image scan policy | #401 | Production deploy should wait for required security checks and use explicit exception paths. |
+| 2A.5 | #406 | Reconcile README, runbook, and API contracts with live routes and auth behavior | #401 | Remove responder and integrator drift before rollout and smoke automation widen. |
+| 2A.6 | #403 | `production_rollout`: preview users, smoke gates, and automated promotion/demotion | #401, #402, #404, #405 | Implement [PRODUCTION_ROLLOUT_SPEC.md](PRODUCTION_ROLLOUT_SPEC.md) in phases. |
+
+**Exit criteria:** Dev/prod promotion path explicit. Deploy runs a real functional smoke after readiness. Preview-user rollout exists. Production deploy is security-gated. Docs/contracts match code. New risky features default to off and can be promoted gradually.
+
+---
+
 ## Stage 3 — Growth & Retention
 
 Features that make Canopex a habit, not a one-off tool.
 
+Do not open more Stage 3 work beyond what is already in flight until Stage 2A is materially complete. Growth features are safer to ship once rollout controls and post-deploy smoke exist.
+
 | Order | Issue | Title | Depends On | Notes |
 |-------|-------|-------|------------|-------|
-| 3.1 | #310 | Scheduled monitoring + change alerts | #314 | Timer Trigger (6 h) → NDVI enrichment → threshold alerts via ACS email. Cosmos `monitors` container, Pro+ tier gated. |
+| 3.1 | #310 | Scheduled monitoring + change alerts | #314 | ✅ PR #394 merged. Timer Trigger (6 h) → NDVI enrichment → threshold alerts via ACS email. Cosmos `monitors` container, Pro+ tier gated. Keep subsequent risky Stage 3 features behind the rollout model from #403 rather than shipping them directly. |
 | 3.2 | #78 | Temporal catalogue in Cosmos DB | #314 | Per-AOI acquisition history, date range queries |
 | 3.3 | #79 | Catalogue API endpoints | #78 | `GET /api/catalogue` — paginated, filterable |
 | 3.4 | — | Shareable analysis links | #312 | Viral loop: "look at this deforestation" → new visitor |
@@ -78,6 +111,8 @@ Features that make Canopex a habit, not a one-off tool.
 | 3.8 | — | ALOS Forest/Non-Forest | — | PC `alos-fnf-mosaic`, 25 m SAR-based, annual |
 | 3.9 | — | GFW deforestation alerts | — | WRI GLAD + RADD alerts REST API |
 | 3.10 | #177 | H3-derived imagery/stat products | — | Optional H3 analytical layer alongside AOI outputs |
+| 3.11a | #400 | Pipeline run telemetry | #314 | Log per-run stats (AOI count, area, spread, enrichments, duration) to Cosmos. Start early so data accumulates. |
+| 3.11b | #399 | Pipeline ETA estimator | #400 | Regression model from historical runs → predict completion time from KML/KMZ profile. Show ETA at job submission. Needs ~100 runs before activation. |
 
 **Exit criteria:** Users on monitoring subs. Catalogue browsable. 3+ enrichment data sources added.
 
@@ -90,7 +125,7 @@ Unlock Team tier (£149/mo) and programmatic access. Higher LTV, lower churn.
 | Order | Issue | Title | Depends On | Notes |
 |-------|-------|-------|------------|-------|
 | 4.1 | #313 | Team workspaces + tenant segregation | #314, #312 | Shared analyses, org billing, CIAM group claims |
-| 4.2 | — | API documentation (interactive) | — | OpenAPI spec exists; needs dev portal + onboarding |
+| 4.2 | — | API documentation (interactive) | #406 | OpenAPI and reference docs must be reconciled before building a developer portal around them |
 | 4.3 | — | Webhook / Slack notifications | #310 | Enterprise integration pattern |
 | 4.4 | — | Long-term historical baselines (Landsat 40-yr) | — | USGS/EE, 1985–present |
 | 4.5 | — | Regional climate & land-use history | — | NOAA/ECMWF/MODIS historical context |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -35,6 +35,7 @@ Last updated: 2026-04-05
 | #413 | `fix/signed-in-pipeline-preview` | Require sign-in for pipeline submissions and clean preview UX |
 | #414 | `infra-gate-dev-redeploy` | Harden dev infra gate validation and rollback |
 | #415 | `fix/startup-json-logging` | Install startup JSON logging for Canopex app families |
+| #416 | `docs/release-safety-guardrails` | Add release-safety guardrails and rollout planning docs |
 
 **Priority call:** finish work already close to merge, but do not start more broad-exposure Stage 3 or Stage 4 work until the release-safety stage below is substantially complete. For Canopex, production should validate and gradually expose the same built artifact, not be the first unrestricted place we discover whether it works.
 


### PR DESCRIPTION
**Superseded by #417** — consolidated into a single clean PR based on current `main`.\n\nOriginal scope (release-safety guardrails, agents, prompts, rollout spec) is fully included in the consolidated PR, with improvements: added `applyTo` to persona-product instruction, removed invalid `todo` tool from orchestrator, removed fragile model names from code-review-critic, wired rollout spec into release-safety instruction.