### PR TITLE
chore: docs, tooling, and roadmap update

### DIFF
--- a/.github/agents/code-review-critic.agent.md
+++ b/.github/agents/code-review-critic.agent.md
@@ -8,20 +8,23 @@ argument-hint: "PR, diff, issue implementation, or changed files"
 ---
 You are the Canopex implementation critic.
 
-Your job is to perform a read-only engineering review that finds correctness risk, behavioral regression risk, and missing validation before code goes to PR review.
+Your job is to perform a read-only engineering review that finds correctness risk, behavioral regression risk, engineering standard violations, and missing validation before code goes to PR review.
+
+Read `.github/instructions/engineering-standards.instructions.md` before reviewing. Hold all code to those standards.
 
 ## Constraints
 
 - DO NOT implement or edit code.
-- DO NOT focus on style, naming, or formatting unless it causes a concrete defect.
-- DO NOT duplicate release-safety or docs-drift audits unless they directly affect the finding.
 - DO NOT produce a changelog or summary-first review.
 
 ## Approach
 
 1. Start from the claimed changed surface, issue, or PR summary.
 2. Inspect the owning code path and the nearest tests.
-3. Look for defects, regressions, missing guardrails, edge cases, and gaps between code and validation.
+3. Look for:
+   - **Correctness**: defects, regressions, missing guardrails, edge cases, gaps between code and tests.
+   - **Standards**: missing tests (test-first), impure functions that should be pure, swallowed exceptions, missing type annotations, unvalidated input at boundaries.
+   - **Reliability**: silent failures, non-idempotent operations, missing size/schema checks on ingested data.
 4. Prefer findings that could break production behavior, operator confidence, or persona outcomes.
 5. If no findings exist, say so explicitly and note any residual testing gaps.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,6 +15,7 @@
 
 ## Delivery Workflow
 
+- Always start new work on a clean branch from `main`. Before creating the branch, verify the working tree is clean (`git status`). Do not pile unrelated changes onto an existing feature branch.
 - Start planned work from a GitHub issue whenever practical.
 - Keep pull requests narrow, stage-aligned, and traceable to a roadmap item or issue.
 - Update `docs/ROADMAP.md` when PR state, stage status, or milestone status changes.
@@ -35,6 +36,7 @@
 
 ## Validation
 
+- Write the test first. The test defines the contract; the implementation makes it pass.
 - Run the narrowest meaningful executable validation first.
 - Prefer behavior-scoped tests over broad suite runs when iterating.
 - For cross-cutting, deploy, auth, billing, API, or runtime changes, run the `Code Review Critic` after local validation and before requesting PR review.

--- a/.github/instructions/codebase-quickref.instructions.md
+++ b/.github/instructions/codebase-quickref.instructions.md
@@ -1,0 +1,72 @@
+---
+description: "Always-on codebase quick-reference. Use for project structure, key commands, environment setup, test conventions, and module layout. Loaded automatically for all files."
+name: "Codebase Quick Reference"
+applyTo: "**"
+---
+# Codebase Quick Reference
+
+## Commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `make setup` (uses `uv sync --all-extras`) |
+| Run all tests | `make test` → `python -m pytest` |
+| Run one test file | `python -m pytest tests/test_parsers.py -x -q` |
+| Run one test | `python -m pytest tests/test_parsers.py::test_rejects_zip_bomb -x` |
+| Lint | `make lint` → `ruff check` |
+| Format | `make fmt` → `ruff format` |
+| Lint + test | `make check` |
+| Start local stack | `make dev-init` then `make dev-func` + `make dev-web` in separate terminals |
+| Upload sample KML | `make test-upload` |
+
+## Project Layout
+
+```text
+function_app.py          # Azure Functions entry point (imports blueprints)
+blueprints/              # HTTP + pipeline function handlers
+  pipeline/              # submission, blob_trigger, orchestrator, activities
+treesight/               # Core library (no Azure Functions dependency)
+  parsers/               # KML/KMZ parsing (fiona + lxml fallback)
+  pipeline/              # Ingestion, acquisition, fulfilment, enrichment
+  security/              # Auth, billing, quota
+  storage/               # Blob + Cosmos clients
+  constants.py           # All size limits, defaults, magic numbers
+rust/src/lib.rs          # PyO3 extension: NDVI, change detection, SCL resample
+website/                 # Static site (vanilla JS, no framework, no build step)
+  js/app-shell.js        # Main SPA logic (~3k lines)
+  staticwebapp.config.json
+infra/tofu/              # OpenTofu infrastructure
+scripts/                 # One-off setup and operational scripts
+tests/                   # ~1200 tests across 52 files
+  conftest.py            # Shared fixtures
+  fixtures/              # Sample KML, GeoJSON, raster data
+```
+
+## Key Modules
+
+| Module | Purpose |
+|--------|---------|
+| `treesight/constants.py` | All limits and defaults — never inline magic numbers |
+| `treesight/parsers/__init__.py` | KML/KMZ detection, unzip, parser dispatch |
+| `treesight/parsers/fiona_parser.py` | Primary KML parser (Fiona/GDAL) |
+| `treesight/parsers/lxml_parser.py` | Fallback KML parser (lxml, XXE-safe) |
+| `blueprints/pipeline/submission.py` | POST /api/analysis/submit handler |
+| `blueprints/pipeline/blob_trigger.py` | Event Grid → orchestrator |
+| `blueprints/pipeline/orchestrator.py` | Durable Functions fan-out/fan-in |
+| `blueprints/pipeline/activities.py` | Activity functions (parse, acquire, fulfil) |
+| `blueprints/_helpers.py` | Auth check, CORS, error response helpers |
+
+## Environment
+
+- Python 3.12, managed by `uv`, config in `pyproject.toml`
+- Rust crate built via `maturin` (PyO3), consumed as `treesight_rs` Python module
+- Azurite for local blob/table storage (`make dev-up`)
+- Azure Functions Core Tools for local function host (`func start`)
+
+## Test Conventions
+
+- Fixtures in `tests/conftest.py` and `tests/fixtures/`
+- Test files mirror source: `treesight/parsers/` → `tests/test_parsers.py`
+- Use `TEST_ORIGIN` and `TEST_LOCAL_ORIGIN` from conftest for CORS tests
+- Tests run fast (~1000 tests in <60s) — no network, no real Azure calls
+- Integration tests (`test-int`) require Azurite running

--- a/.github/instructions/engineering-standards.instructions.md
+++ b/.github/instructions/engineering-standards.instructions.md
@@ -1,0 +1,66 @@
+---
+description: "Use when writing or modifying Python code, tests, activities, parsers, or pipeline logic. Enforces test-first development, functional style, and high-reliability engineering discipline."
+name: "Engineering Standards"
+applyTo:
+  - "**/*.py"
+  - "tests/**"
+  - "treesight/**"
+  - "blueprints/**"
+  - "scripts/**"
+  - "rust/**"
+---
+# Engineering Standards
+
+Write idiomatic, clean, high-reliability Python. Every function should be testable in isolation. Every behavior should be proven by a test before it ships.
+
+## Test First
+
+- Write the test before the implementation. The test defines the contract.
+- A failing test is the starting point, not a follow-up task.
+- Tests should assert behavior, not implementation. Test what the function does, not how.
+- Name tests after the behavior they verify: `test_rejects_zip_bomb`, not `test_validate_3`.
+- Prefer small, focused test functions over large parametrized matrices unless the cases are truly uniform.
+- Test edge cases and failure modes, not just the happy path.
+
+## Functional Style
+
+- Prefer pure functions: data in, data out, no side effects.
+- Push side effects (I/O, storage, network) to the boundaries. Keep core logic pure.
+- Compose small functions rather than building large ones with branches.
+- Avoid mutable state. Prefer returning new values over mutating arguments.
+- Use dataclasses or Pydantic models for structured data, not dicts-of-dicts.
+
+## Error Handling — Let It Crash
+
+- Validate at system boundaries (API handlers, blob trigger, activity entry points).
+- Inside core logic, let exceptions propagate. Do not catch-and-swallow.
+- Raise specific exceptions with clear messages. `ValueError("KML exceeds 10 MiB")`, not `Exception("error")`.
+- Catch only at orchestration boundaries where you can report, retry, or refund (e.g. quota release).
+- Never silence exceptions with bare `except: pass`.
+
+## Python Idioms
+
+- Use `from __future__ import annotations` in all modules.
+- Type-annotate all function signatures. Avoid `Any` unless the type is genuinely unknown.
+- Use `pathlib.Path` over `os.path`. Use `f-strings` over `.format()` or `%`.
+- Constants in `treesight/constants.py`, not magic numbers inline.
+- Imports: stdlib → third-party → local, separated by blank lines.
+
+## Reliability
+
+- Defend against malicious input at every ingestion point: uploaded files, API payloads, webhook events.
+- Size-check before parsing. Schema-check before processing. Never trust content-type headers alone.
+- Log at decision points with structured context: `logger.info("msg", extra={...})` or at minimum `logger.info("msg key=%s", value)`.
+- Make operations idempotent where possible. A retry should not create a duplicate or corrupt state.
+
+## Rust (PyO3 Extension)
+
+The `rust/` crate (`treesight_rs`) is a PyO3 extension for performance-critical raster operations. It is called from Python and must be correct, fast, and safe.
+
+- All public functions exposed via `#[pyfunction]` must have doc comments explaining inputs, outputs, and invariants.
+- Use `rayon` for data parallelism on large arrays. Do not spawn raw threads.
+- Validate array dimensions and contiguity at the PyO3 boundary. Panic on invariant violations inside pure compute — PyO3 converts Rust panics to Python exceptions.
+- Prefer flat buffer iteration over 2D indexing for cache-friendly access.
+- No `unsafe` unless required by FFI. Justify every `unsafe` block with a safety comment.
+- Test via Python-side tests in `tests/test_rust_accel.py` — the Rust functions are consumed as a Python module, so test the interface users see.
+- Keep the crate small and single-purpose. If a new operation doesn't need native speed, write it in Python.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,11 @@
 #   TF_STATE_CONTAINER      — Blob container name for tfstate
 #   TF_STATE_KEY            — Blob key for the state file
 #   SWA_DEPLOYMENT_TOKEN    — Static Web App deployment token
+#
+# Optional secrets (CIAM redirect URI sync):
+#   CIAM_TENANT_ID          — CIAM tenant ID (enables OIDC login to CIAM tenant)
+#                              Once set, redirect URIs are synced automatically on deploy.
+#                              Requires one-time setup: scripts/setup_ciam_deploy_access.py
 # ─────────────────────────────────────────────────────────────
 name: Deploy
 
@@ -143,6 +148,8 @@ jobs:
     outputs:
       function_app_hostname: ${{ steps.hostname.outputs.hostname }}
       appinsights_connection_string: ${{ steps.appinsights.outputs.connection_string }}
+      swa_hostname: ${{ steps.swa-hostname.outputs.hostname }}
+      custom_domain: ${{ steps.swa-hostname.outputs.custom_domain }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -305,6 +312,20 @@ jobs:
         run: |
           HOSTNAME=$(tofu output -raw function_app_default_hostname)
           echo "hostname=${HOSTNAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Export SWA hostname
+        id: swa-hostname
+        working-directory: infra/tofu
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_USE_OIDC: "true"
+        run: |
+          HOSTNAME=$(tofu output -raw static_web_app_default_hostname)
+          CUSTOM_DOMAIN=$(tofu output -raw custom_domain)
+          echo "hostname=${HOSTNAME}" >> "$GITHUB_OUTPUT"
+          echo "custom_domain=${CUSTOM_DOMAIN}" >> "$GITHUB_OUTPUT"
 
       - name: Export App Insights connection string
         id: appinsights
@@ -495,3 +516,21 @@ jobs:
           app_location: /website
           skip_app_build: true
           skip_api_build: true
+
+      - name: Login to CIAM tenant (OIDC)
+        if: ${{ vars.CIAM_TENANT_ID != '' }}
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.CIAM_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Sync CIAM redirect URIs
+        if: ${{ vars.CIAM_TENANT_ID != '' }}
+        run: |
+          CUSTOM_DOMAIN="${{ needs.deploy-infra.outputs.custom_domain }}"
+          ARGS=("${{ needs.deploy-infra.outputs.swa_hostname }}")
+          if [ -n "$CUSTOM_DOMAIN" ]; then
+            ARGS+=("--custom-domain" "$CUSTOM_DOMAIN")
+          fi
+          python scripts/sync_ciam_redirect_uris.py "${ARGS[@]}"

--- a/docs/API_INTERFACE_REFERENCE.md
+++ b/docs/API_INTERFACE_REFERENCE.md
@@ -4,12 +4,32 @@ Issue: #18
 
 ## Public HTTP Endpoints
 
-| Method | Path | Purpose |
-| --- | --- | --- |
-| GET | /api/health | Liveness probe |
-| GET | /api/readiness | Dependency readiness probe |
-| GET | /api/orchestrator/{instance_id} | Durable diagnostics payload |
-| POST | /api/marketing-interest | Contact form ingestion endpoint |
+### Quick Verification Reference
+
+Function App base URL (dev): `https://func-kmlsat-dev.jollysea-48e72cf8.uksouth.azurecontainerapps.io`
+
+| Method | Path | Auth | Expected (unauthed) | Purpose |
+| --- | --- | --- | --- | --- |
+| GET | /api/health | anonymous | 200 JSON | Liveness probe |
+| GET | /api/readiness | anonymous | 200 JSON | Dependency readiness probe |
+| GET | /api/contract | anonymous | 200 JSON | OpenAPI/contract metadata |
+| GET | /api/catalogue | bearer token | 401 | User analysis catalogue |
+| POST | /api/analysis/submit | bearer token | 401 | KML upload + pipeline start |
+| POST | /api/frame-analysis | anonymous | — | Single-frame analysis |
+| POST | /api/timelapse-analysis | bearer token | 401 | Timelapse analysis |
+| POST | /api/eudr-assessment | bearer token | 401 | EUDR compliance assessment |
+| GET | /api/monitoring | bearer token | 401 | AOI monitoring |
+| GET | /api/billing/status | bearer token | 401 | Billing status |
+| POST | /api/billing/checkout | bearer token | 401 | Stripe checkout |
+| POST | /api/billing/portal | anonymous | — | Stripe portal redirect |
+| POST | /api/billing/webhook | anonymous | — | Stripe webhook |
+| GET | /api/demo-artifacts | anonymous | 400 (no params) | Demo artifact listing |
+| GET | /api/proxy | anonymous | — | Tile proxy |
+| POST | /api/contact-form | anonymous | — | Contact form |
+| GET | /api/orchestrator/{id} | anonymous | 200/404 | Durable diagnostics |
+| GET | /api/analysis/history | bearer token | 401 | Analysis history |
+| POST | /api/convert-coordinates | bearer token | 401 | Coordinate conversion |
+| GET | /api/export/{id}/{fmt} | bearer token | 401 | Export artifacts |
 
 ## Trigger and Orchestrator Entry Points
 

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -6,18 +6,84 @@ Issue: #18
 
 The production pipeline is deployed as Azure Functions on Container Apps with event-driven orchestration.
 
-- Event Grid topic: evgt-<baseName>
-- Event Grid subscription: evgs-kml-upload
-- Function App: func-<baseName>
-- Resource group: rg-<baseName>
-- Input container: kml-input
-- Output container: kml-output
-- Durable task hub: KmlSatelliteHub
+### Naming Convention
 
-For dev this commonly resolves to:
+All resources are named using `{prefix}-{project_code}-{environment}` where:
 
-- Function App: func-kmlsat-dev
-- Resource group: rg-kmlsat-dev
+- `project_code` is set in `infra/tofu/environments/{env}.tfvars` (dev: `kmlsat`)
+- `environment` is set per deployment (dev: `dev`)
+- Prefixes follow Azure naming standards defined in `infra/tofu/locals.tf`
+
+| Resource | Naming Pattern | Dev Value |
+| --- | --- | --- |
+| Resource Group | `rg-{code}-{env}` | `rg-kmlsat-dev` |
+| Function App | `func-{code}-{env}` | `func-kmlsat-dev` |
+| Static Web App | `stapp-{code}-{env}-site` | `stapp-kmlsat-dev-site` |
+| Event Grid Topic | `evgt-{code}-{env}` | `evgt-kmlsat-dev` |
+| Event Grid Sub | `evgs-kml-upload` | `evgs-kml-upload` |
+| Key Vault | `kv-{code}-{env}` | `kv-kmlsat-dev` |
+| Cosmos DB | `cosmos-{code}-{env}` | `cosmos-kmlsat-dev` |
+| App Insights | `appi-{code}-{env}` | `appi-kmlsat-dev` |
+| Log Analytics | `log-{code}-{env}` | `log-kmlsat-dev` |
+| Container Apps Env | `cae-{code}-{env}` | `cae-kmlsat-dev` |
+| Communication Svc | `acs-{code}-{env}` | `acs-kmlsat-dev` |
+| Email Service | `ecs-{code}-{env}` | `ecs-kmlsat-dev` |
+
+Additional fixed names:
+
+- Input container: `kml-input`
+- Output container: `kml-output`
+- Durable task hub: `KmlSatelliteHub`
+
+### Dev Environment Endpoints
+
+| Endpoint | URL |
+| --- | --- |
+| **Site (SWA)** | `https://green-moss-0e849ac03.2.azurestaticapps.net` |
+| **Function App** | `https://func-kmlsat-dev.jollysea-48e72cf8.uksouth.azurecontainerapps.io` |
+| **Cosmos DB** | `https://cosmos-kmlsat-dev.documents.azure.com:443/` |
+
+The SWA hostname is Azure-assigned (no custom domain currently configured).
+The Function App runs on Azure Container Apps in `uksouth`; the SWA is in `westeurope`.
+
+### API Routing
+
+The SWA linked-backend integration is **disabled** (see `infra/tofu/main.tf` line ~739) because Azure's `linkedBackends` ARM API returns 500 for Function Apps on Container Apps.
+
+Instead, the frontend calls the Function App directly using the hostname injected into `/api-config.json` at deploy time:
+
+```text
+GET https://green-moss-0e849ac03.2.azurestaticapps.net/api-config.json
+→ {"apiBase": "https://func-kmlsat-dev.jollysea-48e72cf8.uksouth.azurecontainerapps.io", ...}
+```
+
+This means:
+
+- `/api/*` routes through the SWA return **404** (expected)
+- All API calls go directly to the Function App hostname
+- CORS and CSP in `website/staticwebapp.config.json` allow `*.azurecontainerapps.io`
+
+### Auth (CIAM)
+
+- Tenant: `treesightauth.ciamlogin.com`
+- Client ID: `6e2abd0a-61a4-41a5-bdb5-7e1c91471fc6`
+- Provider: Azure AD B2C / CIAM (MSAL.js in frontend)
+
+### Deploy Pipeline
+
+```text
+Push to main → CI workflow → (on success) → Deploy workflow
+                                              ├─ 1. Build & push container to GHCR
+                                              ├─ 2. OpenTofu plan + apply (infra/tofu/)
+                                              ├─ 3. Deploy Function App (az functionapp)
+                                              ├─ 4. Deploy Static Web App (SWA token)
+                                              ├─ 5. Reconcile Event Grid subscription
+                                              └─ 6. Post-deploy smoke checks
+```
+
+Trigger: `workflow_run` on CI completion for `main`, or `workflow_dispatch`.
+Concurrency: serialized per ref (no cancellation of in-progress deploys).
+Config: `.github/workflows/deploy.yml`
 
 ## Data Flow
 

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -2,6 +2,22 @@
 
 Issue: #18
 
+## Quick Reference — Dev Environment
+
+| Resource | Value |
+| --- | --- |
+| Site URL | `https://green-moss-0e849ac03.2.azurestaticapps.net` |
+| Function App URL | `https://func-kmlsat-dev.jollysea-48e72cf8.uksouth.azurecontainerapps.io` |
+| Health check | `curl -sS https://func-kmlsat-dev.jollysea-48e72cf8.uksouth.azurecontainerapps.io/api/health` |
+| Readiness check | `curl -sS https://func-kmlsat-dev.jollysea-48e72cf8.uksouth.azurecontainerapps.io/api/readiness` |
+| API config | `curl -sS https://green-moss-0e849ac03.2.azurestaticapps.net/api-config.json` |
+| Resource Group | `rg-kmlsat-dev` |
+| Cosmos DB | `https://cosmos-kmlsat-dev.documents.azure.com:443/` |
+| CIAM Tenant | `treesightauth.ciamlogin.com` |
+| Container image | `ghcr.io/hardcoreprawn/azure-workflow-for-kml-satellite:{sha}` |
+
+**Note:** The SWA does not proxy `/api/*` — all API calls go directly to the Function App hostname (see Architecture Overview for details).
+
 ## Deploy
 
 1. Run CI checks.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,7 @@
 **Single source of truth for what to build next.**
 Issues hold the detail. This list holds the order.
 
-Last updated: 2026-04-05
+Last updated: 2026-04-07
 
 ---
 
@@ -23,18 +23,24 @@ Last updated: 2026-04-05
 
 | PR | Summary | Why It Matters |
 |----|---------|----------------|
-| #394 | Scheduled monitoring + change alerts (#310) | First Stage 3 capability landed, but subsequent risky growth work should ship behind the Stage 2A rollout model rather than directly to the live site. |
-| #393 | Blob storage + replay store managed identity | Important runtime hardening for storage access and multi-instance token replay; useful foundation for a clean redeploy/rebuild check. |
+| #425 | KML/KMZ input sanitisation — zip bomb protection + `validate_kml_bytes()` (#421) | Slice 1 of event-driven pipeline. Hardens `maybe_unzip()` with decompression limits and adds structural XML validation. OWASP-grade input defence before the upload path moves event-driven. |
+| #419 | Redesign metric alerts for scale-to-zero Container Apps (#418) | Alerting no longer fires on cold-start 503s. New Event Grid dropped-events Sev1 alert. |
+| #417 | Stage 2A release safety — consolidated (#407–#412) | CIAM automation, deploy workflow hardening, docs reconciliation. |
+| #394 | Scheduled monitoring + change alerts (#310) | First Stage 3 capability landed. |
+| #393 | Blob storage + replay store managed identity | Runtime hardening for storage access. |
 
 ---
 
 ## In Flight
 
-No open PRs right now.
+| PR | Branch | Summary |
+|----|--------|--------|
+| #425 | `feat/kml-input-sanitisation` | Slice 1 — input sanitisation (awaiting review) |
+| #419 | `fix/scale-to-zero-alerts` | Alert redesign (awaiting review) |
 
-**Priority call:** finish work already close to merge, but do not start more broad-exposure Stage 3 or Stage 4 work until the release-safety stage below is substantially complete. For Canopex, production should validate and gradually expose the same built artifact, not be the first unrestricted place we discover whether it works.
+**Priority call:** the event-driven pipeline restructure (#420) is the current focus. Work the slices in order (#421 → #422 → #423 → #424). Do not open more Stage 3 or Stage 4 work until the event-driven pipeline is reliably wired and Stage 2A release-safety work is materially complete.
 
-**Infra gate before Stage 2A execution:** the live estate is still a single `dev` environment. `canopex.hrdcrprwn.com` is bound to `stapp-kmlsat-dev-site`, the checked-in deploy workflow still applies `environments/dev.tfvars` only, and the live Event Grid system topic currently has no event subscription even though the upload pipeline depends on `blob_trigger`. Before Stage 2A.1 is considered underway, prove a clean-slate `dev` recreate from OpenTofu state, restore verified ingestion wiring, and make `prd` a real promotion target.
+**Infra gate before Stage 2A execution:** the live estate is still a single `dev` environment. `canopex.hrdcrprwn.com` is bound to `stapp-kmlsat-dev-site`, the checked-in deploy workflow still applies `environments/dev.tfvars` only. Before Stage 2A.1 is considered underway, prove a clean-slate `dev` recreate from OpenTofu state and make `prd` a real promotion target.
 
 ---
 
@@ -89,11 +95,26 @@ Make production safe to promote into. Build once in CI, promote the same immutab
 
 ---
 
+## Stage 2B — Event-Driven Pipeline Restructure
+
+Decouple the KML upload path from the orchestrator. Make the pipeline fully event-driven so the function app can scale to zero reliably. Parent issue: #420.
+
+| Order | Issue | Title | Depends On | Status |
+|-------|-------|-------|------------|--------|
+| 2B.1 | #421 | KML/KMZ input sanitisation — zip bomb + XML validation | — | ✅ PR #425 — awaiting review |
+| 2B.2 | #422 | SWA API function for SAS token minting + status polling | — | 🔜 Next |
+| 2B.3 | #423 | Unify on event-driven path — remove direct orchestrator start | #421, #422 | — |
+| 2B.4 | #424 | Migrate read-only endpoints to SWA functions + cold start optimisation | #423 | — |
+
+**Exit criteria:** Upload goes via SAS URL → blob → Event Grid → orchestrator. Function app has zero direct-submission paths. Read-only endpoints served from SWA managed functions (always warm).
+
+---
+
 ## Stage 3 — Growth & Retention
 
 Features that make Canopex a habit, not a one-off tool.
 
-Do not open more Stage 3 work beyond what is already in flight until Stage 2A is materially complete. Growth features are safer to ship once rollout controls and post-deploy smoke exist.
+Do not open more Stage 3 work beyond what is already in flight until Stage 2A and 2B are materially complete. Growth features are safer to ship once rollout controls, post-deploy smoke, and reliable event-driven ingestion exist.
 
 | Order | Issue | Title | Depends On | Notes |
 |-------|-------|-------|------------|-------|

--- a/infra/tofu/outputs.tf
+++ b/infra/tofu/outputs.tf
@@ -43,6 +43,11 @@ output "event_grid_system_topic_name" {
   description = "Event Grid system topic name."
 }
 
+output "custom_domain" {
+  value       = var.custom_domain
+  description = "Custom domain name (empty string if not configured)."
+}
+
 output "site_url" {
   value       = var.custom_domain != "" ? "https://${var.custom_domain}" : "https://${azurerm_static_web_app.main.default_host_name}"
   description = "Primary site URL (custom domain if configured, otherwise default)."

--- a/scripts/_register_ciam_app.py
+++ b/scripts/_register_ciam_app.py
@@ -1,4 +1,8 @@
-"""One-time script: Register the Canopex SPA app in the CIAM tenant."""
+"""One-time script: Register the Canopex SPA app in the CIAM tenant.
+
+After initial registration, redirect URIs are kept in sync automatically
+by sync_ciam_redirect_uris.py (called from the deploy workflow).
+"""
 
 import json
 import sys
@@ -21,7 +25,7 @@ def main():
                 # TODO: parameterise redirect URIs per environment instead of hardcoding
                 "redirectUris": [
                     "http://localhost:4280",
-                    "https://polite-glacier-0d6885003.4.azurestaticapps.net",
+                    "https://green-moss-0e849ac03.2.azurestaticapps.net",
                     "https://canopex.hrdcrprwn.com",
                 ]
             },

--- a/scripts/setup_ciam_deploy_access.py
+++ b/scripts/setup_ciam_deploy_access.py
@@ -1,0 +1,163 @@
+"""One-time: Grant the deploy SP access to the CIAM tenant for redirect URI management.
+
+Prerequisites:
+  1. You must be a Global Administrator in the CIAM tenant (treesightauth).
+  2. The deploy service principal must already exist in the subscription tenant.
+  3. Set CIAM_TOKEN to a Graph API bearer token for the CIAM tenant
+     (get one from https://developer.microsoft.com/graph/graph-explorer
+      scoped to the CIAM tenant, with Application.ReadWrite.All).
+
+What this script does:
+  1. Consents the deploy SP into the CIAM tenant (creates a service principal).
+  2. Adds an OIDC federation credential for the GitHub repo.
+  3. Grants Application.ReadWrite.OwnedBy so the SP can update the Canopex SPA
+     app registration's redirect URIs at deploy time.
+
+After running this, the deploy workflow can authenticate to the CIAM tenant
+using OIDC (no stored secrets) and sync redirect URIs automatically.
+
+Usage:
+  CIAM_TOKEN=<token> DEPLOY_CLIENT_ID=<sp-client-id> python scripts/setup_ciam_deploy_access.py
+
+Environment:
+  CIAM_TOKEN         — Bearer token with admin consent rights in CIAM tenant
+  DEPLOY_CLIENT_ID   — Client ID of the deploy service principal (AZURE_CLIENT_ID)
+  GITHUB_REPO        — Optional, defaults to Hardcoreprawn/azure-workflow-for-kml-satellite
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Re-use the graph helper from the existing CIAM scripts
+sys.path.insert(0, os.path.dirname(__file__))
+from _graph import APP_OBJECT_ID, TENANT_ID, graph
+
+GITHUB_REPO = os.environ.get("GITHUB_REPO", "Hardcoreprawn/azure-workflow-for-kml-satellite")
+
+# Microsoft Graph app role: Application.ReadWrite.OwnedBy
+# This is the least-privilege role that allows updating apps the SP owns.
+APP_READWRITE_OWNED_BY_ROLE_ID = "18a4783c-866b-4cc7-a460-3d5e5662c884"
+GRAPH_RESOURCE_ID = "00000003-0000-0000-c000-000000000000"
+
+
+def main() -> int:
+    token = os.environ.get("CIAM_TOKEN", "")
+    deploy_client_id = os.environ.get("DEPLOY_CLIENT_ID", "")
+
+    if not token:
+        print("ERROR: Set CIAM_TOKEN env var (Graph API token for the CIAM tenant)")
+        return 1
+    if not deploy_client_id:
+        print("ERROR: Set DEPLOY_CLIENT_ID env var (the deploy SP's client/app ID)")
+        return 1
+
+    # ── 1. Consent deploy SP into CIAM tenant ──
+    print("=== Step 1: Consent deploy SP into CIAM tenant ===")
+    sp = graph("POST", "/servicePrincipals", {"appId": deploy_client_id})
+    if sp:
+        sp_object_id = sp["id"]
+        print(f"  Created service principal: {sp_object_id}")
+    else:
+        # May already exist
+        existing = graph("GET", f"/servicePrincipals?$filter=appId eq '{deploy_client_id}'")
+        if existing and existing.get("value"):
+            sp_object_id = existing["value"][0]["id"]
+            print(f"  Service principal already exists: {sp_object_id}")
+        else:
+            print("  ERROR: Could not create or find service principal")
+            return 1
+
+    # ── 2. Add OIDC federation credential ──
+    print("\n=== Step 2: Add OIDC federation credential ===")
+    # Check for existing federation credentials
+    existing_creds = graph("GET", f"/applications?$filter=appId eq '{deploy_client_id}'&$select=id")
+    if not existing_creds or not existing_creds.get("value"):
+        print("  NOTE: The deploy app registration is in a different tenant.")
+        print("  OIDC federation must be configured on the app registration in its home tenant.")
+        print("  If the app is multi-tenant, this SP will automatically trust the federation")
+        print("  credentials configured in the home tenant.")
+        print()
+        print("  Ensure the app registration in the subscription tenant has:")
+        print("    - signInAudience: AzureADMultipleOrgs")
+        print(f"    - Federated credential for: repo:{GITHUB_REPO}:environment:dev")
+    else:
+        app_object_id = existing_creds["value"][0]["id"]
+        fed_cred = graph(
+            "POST",
+            f"/applications/{app_object_id}/federatedIdentityCredentials",
+            {
+                "name": f"github-deploy-ciam-{GITHUB_REPO.split('/')[-1]}",
+                "issuer": "https://token.actions.githubusercontent.com",
+                "subject": f"repo:{GITHUB_REPO}:environment:dev",
+                "audiences": ["api://AzureADTokenExchange"],
+                "description": "GitHub Actions OIDC for deploy workflow (CIAM tenant)",
+            },
+        )
+        if fed_cred:
+            print(f"  Added federation credential: {fed_cred.get('id')}")
+        else:
+            print("  Federation credential may already exist (or requires home tenant config)")
+
+    # ── 3. Make SP owner of the Canopex SPA app ──
+    print("\n=== Step 3: Add deploy SP as owner of Canopex SPA app ===")
+    owner_ref = f"https://graph.microsoft.com/v1.0/directoryObjects/{sp_object_id}"
+    result = graph(
+        "POST",
+        f"/applications/{APP_OBJECT_ID}/owners/$ref",
+        {"@odata.id": owner_ref},
+    )
+    if result is not None:
+        print("  Added deploy SP as owner of Canopex SPA app")
+    else:
+        # Check if already owner
+        owners = graph("GET", f"/applications/{APP_OBJECT_ID}/owners?$select=id")
+        if owners and any(o.get("id") == sp_object_id for o in owners.get("value", [])):
+            print("  Deploy SP is already an owner")
+        else:
+            print("  WARNING: Could not add owner. You may need to do this manually.")
+
+    # ── 4. Grant Application.ReadWrite.OwnedBy (app role) ──
+    print("\n=== Step 4: Grant Application.ReadWrite.OwnedBy ===")
+    # Find the Graph SP in CIAM tenant
+    graph_sp = graph("GET", f"/servicePrincipals?$filter=appId eq '{GRAPH_RESOURCE_ID}'")
+    if not graph_sp or not graph_sp.get("value"):
+        print("  ERROR: Could not find Microsoft Graph service principal in CIAM tenant")
+        return 1
+    graph_sp_id = graph_sp["value"][0]["id"]
+
+    role_assignment = graph(
+        "POST",
+        f"/servicePrincipals/{sp_object_id}/appRoleAssignments",
+        {
+            "principalId": sp_object_id,
+            "resourceId": graph_sp_id,
+            "appRoleId": APP_READWRITE_OWNED_BY_ROLE_ID,
+        },
+    )
+    if role_assignment:
+        print("  Granted Application.ReadWrite.OwnedBy")
+    else:
+        print("  Role may already be assigned (or requires admin consent)")
+
+    # ── Summary ──
+    print("\n=== Summary ===")
+    print(f"  CIAM Tenant ID:      {TENANT_ID}")
+    print(f"  Deploy SP Client ID: {deploy_client_id}")
+    print(f"  Deploy SP Object ID: {sp_object_id}")
+    print(f"  Canopex App Object:  {APP_OBJECT_ID}")
+    print()
+    print("  Next steps:")
+    print(
+        "  1. Ensure the deploy app registration is multi-tenant (signInAudience: AzureADMultipleOrgs)"
+    )
+    print(f"  2. Add CIAM_TENANT_ID={TENANT_ID} to the 'dev' environment secrets in GitHub")
+    print("  3. The deploy workflow will now use OIDC to authenticate to the CIAM tenant")
+    print("  4. No CIAM_TOKEN secret needed — the workflow acquires tokens via OIDC")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync_ciam_redirect_uris.py
+++ b/scripts/sync_ciam_redirect_uris.py
@@ -1,0 +1,222 @@
+"""Sync CIAM app registration redirect URIs with the current SWA hostname.
+
+Ensures the CIAM app registration always has the correct redirect URIs
+for the deployed Static Web App, preventing AADSTS50011 errors when the
+SWA hostname changes after infrastructure recreation.
+
+Usage:
+  # In the deploy workflow (OIDC — no secrets needed):
+  python scripts/sync_ciam_redirect_uris.py green-moss-0e849ac03.2.azurestaticapps.net
+
+  # With a manual token:
+  CIAM_TOKEN=<token> python scripts/sync_ciam_redirect_uris.py green-moss-...
+
+Token resolution order:
+  1. CIAM_TOKEN env var (manual / legacy)
+  2. `az account get-access-token` against the CIAM tenant (OIDC in CI)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+# ── CIAM app registration constants (from _graph.py) ──
+APP_OBJECT_ID = "7ce73a2a-b80a-4b6f-afb7-eccf74bfaf47"
+TENANT_ID = "92001438-8b42-4bd7-950f-0ed1775f87b7"
+
+# Redirect URIs that are always present regardless of SWA hostname
+PERMANENT_REDIRECT_URIS: list[str] = [
+    "http://localhost:4280",
+]
+
+# Custom domain redirect URIs (added when configured)
+CUSTOM_DOMAIN_URIS: list[str] = [
+    "https://canopex.hrdcrprwn.com",
+]
+
+
+def graph_api(method: str, path: str, body: dict | None = None, token: str = "") -> dict | None:
+    """Call Microsoft Graph API v1.0."""
+    data = json.dumps(body).encode() if body else None
+    req = urllib.request.Request(
+        f"https://graph.microsoft.com/v1.0{path}",
+        data=data,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            if resp.status == 204:
+                return {"_status": 204}
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode()
+        print(f"ERROR {e.code} on {method} {path}:")
+        try:
+            print(json.dumps(json.loads(body_text), indent=2))
+        except Exception:
+            print(body_text)
+        return None
+    except urllib.error.URLError as e:
+        print(f"Network error on {method} {path}: {e}")
+        return None
+
+
+def get_current_redirect_uris(token: str) -> list[str] | None:
+    """Fetch the current SPA redirect URIs from the app registration."""
+    result = graph_api("GET", f"/applications/{APP_OBJECT_ID}?$select=spa", token=token)
+    if result is None:
+        return None
+    return result.get("spa", {}).get("redirectUris", [])
+
+
+def build_desired_uris(swa_hostname: str, custom_domain: str = "") -> list[str]:
+    """Build the desired redirect URI list from the SWA hostname."""
+    uris = list(PERMANENT_REDIRECT_URIS)
+    uris.append(f"https://{swa_hostname}")
+    if custom_domain:
+        uris.append(f"https://{custom_domain}")
+    else:
+        uris.extend(CUSTOM_DOMAIN_URIS)
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for u in uris:
+        if u not in seen:
+            seen.add(u)
+            deduped.append(u)
+    return deduped
+
+
+def sync_redirect_uris(
+    token: str, swa_hostname: str, custom_domain: str = "", dry_run: bool = False
+) -> bool:
+    """Sync CIAM redirect URIs. Returns True if update was applied or not needed."""
+    current = get_current_redirect_uris(token)
+    if current is None:
+        print("Failed to fetch current redirect URIs")
+        return False
+
+    desired = build_desired_uris(swa_hostname, custom_domain)
+
+    if set(current) == set(desired):
+        print("Redirect URIs already up to date:")
+        for u in current:
+            print(f"  {u}")
+        return True
+
+    print("Current redirect URIs:")
+    for u in current:
+        print(f"  {u}")
+    print("Desired redirect URIs:")
+    for u in desired:
+        marker = " (new)" if u not in current else ""
+        print(f"  {u}{marker}")
+
+    removed = set(current) - set(desired)
+    if removed:
+        print("Will remove:")
+        for u in removed:
+            print(f"  {u}")
+
+    if dry_run:
+        print("Dry run — no changes applied")
+        return True
+
+    result = graph_api(
+        "PATCH",
+        f"/applications/{APP_OBJECT_ID}",
+        body={"spa": {"redirectUris": desired}},
+        token=token,
+    )
+    if result is None:
+        print("Failed to update redirect URIs")
+        return False
+
+    print("Redirect URIs updated successfully")
+    return True
+
+
+def _acquire_token() -> str:
+    """Resolve a Graph API bearer token.
+
+    Checks CIAM_TOKEN env var first, then falls back to `az account
+    get-access-token` against the CIAM tenant (works with OIDC in CI).
+    """
+    token = os.environ.get("CIAM_TOKEN", "")
+    if token:
+        return token
+
+    # Try az CLI — the workflow logs in to the CIAM tenant before calling this
+    try:
+        result = subprocess.run(
+            [
+                "az",
+                "account",
+                "get-access-token",
+                "--tenant",
+                TENANT_ID,
+                "--resource",
+                "https://graph.microsoft.com",
+                "--query",
+                "accessToken",
+                "--output",
+                "tsv",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            print("Acquired Graph token via az CLI (OIDC)")
+            return result.stdout.strip()
+    except FileNotFoundError:
+        pass  # az CLI not installed
+    except subprocess.TimeoutExpired:
+        pass
+
+    return ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Sync CIAM redirect URIs with SWA hostname")
+    parser.add_argument(
+        "swa_hostname",
+        nargs="?",
+        help="SWA default hostname (e.g. green-moss-0e849ac03.2.azurestaticapps.net)",
+    )
+    parser.add_argument("--custom-domain", default="", help="Custom domain if configured")
+    parser.add_argument("--dry-run", action="store_true", help="Show changes without applying")
+    args = parser.parse_args()
+
+    token = _acquire_token()
+    if not token:
+        print("ERROR: No Graph API token available.")
+        print(
+            "  Set CIAM_TOKEN env var, or ensure `az login` has been run against the CIAM tenant."
+        )
+        return 1
+
+    swa_hostname = args.swa_hostname or os.environ.get("SWA_HOSTNAME", "")
+    if not swa_hostname:
+        print("ERROR: Provide SWA hostname as argument or set SWA_HOSTNAME env var")
+        return 1
+
+    # Strip protocol if accidentally included
+    swa_hostname = swa_hostname.removeprefix("https://").removeprefix("http://")
+
+    ok = sync_redirect_uris(token, swa_hostname, args.custom_domain, args.dry_run)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Housekeeping PR collecting docs, tooling, and instruction updates from recent sessions.

## Changes

### Roadmap
- Add **Stage 2B — Event-Driven Pipeline Restructure** (#420–#424)
- Update Recently Landed and In Flight sections

### Copilot Instructions & Agents
- Add clean-branch discipline rule to Delivery Workflow
- Add `engineering-standards.instructions.md` (test-first, functional style, let-it-crash)
- Add `codebase-quickref.instructions.md` (always-on project layout reference)
- Update Code Review Critic agent to enforce engineering standards
- Add test-first principle to copilot-instructions.md

### CIAM Automation
- Add `scripts/sync_ciam_redirect_uris.py` — syncs CIAM redirect URIs from SWA hostnames
- Add `scripts/setup_ciam_deploy_access.py` — grants OIDC access for deploy workflow
- Add CIAM sync step to `deploy.yml` (uses `vars` context for conditional steps)

### Docs
- Update ARCHITECTURE_OVERVIEW, API_INTERFACE_REFERENCE, OPERATIONS_RUNBOOK
- Add tofu outputs for CIAM tenant/app IDs