### PR TITLE
fix: add api_location to SWA deploy for managed functions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -514,8 +514,8 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: upload
           app_location: /website
+          api_location: /website/api
           skip_app_build: true
-          skip_api_build: true
 
       - name: Login to CIAM tenant (OIDC)
         if: ${{ vars.CIAM_TENANT_ID != '' }}

--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -396,6 +396,12 @@ class TestDeployWorkflowSettings:
             "HTML meta tags before SWA upload"
         )
 
+    def test_swa_deploy_includes_api_location(self, deploy_yml):
+        assert "api_location" in deploy_yml, (
+            "deploy.yml SWA deploy must set api_location so managed functions "
+            "(upload/token, upload/status) are deployed"
+        )
+
     def test_workflow_dispatch_supports_manual_teardown_rebuild(self, deploy_yml):
         assert "rebuild_after_manual_teardown" in deploy_yml, (
             "deploy.yml manual dispatch must allow rebuilding dev after a manual teardown"


### PR DESCRIPTION
## Problem\n\nThe SWA deploy action in `deploy.yml` was missing `api_location`, so the managed Python functions in `website/api/` (upload/token, upload/status) were never deployed. POST requests to `/api/upload/token` returned HTTP 405 (Method Not Allowed) from SWA's static handler instead of reaching the function.\n\n## Fix\n\n- Add `api_location: /website/api` to the SWA deploy step\n- Remove `skip_api_build: true` so SWA installs Python deps from `requirements.txt`\n- Add launch readiness test to prevent regression\n\n## Validation\n\n- Verified 405 response from live SWA (`Allow: GET, HEAD, OPTIONS`)\n- All 72 launch readiness tests pass\n- Re-deploy will be tracked to confirm 401 (auth gate) replaces 405