### PR TITLE
fix: guard SWA role assignments for first-deploy bootstrap

### DIFF
--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -808,12 +808,14 @@ resource "azurerm_role_assignment" "storage_blob_data_owner" {
 
 # SWA managed identity — blob writes (ticket blobs) + user delegation SAS
 resource "azurerm_role_assignment" "swa_storage_blob_data_contributor" {
+  count                = length(try(azurerm_static_web_app.main.identity, [])) > 0 ? 1 : 0
   scope                = azurerm_storage_account.main.id
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = azurerm_static_web_app.main.identity[0].principal_id
 }
 
 resource "azurerm_role_assignment" "swa_storage_blob_delegator" {
+  count                = length(try(azurerm_static_web_app.main.identity, [])) > 0 ? 1 : 0
   scope                = azurerm_storage_account.main.id
   role_definition_name = "Storage Blob Delegator"
   principal_id         = azurerm_static_web_app.main.identity[0].principal_id


### PR DESCRIPTION
## Problem\n\nPR #430 added SystemAssigned identity to the SWA resource + role assignments referencing `identity[0].principal_id`. On first deploy, the identity doesn't exist in state yet, so `identity[0]` indexes an empty list and tofu plan fails:\n\n```\nError: Missing required argument\n  with azurerm_role_assignment.swa_storage_blob_data_contributor\n  The argument \"principal_id\" is required, but no definition was found.\n```\n\n## Fix\n\nGuard the SWA role assignments with `count = length(try(azurerm_static_web_app.main.identity, [])) > 0 ? 1 : 0`.\n\n- **First deploy (this PR):** SWA gets identity + app_settings. Role assignments skipped (count=0).\n- **Second deploy (manual dispatch):** Identity in state → count=1 → role assignments created.\n\nThe SWA managed API upload endpoint won't fully function until the second deploy assigns the Blob Delegator role."