### PR TITLE
fix: remove stale count guards from SWA role assignments

### DIFF
--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -816,14 +816,12 @@ resource "azurerm_role_assignment" "storage_blob_data_owner" {
 
 # SWA managed identity — blob writes (ticket blobs) + user delegation SAS
 resource "azurerm_role_assignment" "swa_storage_blob_data_contributor" {
-  count                = length(try(azurerm_static_web_app.main.identity, [])) > 0 ? 1 : 0
   scope                = azurerm_storage_account.main.id
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = azurerm_user_assigned_identity.swa.principal_id
 }
 
 resource "azurerm_role_assignment" "swa_storage_blob_delegator" {
-  count                = length(try(azurerm_static_web_app.main.identity, [])) > 0 ? 1 : 0
   scope                = azurerm_storage_account.main.id
   role_definition_name = "Storage Blob Delegator"
   principal_id         = azurerm_user_assigned_identity.swa.principal_id


### PR DESCRIPTION
Removes the stale `count = length(try(azurerm_static_web_app.main.identity, []))` guards left on the SWA role assignments after squash-merging PRs #432 and #433.\n\nWith the UserAssigned identity from #433, `principal_id` comes from `azurerm_user_assigned_identity.swa` which is known at plan time — no count guard needed."