### PR TITLE
fix: resolve code scanning alerts — URL sanitisation, mixed imports, except comments (#381)

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -72,7 +72,7 @@ class TestOidcConfigUrl:
             path_segments = parsed.path.strip("/").split("/")
             # First path segment must be the exact tenant domain
             assert path_segments[0] == "mytenant.onmicrosoft.com"
-            assert url.endswith("/v2.0/.well-known/openid-configuration")
+            assert parsed.path.endswith("/v2.0/.well-known/openid-configuration")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,59 +8,42 @@ from unittest.mock import patch
 
 import pytest
 
+from treesight.config import config_get_int, validate_config
 from treesight.errors import ConfigValidationError
 
 
 class TestConfigGetInt:
     def test_int_value(self):
-        from treesight.config import config_get_int
-
         assert config_get_int({"x": 42}, "x", 0) == 42
 
     def test_string_value(self):
-        from treesight.config import config_get_int
-
         assert config_get_int({"x": "10"}, "x", 0) == 10
 
     def test_float_string_raises(self):
-        from treesight.config import config_get_int
-
         with pytest.raises(ValueError):
             config_get_int({"x": "3.9"}, "x", 0)
 
     def test_missing_key_returns_default(self):
-        from treesight.config import config_get_int
-
         assert config_get_int({}, "x", 99) == 99
 
     def test_none_value_returns_default(self):
-        from treesight.config import config_get_int
-
         assert config_get_int({"x": None}, "x", 7) == 7
 
     def test_garbage_string_raises(self):
-        from treesight.config import config_get_int
-
         with pytest.raises(ValueError):
             config_get_int({"x": "not-a-number"}, "x", 5)
 
     def test_float_value_non_integer_raises(self):
-        from treesight.config import config_get_int
-
         with pytest.raises(ValueError):
             config_get_int({"x": 3.7}, "x", 0)
 
     def test_float_value_integer_ok(self):
-        from treesight.config import config_get_int
-
         assert config_get_int({"x": 4.0}, "x", 0) == 4
 
 
 class TestValidateConfig:
     def test_valid_defaults_pass(self):
         """Default env should pass validation (no errors)."""
-        from treesight.config import validate_config
-
         validate_config()  # Should not raise
 
     def test_invalid_resolution_raises(self):

--- a/tests/test_frontend_config.py
+++ b/tests/test_frontend_config.py
@@ -58,17 +58,11 @@ class TestSwaAuth:
         reg = aad.get("registration", {})
         issuer = reg.get("openIdIssuer", "")
         parsed = urlparse(issuer)
-        valid = (
-            parsed.scheme == "https"
-            and (
-                parsed.hostname is not None
-                and (
-                    parsed.hostname.endswith(".ciamlogin.com")
-                    or parsed.hostname.endswith(".login.microsoftonline.com")
-                )
-            )
-            and parsed.path.endswith("/v2.0")
-        )
+        hostname = parsed.hostname or ""
+        host_labels = hostname.split(".")
+        is_ciam = len(host_labels) >= 3 and host_labels[-2:] == ["ciamlogin", "com"]
+        is_aad = len(host_labels) >= 4 and host_labels[-3:] == ["login", "microsoftonline", "com"]
+        valid = parsed.scheme == "https" and (is_ciam or is_aad) and parsed.path.endswith("/v2.0")
         assert valid, (
             "openIdIssuer must be a full https URL pointing to a valid Azure OIDC v2.0 endpoint"
         )
@@ -171,8 +165,8 @@ class TestCsp:
         csp = swa_config["globalHeaders"]["Content-Security-Policy"]
         connect_match = re.search(r"connect-src\s+([^;]+)", csp)
         assert connect_match, "CSP missing connect-src directive"
-        sources = connect_match.group(1)
-        assert "ciamlogin.com" not in sources, (
+        tokens = connect_match.group(1).split()
+        assert not any(_csp_token_matches_host(src, "ciamlogin.com") for src in tokens), (
             "connect-src still references ciamlogin.com — remove (SWA handles auth)"
         )
 

--- a/tests/test_valet.py
+++ b/tests/test_valet.py
@@ -7,12 +7,8 @@ import time
 
 import pytest
 
-from treesight.security.replay import InMemoryReplayStore
-from treesight.security.valet import (
-    mint_valet_token,
-    set_replay_store,
-    verify_valet_token,
-)
+import treesight.security.replay as replay_mod
+import treesight.security.valet as valet_mod
 
 SECRET = "test-valet-secret-32chars-min!!"  # pragma: allowlist secret
 
@@ -20,15 +16,15 @@ SECRET = "test-valet-secret-32chars-min!!"  # pragma: allowlist secret
 @pytest.fixture(autouse=True)
 def _clear_replay():
     """Reset replay store to a fresh InMemoryReplayStore between tests."""
-    store = InMemoryReplayStore()
-    set_replay_store(store)
+    store = replay_mod.InMemoryReplayStore()
+    valet_mod.set_replay_store(store)
     yield
-    set_replay_store(InMemoryReplayStore())
+    valet_mod.set_replay_store(replay_mod.InMemoryReplayStore())
 
 
 class TestMintValetToken:
     def test_returns_string(self):
-        token = mint_valet_token(
+        token = valet_mod.mint_valet_token(
             submission_id="sub-1",
             submission_blob_name="demo/sub-1.kml",
             artifact_path="imagery/raw/test.tif",
@@ -42,13 +38,13 @@ class TestMintValetToken:
     def test_no_secret_raises(self, monkeypatch):
         monkeypatch.setenv("DEMO_VALET_TOKEN_SECRET", "")
         config_mod = importlib.import_module("treesight.config")
-        valet_mod = importlib.import_module("treesight.security.valet")
+        reloaded_valet = importlib.import_module("treesight.security.valet")
 
         importlib.reload(config_mod)
-        importlib.reload(valet_mod)
+        importlib.reload(reloaded_valet)
         try:
             with pytest.raises(ValueError, match="not configured"):
-                valet_mod.mint_valet_token(
+                reloaded_valet.mint_valet_token(
                     submission_id="sub-1",
                     submission_blob_name="demo/sub-1.kml",
                     artifact_path="test.tif",
@@ -59,7 +55,7 @@ class TestMintValetToken:
         finally:
             monkeypatch.setenv("DEMO_VALET_TOKEN_SECRET", "test-secret-key-for-unit-tests-only")
             importlib.reload(config_mod)
-            importlib.reload(valet_mod)
+            importlib.reload(reloaded_valet)
 
 
 class TestVerifyValetToken:
@@ -73,11 +69,11 @@ class TestVerifyValetToken:
             "secret": SECRET,
         }
         defaults.update(kwargs)
-        return mint_valet_token(**defaults)
+        return valet_mod.mint_valet_token(**defaults)
 
     def test_valid_token(self):
         token = self._mint()
-        claims = verify_valet_token(token, secret=SECRET)
+        claims = valet_mod.verify_valet_token(token, secret=SECRET)
         assert claims["submission_id"] == "sub-1"
         assert claims["artifact_path"] == "imagery/raw/test.tif"
 
@@ -87,34 +83,35 @@ class TestVerifyValetToken:
         parts = token.split(".")
         tampered = parts[0] + ".AAAA" + parts[1][4:]
         with pytest.raises(ValueError):
-            verify_valet_token(tampered, secret=SECRET)
+            valet_mod.verify_valet_token(tampered, secret=SECRET)
 
     def test_wrong_secret_rejected(self):
         token = self._mint()
+        wrong = "wrong-secret-entirely"  # pragma: allowlist secret
         with pytest.raises(ValueError, match="Invalid token signature"):
-            verify_valet_token(token, secret="wrong-secret-entirely")  # pragma: allowlist secret
+            valet_mod.verify_valet_token(token, secret=wrong)
 
     def test_expired_token_rejected(self):
         token = self._mint(ttl_seconds=0)
         time.sleep(0.1)
         with pytest.raises(ValueError, match="expired"):
-            verify_valet_token(token, secret=SECRET)
+            valet_mod.verify_valet_token(token, secret=SECRET)
 
     def test_replay_limit(self):
         token = self._mint(max_uses=2)
         # First two uses succeed
-        verify_valet_token(token, secret=SECRET)
-        verify_valet_token(token, secret=SECRET)
+        valet_mod.verify_valet_token(token, secret=SECRET)
+        valet_mod.verify_valet_token(token, secret=SECRET)
         # Third use fails
         with pytest.raises(ValueError, match="replay limit"):
-            verify_valet_token(token, secret=SECRET)
+            valet_mod.verify_valet_token(token, secret=SECRET)
 
     def test_malformed_token(self):
         with pytest.raises(ValueError, match="Malformed"):
-            verify_valet_token("no-dot-separator", secret=SECRET)
+            valet_mod.verify_valet_token("no-dot-separator", secret=SECRET)
 
     def test_recipient_email_hashed(self):
         token = self._mint()
-        claims = verify_valet_token(token, secret=SECRET)
+        claims = valet_mod.verify_valet_token(token, secret=SECRET)
         assert "recipient_hash" in claims
         assert "@" not in claims.get("recipient_hash", "")

--- a/treesight/ai/client.py
+++ b/treesight/ai/client.py
@@ -132,7 +132,7 @@ def _try_cache_read(cache_key: str) -> dict[str, Any] | None:
             logger.info("AI cache hit: %s", cache_key)
             result["_cached"] = True
             return result
-    except Exception:
+    except Exception:  # broad: cache is best-effort, any failure is non-fatal
         logger.debug("Cache read failed for %s", cache_key, exc_info=True)
     return None
 
@@ -148,7 +148,7 @@ def _cache_write(cache_key: str, result: dict[str, Any]) -> None:
         blob_path = f"{AI_CACHE_PREFIX}{cache_key}.json"
         client.upload_json(AI_CACHE_CONTAINER, blob_path, result)
         logger.info("AI cache write: %s", cache_key)
-    except Exception:
+    except Exception:  # broad: cache is best-effort, any failure is non-fatal
         logger.debug("Cache write failed for %s", cache_key, exc_info=True)
 
 
@@ -192,7 +192,7 @@ def _call_azure_ai(prompt: str) -> str | None:
             data = resp.json()
             _azure_circuit.record_success()
             return data["choices"][0]["message"]["content"]
-    except Exception:
+    except Exception:  # broad: Azure AI is optional, failures produce None
         logger.warning("Azure AI call failed", exc_info=True)
         _azure_circuit.record_failure()
         return None
@@ -218,7 +218,7 @@ def _call_ollama(prompt: str) -> str | None:
             resp.raise_for_status()
             _ollama_circuit.record_success()
             return resp.json().get("response", "")
-    except Exception:
+    except Exception:  # broad: Ollama is optional fallback, failures produce None
         logger.warning("Ollama call failed", exc_info=True)
         _ollama_circuit.record_failure()
         return None


### PR DESCRIPTION
## Summary

Resolves ~20 code scanning alerts (CodeQL + Trivy) per #381.

### URL substring sanitization
- **test_auth.py** (#87, #88): `url.endswith()` → `parsed.path.endswith()` — check parsed path component, not raw URL string
- **test_frontend_config.py** (#2733-2738): hostname `.endswith()` → label-based domain suffix check; CSP `"ciamlogin.com" not in` → tokenized `_csp_token_matches_host()`

### Code quality
- **test_config.py** (#65, #66): moved repeated inline `from treesight.config import ...` to module-level imports
- **test_valet.py** (#67): replaced mixed `from X import Y` + `importlib.import_module()` with consistent module-reference style
- **ai/client.py** (#79): added justification comments to broad `except Exception:` blocks (cache, AI calls are non-fatal)

### Already resolved (verified present)
- dev_server.py (#64): urlparse + normpath + /api/ prefix enforcement ✅
- planetary_computer.py (#77): `super().__init__()` present ✅
- _azurite.py (#69, #70): `__all__` export list present ✅
- _helpers.py: `urlparse()` for blob URL parsing ✅
- main.tf (#102): `infrastructure_encryption_enabled = true` ✅
- test_launch_readiness.py (#2755-2757): token-based `_csp_token_matches_host()` parsing ✅

### False positives / won't fix (per issue body)
- #2722: clear-text logging of public USGS geo data
- #72-76, #78: Abstract method/Protocol `...` bodies (standard Python)
- #100: Storage logging (adds cost)
- #101: Geo-redundancy (adds cost)
- #2812, #2813: pip CVEs in base Docker image (upstream)

Fixes #381
Supersedes #379, #380