### PR TITLE
fix: replace DefaultAzureCredential with account keys in SWA API

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -124,22 +120,8 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
-    },
-    {
-      "path": "detect_secrets.filters.regex.should_exclude_file",
-      "pattern": [
-        "\\.lock$",
-        "uv\\.lock$",
-        "\\.tfstate"
-      ]
-    },
-    {
-      "path": "detect_secrets.filters.regex.should_exclude_secret",
-      "pattern": [
-        "sha384-"
-      ]
     }
   ],
   "results": {},
-  "generated_at": "2026-04-10T17:48:40Z"
+  "generated_at": "2026-04-10T20:44:51Z"
 }

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -836,7 +836,9 @@ resource "azurerm_role_assignment" "storage_blob_data_owner" {
   principal_id         = azapi_resource.function_app.identity[0].principal_id
 }
 
-# SWA managed identity — blob writes (ticket blobs) + user delegation SAS
+# SWA managed identity — kept for future use if SWA adds managed identity
+# support.  Currently unused: SWA managed functions authenticate to storage
+# and Cosmos with account keys (see #498).
 resource "azurerm_role_assignment" "swa_storage_blob_data_contributor" {
   scope                = azurerm_storage_account.main.id
   role_definition_name = "Storage Blob Data Contributor"
@@ -963,17 +965,19 @@ locals {
   # SWA managed API settings (upload/token, upload/status, billing/status,
   # billing/checkout, billing/portal, contact-form, readiness, contract,
   # analysis/history endpoints).
-  # Auth uses user-assigned managed identity — no storage key needed.
+  # SWA managed functions do NOT support managed identity or Key Vault
+  # references — use account keys directly.
   swa_api_app_settings = merge(
     {
       STORAGE_ACCOUNT_NAME                  = azurerm_storage_account.main.name
+      STORAGE_ACCOUNT_KEY                   = azurerm_storage_account.main.primary_access_key
       INPUT_CONTAINER                       = "kml-input"
-      AZURE_CLIENT_ID                       = azurerm_user_assigned_identity.swa.client_id
       APPLICATIONINSIGHTS_CONNECTION_STRING = azurerm_application_insights.main.connection_string
       OTEL_SERVICE_NAME                     = "canopex-swa-api"
     },
     var.enable_cosmos_db ? {
       COSMOS_ENDPOINT      = azurerm_cosmosdb_account.main[0].endpoint
+      COSMOS_KEY           = azurerm_cosmosdb_account.main[0].primary_key
       COSMOS_DATABASE_NAME = azurerm_cosmosdb_sql_database.main[0].name
     } : {},
     var.enable_stripe ? {

--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -502,28 +502,33 @@ class TestStripeKeyVaultBootstrap:
             "outputs.tf must expose the CLI-managed Function App scale cap"
         )
 
-    def test_swa_uses_managed_identity(self):
+    def test_swa_has_storage_account_key_in_settings(self):
+        """SWA app settings must include STORAGE_ACCOUNT_KEY for blob access."""
         main_tf = MAIN_TF.read_text()
-        assert "identity" in main_tf, (
-            "SWA resource must have identity block for managed identity auth"
+        assert "STORAGE_ACCOUNT_KEY" in main_tf, (
+            "SWA app settings must include STORAGE_ACCOUNT_KEY "
+            "(managed identity not available in SWA managed functions)"
         )
-        assert "swa_storage_blob_delegator" in main_tf, (
-            "SWA must have Storage Blob Delegator role for user delegation SAS"
-        )
-        assert "swa_storage_blob_data_contributor" in main_tf, (
-            "SWA must have Storage Blob Data Contributor role for ticket blob writes"
+        assert "COSMOS_KEY" in main_tf, (
+            "SWA app settings must include COSMOS_KEY "
+            "(managed identity not available in SWA managed functions)"
         )
 
-    def test_swa_api_uses_default_credential(self):
+    def test_swa_api_uses_account_key_auth(self):
+        """SWA managed functions cannot use managed identity — verify account key auth."""
         api_code = (ROOT / "website" / "api" / "function_app.py").read_text()
-        assert "DefaultAzureCredential" in api_code, (
-            "SWA API must use DefaultAzureCredential (managed identity), not storage keys"
+        assert "STORAGE_ACCOUNT_KEY" in api_code, (
+            "SWA API must use STORAGE_ACCOUNT_KEY (managed identity unavailable)"
         )
-        assert "STORAGE_ACCOUNT_KEY" not in api_code, (
-            "SWA API must not reference STORAGE_ACCOUNT_KEY — use managed identity"
+        assert "COSMOS_KEY" in api_code, (
+            "SWA API must use COSMOS_KEY (managed identity unavailable)"
         )
-        assert "user_delegation_key" in api_code, (
-            "SWA API must use user delegation SAS, not account-key SAS"
+        assert "DefaultAzureCredential" not in api_code, (
+            "SWA API must NOT use DefaultAzureCredential — SWA managed functions "
+            "do not support managed identity"
+        )
+        assert "account_key" in api_code, (
+            "SAS generation must use account_key, not user_delegation_key"
         )
 
     def test_deployer_still_has_key_vault_secret_access(self):

--- a/tests/test_swa_api.py
+++ b/tests/test_swa_api.py
@@ -41,6 +41,7 @@ _SWA_MODULE_NAME = "swa_function_app"
 def _swa_env(monkeypatch):
     """Set environment variables for the SWA API module."""
     monkeypatch.setenv("STORAGE_ACCOUNT_NAME", "teststorage")
+    monkeypatch.setenv("STORAGE_ACCOUNT_KEY", "dGVzdC1rZXk=")  # base64 "test-key"
     monkeypatch.setenv("INPUT_CONTAINER", "kml-input")
     monkeypatch.setenv("SAS_TOKEN_EXPIRY_MINUTES", "15")
 
@@ -256,12 +257,12 @@ class TestUploadToken:
         assert perms.write is True
         assert perms.read is not True
         assert perms.delete is not True
-        # Must use user delegation key, not account key
-        assert "user_delegation_key" in call_kwargs, (
-            "SAS must be generated with user_delegation_key (managed identity)"
+        # SWA managed functions use account key SAS (no managed identity)
+        assert "account_key" in call_kwargs, (
+            "SAS must be generated with account_key (SWA has no managed identity)"
         )
-        assert "account_key" not in call_kwargs, (
-            "SAS must NOT use account_key — use managed identity delegation"
+        assert "user_delegation_key" not in call_kwargs, (
+            "SAS must NOT use user_delegation_key — SWA has no managed identity"
         )
 
     @patch("swa_function_app._get_blob_service")
@@ -351,16 +352,23 @@ class TestUploadToken:
 
     @patch("swa_function_app._get_blob_service")
     @patch("swa_function_app.generate_blob_sas")
-    def test_returns_502_on_delegation_key_failure(self, mock_sas, mock_blob_svc, _reload_module):
-        """When user delegation key request fails, return 502."""
+    def test_sas_uses_account_key_from_env(self, mock_sas, mock_blob_svc, _reload_module):
+        """SAS must use the account key from STORAGE_ACCOUNT_KEY env var."""
         mod = _reload_module
-        mock_blob_svc.return_value.get_user_delegation_key.side_effect = RuntimeError(
-            "identity not ready"
+        mock_sas.return_value = "sig=test"
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(
+            mod,
+            "STORAGE_ACCOUNT_KEY",
+            "test-key-value",  # pragma: allowlist secret
         )
 
         req = _mock_request(headers=_auth_headers())
-        resp = mod.upload_token(req)
-        assert resp.status_code == 502
+        mod.upload_token(req)
+
+        call_kwargs = mock_sas.call_args[1]
+        assert call_kwargs["account_key"] == "test-key-value"  # pragma: allowlist secret
+        monkeypatch.undo()
 
     @patch("swa_function_app._get_blob_service")
     @patch("swa_function_app.generate_blob_sas")

--- a/website/api/function_app.py
+++ b/website/api/function_app.py
@@ -12,16 +12,22 @@ pre-configured providers.  SWA injects user identity via the
 
 Environment variables (set via SWA app_settings in OpenTofu):
   STORAGE_ACCOUNT_NAME   — storage account for SAS token generation
+  STORAGE_ACCOUNT_KEY    — storage account key (managed identity unavailable)
   SAS_TOKEN_EXPIRY_MINUTES — SAS token lifetime (default: 15)
-  STRIPE_API_KEY         — Stripe secret key (Key Vault reference)
+  STRIPE_API_KEY         — Stripe secret key
   STRIPE_PRICE_ID_PRO_*  — Stripe Price IDs per currency
   BILLING_ALLOWED_USERS  — comma-separated user IDs allowed to use billing
   COMMUNICATION_SERVICES_CONNECTION_STRING — ACS connection string (email)
   EMAIL_SENDER_ADDRESS   — sender address for email notifications
   NOTIFICATION_EMAIL     — recipient for contact-form notifications
+  COSMOS_ENDPOINT        — Cosmos DB account endpoint
+  COSMOS_KEY             — Cosmos DB account key (managed identity unavailable)
+  COSMOS_DATABASE_NAME   — Cosmos DB database name (default: canopex)
 
-Authentication to Azure Storage uses the SWA's user-assigned managed
-identity (DefaultAzureCredential + AZURE_CLIENT_ID) — no shared secrets.
+Note: SWA managed functions do NOT support managed identity or Key Vault
+references (see https://learn.microsoft.com/en-us/azure/static-web-apps/
+apis-functions#constraints).  Authentication to Azure Storage and Cosmos DB
+uses account keys passed via app settings.
 """
 
 from __future__ import annotations
@@ -38,7 +44,6 @@ import time
 import uuid
 
 import azure.functions as func
-from azure.identity import DefaultAzureCredential
 from azure.storage.blob import (
     BlobSasPermissions,
     BlobServiceClient,
@@ -54,12 +59,14 @@ logger = logging.getLogger("swa-api")
 # ---------------------------------------------------------------------------
 
 STORAGE_ACCOUNT_NAME = os.environ.get("STORAGE_ACCOUNT_NAME", "")
+STORAGE_ACCOUNT_KEY = os.environ.get("STORAGE_ACCOUNT_KEY", "")
 INPUT_CONTAINER = os.environ.get("INPUT_CONTAINER", "kml-input")
 SAS_TOKEN_EXPIRY_MINUTES = int(os.environ.get("SAS_TOKEN_EXPIRY_MINUTES", "15"))
 MAX_UPLOAD_BYTES = 10_485_760  # 10 MiB — matches treesight MAX_KML_FILE_SIZE_BYTES
 
 # Cosmos DB (for billing/status, analysis/history)
 COSMOS_ENDPOINT = os.environ.get("COSMOS_ENDPOINT", "")
+COSMOS_KEY = os.environ.get("COSMOS_KEY", "")
 COSMOS_DATABASE_NAME = os.environ.get("COSMOS_DATABASE_NAME", "canopex")
 
 # Stripe billing
@@ -277,28 +284,40 @@ def health(req: func.HttpRequest) -> func.HttpResponse:
 
 
 def _get_blob_service() -> BlobServiceClient:
-    """Lazy-init BlobServiceClient with managed identity credential."""
+    """Lazy-init BlobServiceClient with account key credential.
+
+    SWA managed functions do not support managed identity, so we
+    authenticate with the storage account key.
+    """
     global _blob_service
     if _blob_service is None:
         if not STORAGE_ACCOUNT_NAME:
             raise RuntimeError("STORAGE_ACCOUNT_NAME is not configured")
+        if not STORAGE_ACCOUNT_KEY:
+            raise RuntimeError("STORAGE_ACCOUNT_KEY is not configured")
         account_url = f"https://{STORAGE_ACCOUNT_NAME}.blob.core.windows.net"
         _blob_service = BlobServiceClient(
             account_url=account_url,
-            credential=DefaultAzureCredential(),
+            credential=STORAGE_ACCOUNT_KEY,
         )
     return _blob_service
 
 
 def _get_cosmos_container(container_name: str):
-    """Return a Cosmos DB container proxy, lazily initialising the database client."""
+    """Return a Cosmos DB container proxy, lazily initialising the database client.
+
+    SWA managed functions do not support managed identity, so we
+    authenticate with the Cosmos account key.
+    """
     global _cosmos_db
     if _cosmos_db is None:
         if not COSMOS_ENDPOINT:
             raise RuntimeError("COSMOS_ENDPOINT is not configured")
+        if not COSMOS_KEY:
+            raise RuntimeError("COSMOS_KEY is not configured")
         from azure.cosmos import CosmosClient
 
-        client = CosmosClient(COSMOS_ENDPOINT, credential=DefaultAzureCredential())
+        client = CosmosClient(COSMOS_ENDPOINT, credential=COSMOS_KEY)
         _cosmos_db = client.get_database_client(COSMOS_DATABASE_NAME)
     return _cosmos_db.get_container_client(container_name)
 
@@ -445,20 +464,11 @@ def upload_token(req: func.HttpRequest) -> func.HttpResponse:
     now = datetime.datetime.now(datetime.UTC)
     expiry = now + datetime.timedelta(minutes=SAS_TOKEN_EXPIRY_MINUTES)
 
-    try:
-        delegation_key = blob_service.get_user_delegation_key(
-            key_start_time=now,
-            key_expiry_time=expiry,
-        )
-    except Exception:
-        logger.exception("Failed to obtain user delegation key")
-        return _error(502, "Storage service temporarily unavailable")
-
     sas_token = generate_blob_sas(
         account_name=STORAGE_ACCOUNT_NAME,
         container_name=INPUT_CONTAINER,
         blob_name=blob_name,
-        user_delegation_key=delegation_key,
+        account_key=STORAGE_ACCOUNT_KEY,
         permission=BlobSasPermissions(create=True, write=True),
         expiry=expiry,
         content_type="application/vnd.google-earth.kml+xml",

--- a/website/api/requirements.txt
+++ b/website/api/requirements.txt
@@ -1,5 +1,4 @@
 azure-functions
-azure-identity
 azure-storage-blob
 azure-cosmos
 azure-communication-email


### PR DESCRIPTION
## Superseded by BYOF Consolidation

This PR adds account-key auth to the SWA managed API as a workaround for #498 (no managed identity support). However, the P3 roadmap decision is to **delete the SWA managed API entirely** and consolidate all endpoints onto the Container Apps Function App.

PR #510 adds the last two SWA-only endpoints (`upload/token`, `upload/status`) to Container Apps. Once that merges, all 14 SWA endpoints are fully duplicated and the SWA API can be deleted.

Closing as superseded — the workaround is no longer needed.