### PR TITLE
feat: add upload/token and upload/status BFF endpoints

### DIFF
--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -1,0 +1,230 @@
+"""Upload BFF endpoints — SAS minting and status polling.
+
+These endpoints serve the user-interactive upload flow.
+They are lightweight reads/writes that keep the BFF responsive while
+the pipeline runs asynchronously on Container Apps.
+
+NOTE: Do NOT add ``from __future__ import annotations`` to blueprint modules.
+The Azure Functions worker inspects function signatures at import time
+and ``from __future__ import annotations`` turns all annotations into
+strings, which breaks binding resolution.
+"""
+
+import datetime
+import json
+import logging
+import uuid
+
+import azure.functions as func
+from azure.storage.blob import (
+    BlobSasPermissions,
+    ContentSettings,
+    generate_blob_sas,
+)
+
+from treesight.config import STORAGE_ACCOUNT_NAME
+from treesight.constants import DEFAULT_INPUT_CONTAINER, MAX_KML_FILE_SIZE_BYTES
+from treesight.storage import cosmos as _cosmos_mod
+from treesight.storage.client import get_blob_service_client
+
+from ._helpers import cors_headers, error_response, require_auth
+
+logger = logging.getLogger(__name__)
+
+bp = func.Blueprint()
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_SAS_TOKEN_EXPIRY_MINUTES = 15
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sanitise_submission_context(ctx: dict) -> dict:
+    """Allow-list filter for submission context fields."""
+    clean: dict = {}
+    for field in ("feature_count", "aoi_count"):
+        value = ctx.get(field)
+        if isinstance(value, (int, float)) and value >= 0:
+            clean[field] = int(value)
+    for field in ("max_spread_km", "total_area_ha", "largest_area_ha"):
+        value = ctx.get(field)
+        if isinstance(value, (int, float)) and value >= 0:
+            clean[field] = round(float(value), 2)
+    for field in ("processing_mode", "provider_name", "workspace_role", "workspace_preference"):
+        value = ctx.get(field)
+        if isinstance(value, str) and value.strip():
+            clean[field] = value.strip()[:80]
+    return clean
+
+
+# ---------------------------------------------------------------------------
+# POST /api/upload/token — mint a time-limited, write-only SAS URL
+# ---------------------------------------------------------------------------
+
+
+@bp.route(route="upload/token", methods=["POST", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
+@require_auth
+def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> func.HttpResponse:
+    """Mint a write-only SAS URL for direct-to-blob KML upload."""
+    if not user_id:
+        return error_response(401, "Missing user identity", req=req)
+
+    if not STORAGE_ACCOUNT_NAME:
+        logger.error("Storage account not configured for SAS generation")
+        return error_response(503, "Service not configured", req=req)
+
+    submission_id = str(uuid.uuid4())
+    blob_name = f"analysis/{submission_id}.kml"
+
+    # Parse optional submission context from request body
+    try:
+        body = json.loads(req.get_body()) if req.get_body() else {}
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        body = {}
+
+    # Write ticket blob — trusted server-side record of who initiated the upload
+    ticket: dict = {
+        "user_id": user_id,
+        "created_at": datetime.datetime.now(datetime.UTC).isoformat(),
+    }
+    provider = body.get("provider_name")
+    if isinstance(provider, str) and provider.strip():
+        ticket["provider_name"] = provider.strip()[:80]
+    ctx = body.get("submission_context")
+    if isinstance(ctx, dict):
+        ticket["submission_context"] = _sanitise_submission_context(ctx)
+
+    try:
+        blob_service = get_blob_service_client()
+        ticket_blob = blob_service.get_blob_client(
+            DEFAULT_INPUT_CONTAINER, f".tickets/{submission_id}.json"
+        )
+        ticket_blob.upload_blob(
+            json.dumps(ticket).encode(),
+            overwrite=True,
+            content_settings=ContentSettings(content_type="application/json"),
+        )
+    except Exception:
+        logger.exception("Failed to write ticket for submission_id=%s", submission_id)
+        return error_response(502, "Storage service temporarily unavailable", req=req)
+
+    now = datetime.datetime.now(datetime.UTC)
+    expiry = now + datetime.timedelta(minutes=_SAS_TOKEN_EXPIRY_MINUTES)
+
+    try:
+        delegation_key = blob_service.get_user_delegation_key(
+            key_start_time=now,
+            key_expiry_time=expiry,
+        )
+    except Exception:
+        logger.exception("Failed to obtain user delegation key")
+        return error_response(502, "Storage service temporarily unavailable", req=req)
+
+    sas_token = generate_blob_sas(
+        account_name=STORAGE_ACCOUNT_NAME,
+        container_name=DEFAULT_INPUT_CONTAINER,
+        blob_name=blob_name,
+        user_delegation_key=delegation_key,
+        permission=BlobSasPermissions(create=True, write=True),
+        expiry=expiry,
+        content_type="application/vnd.google-earth.kml+xml",
+    )
+
+    sas_url = (
+        f"https://{STORAGE_ACCOUNT_NAME}.blob.core.windows.net/"
+        f"{DEFAULT_INPUT_CONTAINER}/{blob_name}?{sas_token}"
+    )
+
+    logger.info("Upload URL minted submission_id=%s blob=%s", submission_id, blob_name)
+
+    return func.HttpResponse(
+        json.dumps(
+            {
+                "submissionId": submission_id,
+                "sasUrl": sas_url,
+                "blobName": blob_name,
+                "container": DEFAULT_INPUT_CONTAINER,
+                "expiresMinutes": _SAS_TOKEN_EXPIRY_MINUTES,
+                "maxBytes": MAX_KML_FILE_SIZE_BYTES,
+            }
+        ),
+        status_code=200,
+        mimetype="application/json",
+        headers=cors_headers(req),
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /api/upload/status/{submission_id} — poll orchestration status
+# ---------------------------------------------------------------------------
+
+
+@bp.route(
+    route="upload/status/{submission_id}",
+    methods=["GET", "OPTIONS"],
+    auth_level=func.AuthLevel.ANONYMOUS,
+)
+@require_auth
+def upload_status(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> func.HttpResponse:
+    """Poll the status of a pipeline submission from Cosmos."""
+    if not user_id:
+        return error_response(401, "Missing user identity", req=req)
+
+    submission_id = req.route_params.get("submission_id", "")
+    if not submission_id:
+        return error_response(400, "Missing submission_id", req=req)
+
+    # Validate UUID format to prevent injection
+    try:
+        uuid.UUID(submission_id)
+    except ValueError:
+        return error_response(400, "Invalid submission_id format", req=req)
+
+    # Read status from Cosmos runs container
+    try:
+        records = _cosmos_mod.query_items(
+            "runs",
+            "SELECT c.submission_id, c.status, c.submitted_at, c.feature_count,"
+            " c.aoi_count FROM c WHERE c.submission_id = @sid",
+            parameters=[{"name": "@sid", "value": submission_id}],
+        )
+    except Exception:
+        logger.exception("Cosmos query failed for submission_id=%s", submission_id)
+        return error_response(503, "Status temporarily unavailable", req=req)
+
+    if records:
+        record = records[0]
+        return func.HttpResponse(
+            json.dumps(
+                {
+                    "submissionId": submission_id,
+                    "status": record.get("status", "pending"),
+                    "submittedAt": record.get("submitted_at", ""),
+                    "featureCount": record.get("feature_count"),
+                    "aoiCount": record.get("aoi_count"),
+                }
+            ),
+            status_code=200,
+            mimetype="application/json",
+            headers=cors_headers(req),
+        )
+
+    # Not found yet — may still be in the ingestion queue
+    return func.HttpResponse(
+        json.dumps(
+            {
+                "submissionId": submission_id,
+                "status": "pending",
+                "message": "Submission is being processed",
+            }
+        ),
+        status_code=200,
+        mimetype="application/json",
+        headers=cors_headers(req),
+    )

--- a/function_app.py
+++ b/function_app.py
@@ -27,6 +27,7 @@ from blueprints.export import bp as export_bp
 from blueprints.health import bp as health_bp
 from blueprints.monitoring import bp as monitoring_bp
 from blueprints.pipeline import bp as pipeline_bp
+from blueprints.upload import bp as upload_bp
 
 # Fail-fast config validation (§8.6)
 validate_config()
@@ -69,6 +70,9 @@ app.register_functions(eudr_bp)
 app.register_functions(analysis_bp)
 app.register_functions(catalogue_bp)
 app.register_functions(export_bp)
+
+# Register upload/history BFF endpoints
+app.register_functions(upload_bp)
 
 # Register monitoring blueprint (Timer Trigger + HTTP)
 app.register_functions(monitoring_bp)

--- a/tests/test_upload_endpoints.py
+++ b/tests/test_upload_endpoints.py
@@ -1,0 +1,272 @@
+"""Tests for upload BFF endpoints (blueprints/upload.py).
+
+Covers:
+- POST /api/upload/token — SAS token minting
+- GET  /api/upload/status/{submission_id} — pipeline status polling
+
+Note: endpoints decorated with @require_auth must be called with just (req).
+The decorator extracts auth_claims/user_id from X-MS-CLIENT-PRINCIPAL.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import azure.functions as func
+
+from tests.conftest import TEST_ORIGIN, encode_test_principal
+
+_REQUIRE_AUTH = patch.dict("os.environ", {"REQUIRE_AUTH": "1"})
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_req(
+    url: str,
+    *,
+    method: str = "GET",
+    body: dict | None = None,
+    params: dict[str, str] | None = None,
+    route_params: dict[str, str] | None = None,
+    principal_user_id: str | None = "test-user",
+) -> func.HttpRequest:
+    """Build an authenticated HttpRequest for upload blueprint."""
+    h: dict[str, str] = {"Origin": TEST_ORIGIN}
+    if principal_user_id:
+        h["X-MS-CLIENT-PRINCIPAL"] = encode_test_principal(user_id=principal_user_id)
+
+    raw_body = b""
+    if body is not None:
+        h["Content-Type"] = "application/json"
+        raw_body = json.dumps(body).encode()
+
+    return func.HttpRequest(
+        method=method,
+        url=url,
+        headers=h,
+        params=params or {},
+        route_params=route_params or {},
+        body=raw_body,
+    )
+
+
+# ===================================================================
+# POST /api/upload/token
+# ===================================================================
+
+
+class TestUploadToken:
+    """SAS token minting endpoint."""
+
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_returns_sas_url_for_authenticated_user(self, mock_bsc, mock_gen_sas):
+        from blueprints.upload import upload_token
+
+        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
+
+        req = _make_req("/api/upload/token", method="POST")
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert "submissionId" in data
+        assert "sasUrl" in data
+        assert data["sasUrl"].startswith("https://teststorage.blob.core.windows.net/")
+        assert "blobName" in data
+        assert data["container"] == "kml-input"
+        assert data["expiresMinutes"] > 0
+        assert data["maxBytes"] == 10_485_760
+
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_writes_ticket_blob(self, mock_bsc, mock_gen_sas):
+        from blueprints.upload import upload_token
+
+        mock_blob_client = MagicMock()
+        mock_bsc.return_value.get_blob_client.return_value = mock_blob_client
+        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
+
+        body = {"submission_context": {"feature_count": 5, "aoi_count": 3}}
+        req = _make_req("/api/upload/token", method="POST", body=body)
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 200
+        mock_blob_client.upload_blob.assert_called_once()
+        ticket_data = json.loads(mock_blob_client.upload_blob.call_args[0][0])
+        assert ticket_data["user_id"] == "test-user"
+        assert "created_at" in ticket_data
+        assert ticket_data["submission_context"]["feature_count"] == 5
+
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_sas_uses_user_delegation_key(self, mock_bsc, mock_gen_sas):
+        from blueprints.upload import upload_token
+
+        mock_delegation_key = MagicMock()
+        mock_bsc.return_value.get_user_delegation_key.return_value = mock_delegation_key
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
+
+        req = _make_req("/api/upload/token", method="POST")
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            upload_token(req)
+
+        call_kwargs = mock_gen_sas.call_args[1]
+        assert call_kwargs["user_delegation_key"] is mock_delegation_key
+        assert call_kwargs["permission"].create is True
+        assert call_kwargs["permission"].write is True
+        assert call_kwargs["permission"].read is False
+
+    @_REQUIRE_AUTH
+    def test_rejects_unauthenticated_request(self):
+        from blueprints.upload import upload_token
+
+        req = _make_req("/api/upload/token", method="POST", principal_user_id=None)
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 401
+
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_returns_503_when_storage_not_configured(self, mock_bsc):
+        from blueprints.upload import upload_token
+
+        req = _make_req("/api/upload/token", method="POST")
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", ""):
+            resp = upload_token(req)
+
+        assert resp.status_code == 503
+
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_delegation_key_failure_returns_502(self, mock_bsc, mock_gen_sas):
+        from blueprints.upload import upload_token
+
+        mock_bsc.return_value.get_user_delegation_key.side_effect = RuntimeError("timeout")
+
+        req = _make_req("/api/upload/token", method="POST")
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 502
+
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_sanitises_submission_context(self, mock_bsc, mock_gen_sas):
+        from blueprints.upload import upload_token
+
+        mock_blob_client = MagicMock()
+        mock_bsc.return_value.get_blob_client.return_value = mock_blob_client
+        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
+
+        body = {
+            "submission_context": {
+                "feature_count": 5,
+                "evil_field": "should be stripped",
+                "total_area_ha": -999,  # negative — should be stripped
+            }
+        }
+        req = _make_req("/api/upload/token", method="POST", body=body)
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            upload_token(req)
+
+        ticket_data = json.loads(mock_blob_client.upload_blob.call_args[0][0])
+        ctx = ticket_data.get("submission_context", {})
+        assert "evil_field" not in ctx
+        assert ctx["feature_count"] == 5
+        assert "total_area_ha" not in ctx  # negative rejected
+
+
+# ===================================================================
+# GET /api/upload/status/{submission_id}
+# ===================================================================
+
+
+class TestUploadStatus:
+    """Pipeline status polling endpoint."""
+
+    _VALID_SID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+    @patch("blueprints.upload._cosmos_mod")
+    def test_returns_status_from_cosmos(self, mock_cosmos):
+        from blueprints.upload import upload_status
+
+        mock_cosmos.query_items.return_value = [
+            {
+                "submission_id": self._VALID_SID,
+                "status": "running",
+                "submitted_at": "2026-04-10T10:00:00Z",
+                "feature_count": 5,
+            }
+        ]
+
+        req = _make_req(
+            f"/api/upload/status/{self._VALID_SID}",
+            route_params={"submission_id": self._VALID_SID},
+        )
+        resp = upload_status(req)
+
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["submissionId"] == self._VALID_SID
+        assert data["status"] == "running"
+
+    @patch("blueprints.upload._cosmos_mod")
+    def test_returns_pending_when_not_found(self, mock_cosmos):
+        from blueprints.upload import upload_status
+
+        mock_cosmos.query_items.return_value = []
+
+        req = _make_req(
+            f"/api/upload/status/{self._VALID_SID}",
+            route_params={"submission_id": self._VALID_SID},
+        )
+        resp = upload_status(req)
+
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["status"] == "pending"
+
+    def test_rejects_invalid_uuid(self):
+        from blueprints.upload import upload_status
+
+        req = _make_req(
+            "/api/upload/status/not-a-uuid",
+            route_params={"submission_id": "not-a-uuid"},
+        )
+        resp = upload_status(req)
+
+        assert resp.status_code == 400
+
+    def test_rejects_empty_submission_id(self):
+        from blueprints.upload import upload_status
+
+        req = _make_req(
+            "/api/upload/status/",
+            route_params={"submission_id": ""},
+        )
+        resp = upload_status(req)
+
+        assert resp.status_code == 400
+
+    @_REQUIRE_AUTH
+    def test_rejects_unauthenticated_request(self):
+        from blueprints.upload import upload_status
+
+        req = _make_req(
+            f"/api/upload/status/{self._VALID_SID}",
+            route_params={"submission_id": self._VALID_SID},
+            principal_user_id=None,
+        )
+        resp = upload_status(req)
+
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Adds two new endpoints to the Container Apps Function App that previously only existed on the SWA managed API. This is the first step of the P3 BYOF consolidation — once all endpoints are ported, the SWA managed API can be deleted.

Fixes #509

## Changes

### New endpoints (`blueprints/upload.py`)

| Endpoint | Method | Purpose |
|----------|--------|---------|
| `/api/upload/token` | POST | Mints a write-only SAS URL with user delegation key. Writes `.tickets/{id}.json` blob for server-side audit trail. Sanitises submission context fields. |
| `/api/upload/status/{submission_id}` | GET | Polls Cosmos `runs` container for pipeline status. Validates UUID format. Returns camelCase status or `pending` if not yet ingested. |

### Not added

`/api/analysis/history` — already exists in `blueprints/pipeline/diagnostics.py` with Durable Functions client integration. No duplicate needed.

### Test coverage

12 unit tests in `tests/test_upload_endpoints.py`:
- **TestUploadToken** (7): SAS URL shape, ticket blob writing, user delegation key usage, auth rejection, storage misconfiguration (503), delegation key failure (502), submission context sanitisation
- **TestUploadStatus** (5): Cosmos record retrieval, pending when not found, invalid UUID rejection, empty submission_id rejection, auth rejection

### Roadmap

P3 BYOF Consolidation — item B.2 (add missing upload endpoints to Container Apps FA)

## Validation

- `pytest tests/test_upload_endpoints.py` — 12/12 pass
- Full suite: 1176 passed, 14 skipped
- `ruff check` clean
- Pre-commit hooks pass (pyright, ruff, ruff-format, detect-secrets)