### PR TITLE
fix: address PR #512 review comments — UTF-8 base64, smoke test, SWA identity cleanup

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -148,9 +148,9 @@ Cosmos documents and blob JSON — the BFF handles all translation.
 |-------|-------|-------|--------|
 | B.1 | #498 | Root cause: SWA managed functions don't support managed identity | ✅ Superseded by BYOF |
 | B.2 | #506 | Stripe Key Vault refs don't resolve in SWA managed functions | ✅ Superseded by BYOF |
-| B.3 | #511 | Delete `website/api/` managed function code | ✅ PR #511 |
-| B.4 | #511 | Configure `api-config.json` to route `/api/*` to Container Apps FA | ✅ PR #511 |
-| B.5 | #511 | Update deploy workflow to skip SWA managed API build | ✅ PR #511 |
+| B.3 | #511 | Delete `website/api/` managed function code | ✅ PR #512 |
+| B.4 | #511 | Configure `api-config.json` to route `/api/*` to Container Apps FA | ✅ PR #512 |
+| B.5 | #511 | Update deploy workflow to skip SWA managed API build | ✅ PR #512 |
 | B.6 | #499 | Add orchestrator status endpoint (on Container Apps) | ✅ Already exists |
 | B.7 | #500 | Add timelapse-data read endpoint (on Container Apps) | ✅ Already exists |
 | B.8 | #501 | Add timelapse-analysis-load endpoint (on Container Apps) | ✅ Already exists |

--- a/infra/tofu/locals.tf
+++ b/infra/tofu/locals.tf
@@ -11,7 +11,6 @@ locals {
     event_grid_system_topic    = "evgt-${local.name_suffix}"
     event_grid_subscription    = "evgs-kml-upload"
     static_web_app             = "stapp-${local.name_suffix}-site"
-    swa_identity               = "id-${local.name_suffix}-swa"
     communication_service      = "acs-${local.name_suffix}"
     email_service              = "ecs-${local.name_suffix}"
     cosmos_account             = "cosmos-${local.name_suffix}"

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -788,13 +788,6 @@ resource "azapi_resource" "function_app" {
   response_export_values = ["id", "name", "properties.defaultHostName"]
 }
 
-resource "azurerm_user_assigned_identity" "swa" {
-  name                = local.names.swa_identity
-  location            = azurerm_resource_group.main.location
-  resource_group_name = azurerm_resource_group.main.name
-  tags                = local.tags
-}
-
 resource "azurerm_static_web_app" "main" {
   name                = local.names.static_web_app
   location            = var.static_web_app_location
@@ -802,11 +795,6 @@ resource "azurerm_static_web_app" "main" {
   sku_tier            = "Standard"
   sku_size            = "Standard"
   tags                = local.tags
-
-  identity {
-    type         = "UserAssigned"
-    identity_ids = [azurerm_user_assigned_identity.swa.id]
-  }
 }
 
 # --- Linked backend (disabled): the linkedBackends ARM API returns 500

--- a/tests/test_frontend_config.py
+++ b/tests/test_frontend_config.py
@@ -18,6 +18,7 @@ from treesight.security.url import csp_token_matches_host as _csp_token_matches_
 WEBSITE = Path(__file__).resolve().parent.parent / "website"
 INDEX_HTML = WEBSITE / "index.html"
 LANDING_JS = WEBSITE / "js" / "landing.js"
+APP_SHELL_JS = WEBSITE / "js" / "app-shell.js"
 SWA_CONFIG = WEBSITE / "staticwebapp.config.json"
 HELPERS_PY = Path(__file__).resolve().parent.parent / "blueprints" / "_helpers.py"
 
@@ -30,6 +31,11 @@ def index_html():
 @pytest.fixture()
 def landing_js():
     return LANDING_JS.read_text()
+
+
+@pytest.fixture()
+def app_shell_js():
+    return APP_SHELL_JS.read_text()
 
 
 @pytest.fixture()
@@ -151,6 +157,30 @@ class TestAuthConfig:
         """landing.js must forward X-MS-CLIENT-PRINCIPAL for BYOF auth."""
         assert "X-MS-CLIENT-PRINCIPAL" in landing_js, (
             "landing.js apiFetch must send X-MS-CLIENT-PRINCIPAL header"
+        )
+
+    def test_landing_uses_utf8_safe_base64(self, landing_js):
+        """landing.js must use TextEncoder for UTF-8 safe base64 encoding."""
+        assert "TextEncoder" in landing_js, (
+            "landing.js must use TextEncoder for UTF-8 safe base64 of client principal"
+        )
+
+    def test_app_shell_forwards_client_principal(self, app_shell_js):
+        """app-shell.js must forward X-MS-CLIENT-PRINCIPAL for BYOF auth."""
+        assert "X-MS-CLIENT-PRINCIPAL" in app_shell_js, (
+            "app-shell.js apiFetch must send X-MS-CLIENT-PRINCIPAL header"
+        )
+
+    def test_app_shell_uses_utf8_safe_base64(self, app_shell_js):
+        """app-shell.js must use TextEncoder for UTF-8 safe base64 encoding."""
+        assert "TextEncoder" in app_shell_js, (
+            "app-shell.js must use TextEncoder for UTF-8 safe base64 of client principal"
+        )
+
+    def test_app_shell_uses_api_config_json(self, app_shell_js):
+        """app-shell.js must discover the Container Apps FA via /api-config.json."""
+        assert "api-config.json" in app_shell_js, (
+            "app-shell.js must read /api-config.json for BYOF hostname discovery"
         )
 
 

--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -423,12 +423,16 @@ class TestDeployWorkflowSettings:
 
     def test_deploy_smoke_checks_container_apps_fa(self, deploy_yml):
         """Deploy must smoke-check the Container Apps FA health endpoint."""
-        assert "Container Apps" in deploy_yml, (
-            "deploy.yml smoke check must target the Container Apps FA, not SWA managed functions"
+        assert "Smoke-check Container Apps Function App" in deploy_yml, (
+            "deploy.yml must have a named smoke check step targeting Container Apps FA"
+        )
+        assert "function_app_hostname" in deploy_yml, (
+            "deploy.yml smoke check must use function_app_hostname output"
         )
         assert "/api/health" in deploy_yml, (
             "deploy.yml smoke check must test /api/health on the Container Apps FA"
         )
+        assert "curl" in deploy_yml, "deploy.yml smoke check must curl the FA health endpoint"
 
     def test_workflow_dispatch_supports_manual_teardown_rebuild(self, deploy_yml):
         assert "rebuild_after_manual_teardown" in deploy_yml, (

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -310,7 +310,11 @@
     // Forward the SWA client principal to Container Apps FA so the
     // require_auth decorator can identify the user on cross-origin calls.
     if (_clientPrincipal) {
-      opts.headers['X-MS-CLIENT-PRINCIPAL'] = btoa(JSON.stringify(_clientPrincipal));
+      // UTF-8 safe base64: encode to bytes first, then btoa on Latin-1 string.
+      var jsonStr = JSON.stringify(_clientPrincipal);
+      var bytes = new TextEncoder().encode(jsonStr);
+      var binStr = Array.from(bytes, function (b) { return String.fromCharCode(b); }).join('');
+      opts.headers['X-MS-CLIENT-PRINCIPAL'] = btoa(binStr);
     }
     const url = _apiBase ? _apiBase + path : path;
     const resp = await fetch(url, opts);

--- a/website/js/landing.js
+++ b/website/js/landing.js
@@ -72,7 +72,11 @@
     opts = opts || {};
     opts.headers = opts.headers || {};
     if (_clientPrincipal) {
-      opts.headers['X-MS-CLIENT-PRINCIPAL'] = btoa(JSON.stringify(_clientPrincipal));
+      // UTF-8 safe base64: encode to bytes first, then btoa on Latin-1 string.
+      var jsonStr = JSON.stringify(_clientPrincipal);
+      var bytes = new TextEncoder().encode(jsonStr);
+      var binStr = Array.from(bytes, function (b) { return String.fromCharCode(b); }).join('');
+      opts.headers['X-MS-CLIENT-PRINCIPAL'] = btoa(binStr);
     }
     var url = _apiBase ? _apiBase + path : path;
     var resp = await fetch(url, opts);


### PR DESCRIPTION
Addresses all review comments from PR #512 and #514.\n\n## Changes\n\n### UTF-8 safe base64 encoding (app-shell.js + landing.js)\n`btoa(JSON.stringify(principal))` throws on non-Latin1 characters (e.g. Unicode names). Fixed by encoding through `TextEncoder` → `Array.from` → `btoa` on Latin-1 binary string.\n\n### Stronger deploy smoke check test\nPreviously asserted only `\"Container Apps\" in deploy_yml`. Now asserts:\n- Step name `\"Smoke-check Container Apps Function App\"`\n- `function_app_hostname` output used\n- `/api/health` endpoint checked\n- `curl` command used\n\n### Remove orphaned SWA user-assigned identity\n`azurerm_user_assigned_identity.swa` had no RBAC assignments after BYOF. Removed the identity resource, the SWA identity block, and the `swa_identity` local name.\n\n### Fix roadmap PR refs\nB.3–B.5 referenced PR #511 (issue) instead of PR #512 (implementation).\n\n### New test assertions\n- `test_app_shell_forwards_client_principal`\n- `test_app_shell_uses_utf8_safe_base64`\n- `test_app_shell_uses_api_config_json`\n- `test_landing_uses_utf8_safe_base64`\n\n## Validation\n\n- 1,071 passed, 13 skipped\n- Pre-commit hooks pass