### PR TITLE
feat: build-once/promote deploy pipeline with PR previews

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -336,12 +336,81 @@ jobs:
             --resource-group "$FUNC_RG" \
             --settings "${APP_SETTINGS[@]}"
 
+          # Keep platform-level CORS in sync via CLI because tofu ignores body
+          # updates on the Function App resource while the azapi identity bug exists.
+          ALLOWED_ORIGINS_JSON=$(tofu output -json browser_allowed_origins | jq -c '.')
+          if [ "$(echo "$ALLOWED_ORIGINS_JSON" | jq 'length')" -eq 0 ]; then
+            echo "❌ Refusing to clear Function App CORS: browser_allowed_origins is empty"
+            exit 1
+          fi
+
+          FUNC_ID=$(az functionapp show --name "$FUNC_NAME" --resource-group "$FUNC_RG" --query id -o tsv)
+          CORS_BODY=$(jq -cn --argjson origins "$ALLOWED_ORIGINS_JSON" '{properties:{cors:{allowedOrigins:$origins,supportCredentials:false}}}')
+          az rest --method PATCH \
+            --url "${FUNC_ID}/config/web?api-version=2024-04-01" \
+            --body "$CORS_BODY"
+
           # Apply scaling cap from Terraform output (body is ignore_changes in tofu)
           MAX_INSTANCES=$(tofu output -raw function_app_cli_maximum_instance_count)
-          FUNC_ID=$(az functionapp show --name "$FUNC_NAME" --resource-group "$FUNC_RG" --query id -o tsv)
           az rest --method PATCH \
             --url "${FUNC_ID}?api-version=2024-04-01" \
             --body "{\"properties\":{\"functionAppConfig\":{\"scaleAndConcurrency\":{\"maximumInstanceCount\":${MAX_INSTANCES}}}}}"
+
+      - name: Verify browser CORS contract
+        id: verify-browser-cors
+        working-directory: infra/tofu
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_USE_OIDC: "true"
+        run: |
+          RG_NAME=$(tofu output -raw resource_group_name)
+          FUNC_HOST=$(tofu output -raw function_app_default_hostname)
+          STORAGE_NAME=$(tofu output -raw storage_account_name)
+          ORIGINS_JSON=$(tofu output -json browser_allowed_origins)
+
+          if [ "$(echo "$ORIGINS_JSON" | jq 'length')" -eq 0 ]; then
+            echo "❌ browser_allowed_origins is empty; cannot verify browser CORS contract"
+            exit 1
+          fi
+
+          while IFS= read -r origin; do
+            echo "Checking Function App preflight for ${origin}"
+            HEADERS=$(mktemp)
+            STATUS=$(curl -sS -o /dev/null -D "$HEADERS" \
+              -X OPTIONS "https://${FUNC_HOST}/api/upload/token" \
+              -H "Origin: ${origin}" \
+              -H 'Access-Control-Request-Method: POST' \
+              -H 'Access-Control-Request-Headers: content-type,x-ms-client-principal' \
+              -w '%{http_code}')
+            ACAO=$(awk 'tolower($0) ~ /^access-control-allow-origin:/ {gsub(/\r/, "", $2); print $2}' "$HEADERS")
+            rm -f "$HEADERS"
+            if [ "$STATUS" != "204" ] || [ "$ACAO" != "$origin" ]; then
+              echo "❌ Function App preflight failed for ${origin}: status=${STATUS} allow-origin=${ACAO:-<missing>}"
+              exit 1
+            fi
+          done < <(echo "$ORIGINS_JSON" | jq -r '.[]')
+
+          BLOB_CORS_JSON=$(az storage account blob-service-properties show \
+            --account-name "$STORAGE_NAME" \
+            --resource-group "$RG_NAME" \
+            --query 'cors.corsRules' -o json)
+
+          if [ "$(echo "$BLOB_CORS_JSON" | jq '. // [] | length')" -eq 0 ]; then
+            echo "❌ Blob service has no CORS rules configured"
+            exit 1
+          fi
+
+          while IFS= read -r origin; do
+            MATCH_COUNT=$(echo "$BLOB_CORS_JSON" | jq --arg origin "$origin" '[.[] | select((.allowedOrigins // []) | index($origin)) | select((.allowedMethods // []) | index("PUT")) | select((.allowedMethods // []) | index("OPTIONS"))] | length')
+            if [ "$MATCH_COUNT" -eq 0 ]; then
+              echo "❌ Blob CORS missing required origin or methods for ${origin}"
+              exit 1
+            fi
+          done < <(echo "$ORIGINS_JSON" | jq -r '.[]')
+
+          echo "✅ Browser CORS contract verified for Function App preflight and blob service configuration."
 
       - name: Export Function App hostname
         id: hostname

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,14 +2,17 @@
 # Deploy — Infra (OpenTofu) → Container image (GHCR) → Static site
 #
 # Triggered when CI passes on main, or manually.
+# The same immutable container image is built once and can be
+# promoted to any environment by re-running with a different
+# `environment` input.
 #
-# Required GitHub Secrets (set in 'dev' environment):
+# Required GitHub Secrets (set per GitHub Environment):
 #   AZURE_CLIENT_ID         — SP / managed identity client ID (OIDC)
 #   AZURE_TENANT_ID         — Azure AD tenant
 #   AZURE_SUBSCRIPTION_ID   — Target subscription
 #   TF_STATE_RESOURCE_GROUP — Resource group holding tfstate storage
 #   TF_STATE_STORAGE_ACCOUNT— Storage account name for tfstate
-#   TF_STATE_CONTAINER      — Blob container name for tfstate
+#   TF_STATE_CONTAINER      — Blob container for this environment
 #   TF_STATE_KEY            — Blob key for the state file
 #   SWA_DEPLOYMENT_TOKEN    — Static Web App deployment token
 #
@@ -23,8 +26,20 @@ on:
     branches: [main]
   workflow_dispatch:
     inputs:
+      environment:
+        description: Target environment (must match a GitHub Environment and a tfvars file)
+        required: true
+        type: choice
+        options:
+          - dev
+          - prd
+        default: dev
+      image_tag:
+        description: 'Container image tag to deploy (default: latest main SHA)'
+        required: false
+        type: string
       rebuild_after_manual_teardown:
-        description: Recreate dev after app-managed resources were deleted manually outside the workflow.
+        description: Recreate after app-managed resources were deleted manually outside the workflow.
         required: false
         type: boolean
         default: false
@@ -41,19 +56,35 @@ concurrency:
 
 env:
   TOFU_VERSION: "1.8.0"
+  # Resolve environment: workflow_dispatch supplies it; workflow_run always deploys to dev.
+  DEPLOY_ENV: ${{ inputs.environment || 'dev' }}
 
 jobs:
   # ── 1. Build & push container to GHCR ──────────────────────
+  # When promoting an existing image (image_tag input set), this job
+  # resolves the URI without rebuilding.
   build-image:
     name: Build & Push Container
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     outputs:
-      image_uri: ${{ steps.meta.outputs.image_uri }}
+      image_uri: ${{ steps.resolve.outputs.image_uri || steps.meta.outputs.image_uri }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # ── Promotion path: reuse an existing GHCR image ────────
+      - name: Resolve existing image for promotion
+        id: resolve
+        if: ${{ inputs.image_tag != '' }}
+        run: |
+          source .github/image-config.env
+          IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${APP_IMAGE_REPO}"
+          echo "image_uri=${IMAGE_NAME}:${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          echo "### ♻️ Promoting existing image: \`${IMAGE_NAME}:${{ inputs.image_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+
+      # ── Normal path: build fresh image ──────────────────────
       - name: Log in to GHCR
+        if: ${{ inputs.image_tag == '' }}
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
@@ -61,6 +92,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set image tag
+        if: ${{ inputs.image_tag == '' }}
         id: meta
         run: |
           source .github/image-config.env
@@ -72,6 +104,7 @@ jobs:
           echo "app_version=${APP_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Resolve base image
+        if: ${{ inputs.image_tag == '' }}
         id: base
         run: |
           source .github/image-config.env
@@ -89,6 +122,7 @@ jobs:
           fi
 
       - name: Build image
+        if: ${{ inputs.image_tag == '' }}
         env:
           IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
         run: |
@@ -101,6 +135,7 @@ jobs:
             -t "${IMAGE_NAME}:latest" .
 
       - name: Run container smoke tests
+        if: ${{ inputs.image_tag == '' }}
         env:
           IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
         run: |
@@ -110,6 +145,7 @@ jobs:
             python3 /scripts/container_smoke_test.py
 
       - name: Push to GHCR
+        if: ${{ inputs.image_tag == '' }}
         env:
           IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
         run: |
@@ -118,6 +154,7 @@ jobs:
           docker push "${IMAGE_NAME}:latest"
 
       - name: Trivy container scan
+        if: ${{ inputs.image_tag == '' }}
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ steps.meta.outputs.image_uri }}
@@ -129,7 +166,7 @@ jobs:
           exit-code: "0"        # warn, don't block deploy (set to "1" to gate)
 
       - name: Upload Trivy image SARIF
-        if: always()
+        if: ${{ always() && inputs.image_tag == '' }}
         uses: github/codeql-action/upload-sarif@480db559a14342288b67e54bd959dd52dc3ee68f # v3
         with:
           sarif_file: trivy-image.sarif
@@ -140,7 +177,7 @@ jobs:
     name: Deploy Infrastructure
     runs-on: ubuntu-latest
     needs: build-image
-    environment: dev
+    environment: ${{ github.event.inputs.environment || 'dev' }}
     outputs:
       function_app_hostname: ${{ steps.hostname.outputs.hostname }}
       appinsights_connection_string: ${{ steps.appinsights.outputs.connection_string }}
@@ -182,8 +219,8 @@ jobs:
             if tofu init \
               -backend-config="resource_group_name=${{ secrets.TF_STATE_RESOURCE_GROUP }}" \
               -backend-config="storage_account_name=${{ secrets.TF_STATE_STORAGE_ACCOUNT }}" \
-              -backend-config="container_name=${{ secrets.TF_STATE_CONTAINER_DEV }}" \
-              -backend-config="key=${{ secrets.TF_STATE_KEY_DEV }}"; then
+              -backend-config="container_name=${{ secrets.TF_STATE_CONTAINER }}" \
+              -backend-config="key=${{ secrets.TF_STATE_KEY }}"; then
               echo "✅ tofu init succeeded on attempt ${attempt}"
               exit 0
             fi
@@ -226,7 +263,7 @@ jobs:
           tofu plan -out=tfplan \
             -var="subscription_id=${{ secrets.AZURE_SUBSCRIPTION_ID }}" \
             -var="container_image=${{ needs.build-image.outputs.image_uri }}" \
-            -var-file="environments/dev.tfvars"
+            -var-file="environments/${{ env.DEPLOY_ENV }}.tfvars"
 
       - name: Tofu Apply
         working-directory: infra/tofu
@@ -430,7 +467,7 @@ jobs:
           FUNC_NAME=$(tofu output -raw function_app_name)
           HOSTNAME=$(tofu output -raw function_app_default_hostname)
           TOPIC_NAME=$(tofu output -raw event_grid_system_topic_name)
-          EXPECTED_CAP=$(awk -F '=' '/^log_daily_cap_gb[[:space:]]*=/{gsub(/[[:space:]]/, "", $2); print $2; exit}' environments/dev.tfvars)
+          EXPECTED_CAP=$(awk -F '=' '/^log_daily_cap_gb[[:space:]]*=/{gsub(/[[:space:]]/, "", $2); print $2; exit}' environments/${{ env.DEPLOY_ENV }}.tfvars)
           : "${EXPECTED_CAP:=0.1}"
 
           python ../../scripts/validate_dev_infra_gate.py \
@@ -484,7 +521,7 @@ jobs:
     name: Deploy Static Website
     runs-on: ubuntu-latest
     needs: deploy-infra
-    environment: dev
+    environment: ${{ github.event.inputs.environment || 'dev' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ permissions:
   security-events: write   # upload Trivy SARIF
 
 concurrency:
-  group: deploy-${{ github.ref }}
+  group: deploy-${{ inputs.environment || 'dev' }}-${{ github.ref }}
   cancel-in-progress: false
 
 env:
@@ -72,15 +72,24 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # ── Guard: prd must promote an existing image ──────────
+      - name: Require image_tag for production
+        if: ${{ inputs.environment == 'prd' && inputs.image_tag == '' }}
+        run: |
+          echo "::error::Production deploys must promote an existing image. Provide image_tag."
+          exit 1
+
       # ── Promotion path: reuse an existing GHCR image ────────
       - name: Resolve existing image for promotion
         id: resolve
         if: ${{ inputs.image_tag != '' }}
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
           source .github/image-config.env
           IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${APP_IMAGE_REPO}"
-          echo "image_uri=${IMAGE_NAME}:${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
-          echo "### ♻️ Promoting existing image: \`${IMAGE_NAME}:${{ inputs.image_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "image_uri=${IMAGE_NAME}:${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "### ♻️ Promoting existing image: \`${IMAGE_NAME}:${IMAGE_TAG}\`" >> "$GITHUB_STEP_SUMMARY"
 
       # ── Normal path: build fresh image ──────────────────────
       - name: Log in to GHCR

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -1,0 +1,54 @@
+# ─────────────────────────────────────────────────────────────
+# Preview Site — SWA staging environment for website-only PRs
+#
+# Deploys a staging environment on Azure Static Web Apps when
+# a PR modifies files under website/.  The staging URL is posted
+# as a PR comment.  On PR close, the staging environment is torn down.
+#
+# Required GitHub Secrets (from the 'dev' environment):
+#   SWA_DEPLOYMENT_TOKEN — Static Web App deployment token
+# ─────────────────────────────────────────────────────────────
+name: Preview Site
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - "website/**"
+
+permissions:
+  contents: read
+  pull-requests: write       # for posting preview URL comment
+
+jobs:
+  deploy-preview:
+    name: Deploy Preview
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed'
+    environment: dev
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Deploy to SWA staging environment
+        uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.SWA_DEPLOYMENT_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: upload
+          app_location: /website
+          skip_app_build: true
+          deployment_environment: "pr-${{ github.event.pull_request.number }}"
+
+  close-preview:
+    name: Close Preview
+    runs-on: ubuntu-latest
+    if: github.event.action == 'closed'
+    environment: dev
+    steps:
+      - name: Tear down staging environment
+        uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.SWA_DEPLOYMENT_TOKEN }}
+          action: close
+          app_location: /website
+          deployment_environment: "pr-${{ github.event.pull_request.number }}"

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -24,7 +24,7 @@ jobs:
   deploy-preview:
     name: Deploy Preview
     runs-on: ubuntu-latest
-    if: github.event.action != 'closed'
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     environment: dev
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -42,7 +42,7 @@ jobs:
   close-preview:
     name: Close Preview
     runs-on: ubuntu-latest
-    if: github.event.action == 'closed'
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     environment: dev
     steps:
       - name: Tear down staging environment

--- a/blueprints/_helpers.py
+++ b/blueprints/_helpers.py
@@ -16,15 +16,18 @@ logger = logging.getLogger(__name__)
 EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 MAX_FIELD_LEN = 2000
 
-# Allowed CORS origins — production SWA + local dev
-_ALLOWED_ORIGINS: set[str] = {
-    "https://polite-glacier-0d6885003.4.azurestaticapps.net",
-    "https://canopex.hrdcrprwn.com",
-    "http://localhost:4280",
-    "http://localhost:1111",
-}
 
-# Allow override via env var (comma-separated) for custom domains.
+def _default_allowed_origins() -> set[str]:
+    origins = {"https://canopex.hrdcrprwn.com"}
+    if os.environ.get("REQUIRE_AUTH", "").lower() not in ("true", "1", "yes"):
+        origins.update({"http://localhost:4280", "http://localhost:1111"})
+    return origins
+
+
+# Stable browser origins allowed without infra-provided overrides.
+_ALLOWED_ORIGINS: set[str] = _default_allowed_origins()
+
+# Allow override via env var (comma-separated) for current SWA/default hosts.
 # Only https:// origins are accepted to prevent open CORS misconfiguration.
 _extra = os.environ.get("CORS_ALLOWED_ORIGINS", "")
 if _extra:

--- a/blueprints/pipeline/_helpers.py
+++ b/blueprints/pipeline/_helpers.py
@@ -130,8 +130,21 @@ def _durable_status_payload(status: Any) -> dict[str, Any]:
     }
 
 
-def _reshape_output(output: dict[str, Any]) -> dict[str, Any]:
-    """Reshape PipelineSummary to the diagnostics contract (§4.3)."""
+def _reshape_output(output: dict[str, Any] | str) -> dict[str, Any]:
+    """Reshape PipelineSummary to the diagnostics contract (§4.3).
+
+    The Durable Functions SDK sometimes returns output as a JSON string
+    instead of a parsed dict — handle both cases.
+    """
+    if isinstance(output, str):
+        import json
+
+        try:
+            output = json.loads(output)
+        except (json.JSONDecodeError, TypeError):
+            return {"status": "unknown", "message": output}
+    if not isinstance(output, dict):
+        return {"status": "unknown", "message": str(output)}
     result = {
         "status": output.get("status", ""),
         "message": output.get("message", ""),

--- a/docs/3-tier-architecture.md
+++ b/docs/3-tier-architecture.md
@@ -1,194 +1,213 @@
 # Architecture Specification: Serverless Geospatial Processing Pipeline
 
+> **Last updated:** 2026-04-11
+>
+> **Status:** This document reflects the current 2-tier architecture decision.
+> The original 3-tier design (SWA Functions + Durable Orchestrator + Container
+> Apps Jobs) was rejected — see [Decision Record](#decision-swa-managed-functions-rejected) below.
+
 ## **1. Overview**
 
-This system provides an event‑driven, serverless pipeline for on‑demand geospatial processing. It supports large, memory‑intensive workloads (e.g., parsing KMZ/KML, polygon extraction, spatial joins) while maintaining minimal idle cost.
+This system provides an event-driven, serverless pipeline for on-demand
+geospatial processing. It supports large, memory-intensive workloads (KMZ/KML
+parsing, imagery fulfilment, NDVI/change-detection enrichment) while
+maintaining minimal idle cost.
 
-The architecture separates concerns into three layers:
+The architecture uses **two Container Apps Function Apps** sharing a single
+Durable Functions task hub:
 
-1. **Frontend/API Layer** — Always‑on, lightweight endpoints  
-2. **Orchestration Layer** — Scale‑to‑zero Durable Functions  
-3. **Compute Layer** — High‑CPU/RAM Activity Functions (with Container Apps Jobs as a horizon option)  
+1. **T2 — API + Orchestrator** — Always-warm BFF endpoints + lightweight
+   orchestration (no GDAL/rasterio)
+2. **T3 — Compute** — Scale-to-zero activity functions with full
+   GDAL/rasterio/Rust stack
 
-This ensures predictable cost, clean boundaries, and the ability to burst into high‑performance compute only when required.
+SWA serves **static files and auth only** — no managed functions.
 
 ---
 
 ## **2. Components**
 
-### **2.1 Static Web Apps (SWA) + SWA Functions**
+### **2.1 Azure Static Web Apps (SWA) — Static Hosting + Auth**
 
-**Purpose:**  
+**Purpose:**
 
-- Provide public or authenticated API endpoints  
-- Handle request validation, routing, and lightweight logic  
-- Keep a warm, low‑cost entry point for the system  
+- Serve the vanilla-JS frontend (`website/`)
+- Handle Azure AD authentication via built-in pre-configured providers
+- Route `/api/*` cross-origin to the Container Apps FA (BYOF pattern)
 
-**Responsibilities:**  
+**Does NOT:**
 
-- Accept incoming requests (HTTP/REST)  
-- Validate payloads and user context  
-- Forward work requests to the Durable Orchestrator  
-- Return orchestration status or job results  
+- Host any managed API functions (deprecated — see decision record)
+- Run any Python code
+- Access Key Vault, Cosmos, or Blob directly
 
-**Constraints:**  
+### **2.2 T2 — API + Orchestrator (Container Apps Function App)**
 
-- Must remain lightweight (no heavy compute)  
-- Must not perform long‑running operations  
+**Name:** `func-kmlsat-{env}` (Phase 1, single image) → `func-kmlsat-{env}-api` (Phase 2)
 
----
+**Purpose:**
 
-### **2.2 Durable Functions (Container Apps)**
+- Serve all BFF HTTP endpoints (billing, upload, status, history, export, etc.)
+- Run the Durable Functions orchestrator (fan-out/fan-in)
+- Run lightweight activity functions (parse, prepare, acquire, poll)
 
-**Purpose:**  
+**Resources (Phase 2 target):**
 
-- Act as the orchestration engine  
-- Manage fan‑out/fan‑in patterns  
-- Coordinate execution of compute jobs  
-- Maintain state, retries, and workflow history  
+- Image: ~300 MB (no GDAL, no rasterio, no Rust)
+- 0.5 vCPU, 1 GiB, **min 1 replica** (always-warm BFF)
+- Cost: ~£8/month
 
-**Responsibilities:**  
+**Capabilities:**
 
-- Receive work requests from SWA Functions  
-- Split workloads into parallelizable units  
-- Trigger Container Apps Jobs with parameters  
-- Poll for job completion or receive callbacks  
-- Aggregate results and return final output  
+- Managed identity (DefaultAzureCredential) for Blob, Cosmos, Key Vault
+- Key Vault references for Stripe secrets
+- Durable Functions v2 with `KmlSatelliteHub` task hub
+- Python 3.12
+- Application Insights telemetry
 
-**Constraints:**  
+### **2.3 T3 — Compute (Container Apps Function App)**
 
-- Runs in Container Apps with scale‑to‑zero enabled  
-- Must not perform heavy geospatial computation  
-- Must remain CPU/memory‑light to minimize idle cost  
+**Name:** `func-kmlsat-{env}-compute` (Phase 2)
 
----
+**Purpose:**
 
-### **2.3 Container Apps Jobs (Compute Layer)**
+- Run CPU/RAM-intensive activity functions: download_imagery,
+  post_process_imagery, run_enrichment
+- Scale to zero when no pipeline work queued
 
-**Purpose:**  
+**Resources:**
 
-- Execute high‑CPU, high‑memory geospatial workloads  
-- Scale to zero when idle  
-- Provide isolated, reproducible compute environments  
+- Image: ~1.2 GB (GDAL + rasterio + numpy + Rust/PyO3)
+- 4 vCPU, 8 GiB, **min 0 replicas** (scale-to-zero), max 10
+- KEDA trigger: Durable Functions activity queue depth
+- Cost: £0 idle, ~£0.40–1.60/hour during pipeline runs
 
-**Responsibilities:**  
+**Shared with T2:**
 
-- Run containerized geospatial code (GDAL, GeoPandas, PROJ, Shapely, etc.)  
-- Pull input data from Blob Storage  
-- Perform CPU/RAM‑intensive operations  
-- Write results back to Blob Storage  
-- Emit completion events or status updates  
+- Same Durable Functions task hub (`KmlSatelliteHub`)
+- Same storage account
+- Activities auto-route via the shared work queue — no explicit dispatch needed
 
-**Constraints:**  
+### **2.4 Azure Batch (Horizon)**
 
-- Stateless execution  
-- Configurable CPU/RAM (e.g., 8–32 vCPU, 32–256 GB RAM)  
-- Must terminate after job completion  
+For AOIs ≥50k ha or future GPU workloads, Azure Batch Spot VMs provide
+dedicated compute. Not currently active — deferred until proven necessary.
 
 ---
 
 ## **3. Data Flow**
 
-### **3.1 Request Flow**
+### **3.1 Upload + Pipeline Trigger**
 
-1. Client sends request to SWA API  
-2. SWA Function validates and forwards to Durable Orchestrator  
-3. Orchestrator creates a workflow instance  
+1. User authenticates via `/.auth/login/aad` (SWA built-in)
+2. Frontend calls `POST /api/upload/token` → T2 mints a write-only SAS URL
+3. Frontend uploads KML/KMZ directly to Blob Storage via SAS
+4. Event Grid fires BlobCreated → `kml_blob_trigger` (T2)
+5. Blob trigger validates input and starts the Durable orchestrator
 
-### **3.2 Orchestration Flow**
+### **3.2 Orchestration + Compute**
 
-1. Orchestrator splits workload into N tasks  
-2. For each task, orchestrator triggers a Container Apps Job  
-3. Orchestrator waits for job completion (polling or callback)  
-4. Orchestrator aggregates results  
-5. Orchestrator returns final output to SWA  
+1. Orchestrator (T2) runs phase pipeline:
+   - `parse_kml` → `prepare_aoi` → `write_metadata`
+   - `acquire_imagery` → `poll_order` (sub-orchestrator)
+   - `download_imagery` → `post_process_imagery` (dispatched to T3 via shared queue)
+   - `run_enrichment` (T3 — NDVI, change detection, weather)
+2. Results written to Blob Storage output paths
+3. Status updates written to Cosmos DB
 
-### **3.3 Compute Flow**
+### **3.3 Status Polling**
 
-1. Job container starts with assigned CPU/RAM  
-2. Job retrieves input from Blob Storage  
-3. Job performs geospatial processing  
-4. Job writes output to Blob Storage  
-5. Job exits (scale‑to‑zero)  
+1. Frontend polls `GET /api/upload/status/{id}` on T2
+2. T2 reads from Cosmos and returns progress + results
 
 ---
 
 ## **4. Scaling Characteristics**
 
-### **4.1 SWA Functions**
-
-- Always-on  
-- Low memory/CPU footprint  
-- Predictable cost  
-
-### **4.2 Durable Functions (Container Apps)**
-
-- Scale-to-zero when idle  
-- Scales out for orchestrations  
-- Minimal compute footprint  
-
-### **4.3 Container Apps Jobs**
-
-- Zero cost when idle  
-- Scale up/down per job  
-- Supports large compute bursts  
+| Component | Replicas | Cold Start | Scale Trigger |
+|-----------|----------|------------|---------------|
+| SWA | N/A (CDN) | None | N/A |
+| T2 (API+Orch) | 1–10 | None (min 1) | HTTP + queue depth |
+| T3 (Compute) | 0–10 | ~30–60s | Activity queue depth (KEDA) |
 
 ---
 
 ## **5. Operational Boundaries**
 
-### **SWA Functions**
+### **T2 (API + Orchestrator)**
 
-- May contain lightweight, request-scoped business logic (auth/authz, billing/quota checks, read/status lookups, SAS minting) but must not perform heavy compute or long-running processing  
-- Must not perform geospatial operations  
-- Must not call compute containers directly  
+- Serves all BFF endpoints — auth, billing, upload, status, history, export
+- Runs orchestrator and lightweight activities (parse, prepare, acquire, poll)
+- Must not import GDAL, rasterio, or heavy geospatial libraries (Phase 2)
+- Must not perform CPU-intensive raster processing
 
-### **Durable Functions**
+### **T3 (Compute)**
 
-- Must not perform heavy computation  
-- Must not store large payloads in state  
-- Must not assume synchronous job completion  
-
-### **Container Apps Jobs**
-
-- Must not maintain state between runs  
-- Must not expose public endpoints  
-- Must not depend on orchestrator availability  
+- Runs only activity functions that need GDAL/rasterio/Rust
+- Stateless — all data via Blob Storage claim-check pattern
+- Must not expose HTTP endpoints
+- Must not depend on T2 availability (activities are queue-driven)
 
 ---
 
 ## **6. Error Handling & Resilience**
 
-### **Durable Functions**
-
-- Automatic retries for transient failures  
-- Workflow state persisted in storage  
-- Fan‑out tasks isolated from each other  
-
-### **Container Apps Jobs**
-
-- Failures reported back to orchestrator  
-- Jobs can be retried independently  
-- Logs stored in Container Apps logging backend  
+- Durable Functions provide automatic retries for transient failures
+- Workflow state persisted in Azure Storage (durable)
+- Fan-out tasks are isolated — one AOI failure doesn't block others
+- Circuit breaker on Planetary Computer API (exponential backoff)
+- Failed activities are retried independently by the orchestrator
 
 ---
 
 ## **7. Security Model**
 
-- SWA handles authentication/authorization  
-- Durable Functions validate job parameters  
-- Container Apps Jobs access data via managed identity  
-- All inter‑service communication uses private networking  
+- SWA handles authentication (Azure AD built-in provider)
+- Auth forwarding: `X-MS-CLIENT-PRINCIPAL` header (BYOF pattern)
+- Container Apps FA uses managed identity for all Azure data-plane access
+- Key Vault for Stripe secrets and other sensitive config
+- CORS restricted to SWA hostname
+- Stripe webhooks use signature verification (not `X-MS-CLIENT-PRINCIPAL`)
 
 ---
 
-## **8. Benefits of This Architecture**
+## **8. Migration Phases**
 
-- **Minimal idle cost**  
-- **Massive compute bursts on demand**  
-- **Clear separation of concerns**  
-- **Durable, observable workflows**  
-- **Reproducible geospatial compute environments**  
-- **No VM or cluster management**  
+| Phase | Topology | Baseline Cost | Status |
+|-------|----------|---------------|--------|
+| **Phase 1 (P3)** | Single Container Apps FA — all endpoints + pipeline | ~£20/mo | ✅ Current |
+| **Phase 2 (P5)** | T2 (API+Orch) + T3 (Compute, scale-to-zero) | ~£8/mo | Planned |
+| **Phase 3 (P8)** | T2 + Container Apps Jobs (per-AOI burst) | ~£8/mo + usage | Horizon |
+
+Each phase is independently shippable and reversible.
 
 ---
+
+## **Decision: SWA Managed Functions Rejected** {#decision-swa-managed-functions-rejected}
+
+**Date:** 2026-04-10
+
+The original architecture spec proposed SWA managed functions as the
+always-warm API layer. This was rejected after implementation proved that SWA
+managed functions:
+
+1. **Do not support managed identity** — cannot access Key Vault, Cosmos, or
+   Blob via DefaultAzureCredential (#498)
+2. **Cannot resolve Key Vault references** — Stripe secrets unavailable (#506)
+3. **Cannot use Durable Functions** — no orchestration capability
+4. **Are pinned to Python ≤3.11** — behind the project's Python 3.12 baseline
+5. **Lack Application Insights integration** — no telemetry without manual setup
+6. **Duplicate every capability** — every endpoint must be re-implemented with
+   restricted tooling
+
+The Container Apps Function App already has managed identity, Key Vault,
+Durable Functions, Python 3.12, and 15+ endpoints. Consolidating onto it
+(BYOF pattern) eliminated ~900 lines of duplicated code and all five blockers.
+
+**Alternatives considered:**
+
+- **FastAPI on Container Apps** — rejected; loses Durable Functions and SWA
+  auth integration
+- **Azure API Management** — rejected; unnecessary cost/complexity for current scale
+- **SWA linked backend** — evaluated; still requires Container Apps FA, adds
+  complexity without solving managed identity gap

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -171,7 +171,7 @@ Backlog tracking:
 
 ## Provider Adapter Boundary
 
-The orchestrator calls provider adapters only through the ImageryProvider contract in kml_satellite/providers/base.py.
+The orchestrator calls provider adapters only through the ImageryProvider contract in `treesight/providers/base.py`.
 
 Required adapter methods:
 
@@ -197,7 +197,7 @@ Core runtime settings:
 - AzureWebJobsStorage
 - APPLICATIONINSIGHTS_CONNECTION_STRING
 
-Validation and defaults are implemented in kml_satellite/core/config.py.
+Validation and defaults are implemented in `treesight/config.py`.
 
 ## Observability Surface
 

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -22,10 +22,12 @@ Issue: #18
 
 1. Run CI checks.
 2. Deploy infrastructure and app via GitHub Actions deploy workflow.
-3. Verify Function host readiness using /api/health.
-4. Verify Event Grid subscription reconciliation succeeds.
-5. `/api/analysis/submit` must reject unauthenticated callers before any upload or orchestration work begins.
-6. For direct `analysis/` uploads created by `/api/analysis/submit`, rely on the HTTP submission path as the authoritative orchestration start; BlobCreated automation should only start storage-native uploads outside that prefix.
+3. Confirm Terraform-managed browser origins include the SWA default hostname and the production custom domain so both `/api/*` and direct blob SAS uploads pass CORS preflight.
+4. Preview SWA hosts are not wildcard-allowed for blob uploads; if a preview environment needs browser uploads, add its exact origin through infra before rollout.
+5. Verify Function host readiness using /api/health.
+6. Verify Event Grid subscription reconciliation succeeds.
+7. `/api/analysis/submit` must reject unauthenticated callers before any upload or orchestration work begins.
+8. For direct `analysis/` uploads created by `/api/analysis/submit`, rely on the HTTP submission path as the authoritative orchestration start; BlobCreated automation should only start storage-native uploads outside that prefix.
 
 Reference: .github/workflows/deploy.yml and infra/tofu/README.md.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -175,7 +175,7 @@ Make production safe to promote into. Build once in CI, promote the same immutab
 
 | Order | Issue | Title | Status |
 |-------|-------|-------|--------|
-| 2A.1 | #401 | Separate dev and prod deployment flows (immutable artifact promotion) | Open |
+| 2A.1 | #401 | Separate dev and prod deployment flows (immutable artifact promotion) | 🔄 In PR |
 | 2A.2 | #404 | Structured JSON logging at Azure Functions startup | ✅ Closed |
 | 2A.3 | #405 | Reduce Function App config drift between OpenTofu and az CLI | Open — depends #401 |
 | 2A.4 | #402 | Gate production deploys on security workflow results | Open — depends #401 |

--- a/infra/tofu/.terraform.lock.hcl
+++ b/infra/tofu/.terraform.lock.hcl
@@ -21,23 +21,6 @@ provider "registry.opentofu.org/azure/azapi" {
   ]
 }
 
-provider "registry.opentofu.org/hashicorp/azuread" {
-  version     = "3.8.0"
-  constraints = "~> 3.1"
-  hashes = [
-    "h1:rqAjqkA5dloKFuETW2+/jaFrnUFIPKJkTAkpQFUFh6k=",
-    "zh:0cb139a86c05254ad19d6fe7e287758121300d85f6093e5da2fc4e5bc3905b1e",
-    "zh:28a656a84534c5f954a0c77133737890a1923ff077cdde38a5c99073bffb5ec8",
-    "zh:2944340622ec29f64e2a6425ef6ef954bba7ece30f1a0aa3782a5725cd6a6b72",
-    "zh:4317d439cb32edd7f493dfab4b7b4cec55023564ed0bad7a41ee2fccc8cc42e7",
-    "zh:4446aedb4f31c84051f7868e14abf278d4a8d604fb8f1946f58624c2976797fa",
-    "zh:45fc14856de8baaafb1954298b6f6e68510e3225d8d794e07f3e2c295f7be6d7",
-    "zh:6996bf92d8a1ba346323659b631489849c971f8caac711cecb518409e35a3eed",
-    "zh:6f5a31e6e1aac4b2f84001cdb73f1f02833986141d0019b257d1a2e4a8598864",
-    "zh:a05b0790926f02bf0a80b4dd3595a3cdf1d22e175cbe1de0dccf04d66f827aee",
-  ]
-}
-
 provider "registry.opentofu.org/hashicorp/azurerm" {
   version     = "4.68.0"
   constraints = "~> 4.22"

--- a/infra/tofu/environments/prd.tfvars
+++ b/infra/tofu/environments/prd.tfvars
@@ -4,6 +4,7 @@ static_web_app_location           = "westeurope"
 location_code                     = "uks"
 project_code                      = "kmlsat"
 log_retention_days                = 90
+log_daily_cap_gb                  = 0.5
 enable_event_grid_subscription    = false
 enable_key_vault_purge_protection = true
 container_image                   = "mcr.microsoft.com/azure-functions/python:4-python3.12"
@@ -12,3 +13,7 @@ default_tags = {
 }
 budget_amount         = 50
 budget_contact_emails = ["alerts@jablab.dev"]
+custom_domain         = ""
+enable_azure_ai       = false
+enable_stripe         = true
+enable_cosmos_db      = true

--- a/infra/tofu/environments/prd.tfvars
+++ b/infra/tofu/environments/prd.tfvars
@@ -13,7 +13,7 @@ default_tags = {
 }
 budget_amount         = 50
 budget_contact_emails = ["alerts@jablab.dev"]
-custom_domain         = ""
+custom_domain         = "canopex.hrdcrprwn.com"
 enable_azure_ai       = false
 enable_stripe         = true
 enable_cosmos_db      = true

--- a/infra/tofu/locals.tf
+++ b/infra/tofu/locals.tf
@@ -24,4 +24,18 @@ locals {
   }
 
   tags = merge(local.required_tags, var.default_tags)
+
+  # Use exact browser origins so Function App and Blob Storage stay in sync.
+  # SWA preview hostnames are intentionally excluded because blob CORS must
+  # enumerate concrete origins for the direct browser SAS upload path.
+  browser_allowed_origins = distinct(concat(
+    var.environment == "prd" ? [] : [
+      "http://localhost:1111",
+      "http://localhost:4280",
+    ],
+    ["https://${azurerm_static_web_app.main.default_host_name}"],
+    var.custom_domain != "" ? ["https://${var.custom_domain}"] : []
+  ))
+
+  primary_site_url = var.custom_domain != "" ? "https://${var.custom_domain}" : "https://${azurerm_static_web_app.main.default_host_name}"
 }

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -25,7 +25,16 @@ resource "azurerm_storage_account" "main" {
   infrastructure_encryption_enabled = true
   allow_nested_items_to_be_public   = false
   shared_access_key_enabled         = true
-  tags                              = local.tags
+  blob_properties {
+    cors_rule {
+      allowed_headers    = ["*"]
+      allowed_methods    = ["OPTIONS", "PUT"]
+      allowed_origins    = local.browser_allowed_origins
+      exposed_headers    = ["ETag", "x-ms-request-id", "x-ms-version"]
+      max_age_in_seconds = 3600
+    }
+  }
+  tags = local.tags
 }
 
 resource "azurerm_storage_container" "kml_input" {
@@ -257,7 +266,7 @@ resource "azurerm_application_insights_standard_web_test" "site_ping" {
   tags          = local.tags
 
   request {
-    url = var.custom_domain != "" ? "https://${var.custom_domain}" : "https://${azurerm_static_web_app.main.default_host_name}"
+    url = local.primary_site_url
   }
 
   validation_rules {
@@ -656,8 +665,8 @@ resource "azapi_resource" "function_app" {
 
   # Workaround: azapi v2 "Missing Resource Identity After Update" bug.
   # The ARM API omits identity from update responses, crashing the provider.
-  # Body changes (image, app settings) are handled by az CLI in the deploy
-  # pipeline to avoid triggering updates that hit this bug.
+  # Body changes (image, app settings, platform CORS) are handled by az CLI
+  # in the deploy pipeline to avoid triggering updates that hit this bug.
   lifecycle {
     ignore_changes = [identity, body]
   }
@@ -675,14 +684,7 @@ resource "azapi_resource" "function_app" {
       siteConfig = {
         linuxFxVersion = "DOCKER|${var.container_image}"
         cors = {
-          allowedOrigins = concat(
-            [
-              "http://localhost:1111",
-              "https://${azurerm_static_web_app.main.default_host_name}",
-              "https://*.azurestaticapps.net",
-            ],
-            var.custom_domain != "" ? ["https://${var.custom_domain}"] : []
-          )
+          allowedOrigins     = local.browser_allowed_origins
           supportCredentials = false
         }
         appSettings = concat(
@@ -899,6 +901,7 @@ locals {
     {
       WEBSITES_ENABLE_APP_SERVICE_STORAGE = "false"
       AzureWebJobsStorage__accountName    = azurerm_storage_account.main.name
+      CORS_ALLOWED_ORIGINS                = join(",", local.browser_allowed_origins)
       REQUIRE_AUTH                        = var.environment == "prd" ? "true" : ""
     },
     var.enable_cosmos_db ? {

--- a/infra/tofu/outputs.tf
+++ b/infra/tofu/outputs.tf
@@ -48,8 +48,13 @@ output "custom_domain" {
   description = "Custom domain name (empty string if not configured)."
 }
 
+output "browser_allowed_origins" {
+  value       = local.browser_allowed_origins
+  description = "Browser origins allowed for Function App and blob upload CORS."
+}
+
 output "site_url" {
-  value       = var.custom_domain != "" ? "https://${var.custom_domain}" : "https://${azurerm_static_web_app.main.default_host_name}"
+  value       = local.primary_site_url
   description = "Primary site URL (custom domain if configured, otherwise default)."
 }
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -266,7 +266,7 @@ class TestCorsHeaders:
         req = func.HttpRequest(
             method="OPTIONS",
             url="/api/test",
-            headers={"Origin": "https://polite-glacier-0d6885003.4.azurestaticapps.net"},
+            headers={"Origin": "https://canopex.hrdcrprwn.com"},
             body=b"",
         )
         headers = cors_headers(req)

--- a/tests/test_frontend_config.py
+++ b/tests/test_frontend_config.py
@@ -190,15 +190,13 @@ class TestAuthConfig:
 
 
 class TestCorsConfig:
-    def test_swa_hostname_in_cors_origins(self):
-        """The SWA default hostname must be in _ALLOWED_ORIGINS."""
+    def test_no_hardcoded_swa_hostname_in_cors_origins(self):
+        """SWA hostnames must come from env, not stale code constants."""
         src = HELPERS_PY.read_text()
-        assert re.search(
-            r'["\']https://polite-glacier-0d6885003\.4\.azurestaticapps\.net["\']', src
-        ), "_ALLOWED_ORIGINS must contain the SWA default hostname"
+        assert ".azurestaticapps.net" not in src
 
     def test_custom_domain_in_cors_origins(self):
-        """The custom domain must be in _ALLOWED_ORIGINS."""
+        """The custom domain must remain in the stable allowlist."""
         src = HELPERS_PY.read_text()
         assert re.search(r'["\']https://canopex\.hrdcrprwn\.com["\']', src), (
             "_ALLOWED_ORIGINS must contain the custom domain"

--- a/tests/test_health_endpoints.py
+++ b/tests/test_health_endpoints.py
@@ -10,11 +10,11 @@ Covers:
 import json
 
 from blueprints.health import contract, health, readiness
-from tests.conftest import TEST_ORIGIN, make_test_request
+from tests.conftest import TEST_LOCAL_ORIGIN, TEST_ORIGIN, make_test_request
 from treesight import __git_sha__, __version__
 from treesight.constants import API_CONTRACT_VERSION
 
-_ALLOWED_ORIGIN = "https://polite-glacier-0d6885003.4.azurestaticapps.net"
+_ALLOWED_ORIGIN = TEST_LOCAL_ORIGIN
 _CUSTOM_DOMAIN_ORIGIN = TEST_ORIGIN
 _UNKNOWN_ORIGIN = "https://evil.example.com"
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -18,6 +18,7 @@ from blueprints._helpers import (
 from blueprints.analysis import (
     _sanitise_for_prompt,  # pyright: ignore[reportPrivateUsage]
 )
+from tests.conftest import TEST_ORIGIN
 from treesight.parsers import ensure_closed
 
 # ---------------------------------------------------------------------------
@@ -139,7 +140,7 @@ class TestErrorResponse:
 
 
 class TestCorsPreflight:
-    def _make_req(self, origin="https://polite-glacier-0d6885003.4.azurestaticapps.net"):
+    def _make_req(self, origin=TEST_ORIGIN):
         return func.HttpRequest(
             method="OPTIONS",
             url="/api/test",
@@ -237,6 +238,39 @@ class TestCorsOriginHardening:
         assert test_origin in origins, f"Expected {test_origin} in CORS origins"
         # Restore
         self._reload_with_env(monkeypatch)
+
+    def test_cors_headers_accept_env_injected_origin(self, monkeypatch):
+        """cors_headers must honor a current SWA hostname injected from env."""
+        import importlib
+        import sys
+
+        injected_origin = "https://green-moss-0e849ac03.2.azurestaticapps.net"
+        try:
+            monkeypatch.setenv("CORS_ALLOWED_ORIGINS", injected_origin)
+            helpers_mod = importlib.reload(sys.modules["blueprints._helpers"])
+            req = func.HttpRequest(
+                method="OPTIONS",
+                url="/api/test",
+                headers={"Origin": injected_origin},
+                body=b"",
+            )
+
+            headers = helpers_mod.cors_headers(req)
+            assert headers["Access-Control-Allow-Origin"] == injected_origin
+        finally:
+            self._reload_with_env(monkeypatch)
+
+    @pytest.mark.parametrize("require_auth", ["true", "1", "yes"])
+    def test_excludes_localhost_when_require_auth_enabled(self, monkeypatch, require_auth):
+        """Production-style auth mode must not keep localhost in the allowlist."""
+        try:
+            monkeypatch.setenv("REQUIRE_AUTH", require_auth)
+            origins = self._reload_with_env(monkeypatch, None)
+            assert "http://localhost:4280" not in origins
+            assert "http://localhost:1111" not in origins
+        finally:
+            monkeypatch.delenv("REQUIRE_AUTH", raising=False)
+            self._reload_with_env(monkeypatch)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Parameterize the deploy workflow for build-once/promote semantics and add SWA PR preview environments.

fixes #401

## Changes

### deploy.yml — environment-aware promotion pipeline
- **`environment` input** (choice: `dev` / `prd`) — selects the GitHub Environment, tfvars file, and TF state backend
- **`image_tag` input** — when set, skips the entire build/scan pipeline and promotes an existing GHCR image
- **`DEPLOY_ENV` env var** — drives `environments/${DEPLOY_ENV}.tfvars`, `TF_STATE_CONTAINER`, `TF_STATE_KEY` per-environment
- All hardcoded `environment: dev` and `dev.tfvars` references are now dynamic
- TF state secrets renamed: `TF_STATE_CONTAINER_DEV` / `TF_STATE_KEY_DEV` → `TF_STATE_CONTAINER` / `TF_STATE_KEY` (set per GitHub Environment)

### preview-site.yml — new SWA PR preview workflow
- Triggered on PRs that modify `website/**`
- Deploys to SWA staging environment `pr-{number}`
- Tears down staging environment on PR close

### prd.tfvars — completed
- Added missing fields: `log_daily_cap_gb`, `custom_domain`, `enable_azure_ai`, `enable_stripe`, `enable_cosmos_db`

## Promotion workflow

```
# Normal deploy (CI passes on main → build + deploy to dev)
workflow_run trigger → build-image → deploy-infra(dev) → deploy-website(dev)

# Promote to prd (manual, reuse immutable image)
workflow_dispatch(environment=prd, image_tag=abc123) → resolve-image → deploy-infra(prd) → deploy-website(prd)
```

## Follow-up (out of scope)

- Configure `prd` GitHub Environment with its own secrets (`TF_STATE_CONTAINER`, `TF_STATE_KEY`, `AZURE_*`, `SWA_DEPLOYMENT_TOKEN`)
- Add required reviewers / environment protection rules for `prd`
- Container Apps revision routing for canary deploys (#403)
- Security gate on production deploys (#402)

## Validation

- 1071 tests pass
- YAML lint passes (pre-commit `actionlint`)
- No changes to runtime code