### PR TITLE
fix: resolve TF_STATE_CONTAINER/KEY from env-suffixed secrets in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -214,6 +214,16 @@ jobs:
           key: tofu-providers-${{ hashFiles('infra/tofu/.terraform.lock.hcl') }}
           restore-keys: tofu-providers-
 
+      - name: Resolve state backend secrets
+        run: |
+          if [ "${{ env.DEPLOY_ENV }}" == "prd" ]; then
+            echo "TF_STATE_CONTAINER=${{ secrets.TF_STATE_CONTAINER_PRD }}" >> "$GITHUB_ENV"
+            echo "TF_STATE_KEY=${{ secrets.TF_STATE_KEY_PRD }}" >> "$GITHUB_ENV"
+          else
+            echo "TF_STATE_CONTAINER=${{ secrets.TF_STATE_CONTAINER_DEV }}" >> "$GITHUB_ENV"
+            echo "TF_STATE_KEY=${{ secrets.TF_STATE_KEY_DEV }}" >> "$GITHUB_ENV"
+          fi
+
       - name: Tofu Init
         working-directory: infra/tofu
         env:
@@ -228,8 +238,8 @@ jobs:
             if tofu init \
               -backend-config="resource_group_name=${{ secrets.TF_STATE_RESOURCE_GROUP }}" \
               -backend-config="storage_account_name=${{ secrets.TF_STATE_STORAGE_ACCOUNT }}" \
-              -backend-config="container_name=${{ secrets.TF_STATE_CONTAINER }}" \
-              -backend-config="key=${{ secrets.TF_STATE_KEY }}"; then
+              -backend-config="container_name=$TF_STATE_CONTAINER" \
+              -backend-config="key=$TF_STATE_KEY"; then
               echo "✅ tofu init succeeded on attempt ${attempt}"
               exit 0
             fi


### PR DESCRIPTION
## Problem

The deploy workflow referenced `secrets.TF_STATE_CONTAINER` and `secrets.TF_STATE_KEY` which don't exist as named. The actual repo/environment secrets are suffixed: `TF_STATE_CONTAINER_DEV`, `TF_STATE_CONTAINER_PRD`, `TF_STATE_KEY_DEV`, `TF_STATE_KEY_PRD`.

This caused `tofu init` to receive an empty `container_name` backend-config value, resulting in a `ContainerNotFound` 404 on every deploy run after PR #516 merged.

## Fix

Add a **Resolve state backend secrets** step before Tofu Init that writes the correct pair into `GITHUB_ENV` based on `DEPLOY_ENV`, then reference them as shell env vars (`$TF_STATE_CONTAINER`, `$TF_STATE_KEY`) in the backend-config flags.

## Validation

- Workflow YAML lints cleanly (GitHub Actions linter in pre-commit passes)
- No other references to the old bare secret names remain in the workflow