### PR TITLE
feat: ops dashboard, CORS env-var fix, cold-start mitigation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -366,6 +366,12 @@ jobs:
             --url "${FUNC_ID}?api-version=2024-04-01" \
             --body "{\"properties\":{\"functionAppConfig\":{\"scaleAndConcurrency\":{\"maximumInstanceCount\":${MAX_INSTANCES}}}}}"
 
+          # Apply minimum always-ready instances to avoid cold-start 504s
+          MIN_INSTANCES=$(tofu output -raw function_app_cli_minimum_instance_count)
+          az rest --method PATCH \
+            --url "${FUNC_ID}/config/web?api-version=2024-04-01" \
+            --body "{\"properties\":{\"minimumElasticInstanceCount\":${MIN_INSTANCES}}}"
+
       - name: Verify browser CORS contract
         id: verify-browser-cors
         working-directory: infra/tofu

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -367,10 +367,21 @@ jobs:
             --body "{\"properties\":{\"functionAppConfig\":{\"scaleAndConcurrency\":{\"maximumInstanceCount\":${MAX_INSTANCES}}}}}"
 
           # Apply minimum always-ready instances to avoid cold-start 504s
+          # Uses functionAppConfig.scaleAndConcurrency.alwaysReady for Container Apps
           MIN_INSTANCES=$(tofu output -raw function_app_cli_minimum_instance_count)
+          if [ "$MIN_INSTANCES" -gt 0 ]; then
+            ALWAYS_READY='[{"name":"http","instanceCount":'"${MIN_INSTANCES}"'}]'
+          else
+            ALWAYS_READY='[]'
+          fi
           az rest --method PATCH \
-            --url "${FUNC_ID}/config/web?api-version=2024-04-01" \
-            --body "{\"properties\":{\"minimumElasticInstanceCount\":${MIN_INSTANCES}}}"
+            --url "${FUNC_ID}?api-version=2024-04-01" \
+            --body "{\"properties\":{\"functionAppConfig\":{\"scaleAndConcurrency\":{\"alwaysReady\":${ALWAYS_READY}}}}}"
+
+          # Verify min instances applied
+          ACTUAL=$(az rest --method GET --url "${FUNC_ID}?api-version=2024-04-01" \
+            | jq '.properties.functionAppConfig.scaleAndConcurrency.alwaysReady // []')
+          echo "Always-ready config: $ACTUAL"
 
       - name: Verify browser CORS contract
         id: verify-browser-cors

--- a/blueprints/_helpers.py
+++ b/blueprints/_helpers.py
@@ -17,24 +17,51 @@ EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 MAX_FIELD_LEN = 2000
 
 
-def _default_allowed_origins() -> set[str]:
-    origins = {"https://canopex.hrdcrprwn.com"}
+def _track_req(
+    req: func.HttpRequest,
+    resp: func.HttpResponse,
+    user_id: str,
+    t0: float,
+) -> None:
+    """Record request for ops dashboard (best-effort, never raises)."""
+    import time
+
+    try:
+        from blueprints.ops import track_request
+
+        track_request(
+            method=req.method or "",
+            path=req.url.split("/api/")[-1].split("?")[0] if "/api/" in req.url else req.url,
+            status=resp.status_code,
+            user_id=user_id,
+            duration_ms=(time.monotonic() - t0) * 1000,
+        )
+    except Exception:  # noqa: S110 — must never break request handling
+        pass
+
+
+def _build_allowed_origins() -> set[str]:
+    """Build allowed origins from the infra-managed CORS_ALLOWED_ORIGINS env var.
+
+    Production origins come exclusively from the env var which is set by
+    OpenTofu (``local.browser_allowed_origins``).  Localhost dev origins
+    are added only when ``REQUIRE_AUTH`` is not enforced.
+    """
+    origins: set[str] = set()
+
+    configured = os.environ.get("CORS_ALLOWED_ORIGINS", "")
+    for origin in configured.split(","):
+        origin = origin.strip()
+        if origin and origin.startswith("https://"):
+            origins.add(origin)
+
     if os.environ.get("REQUIRE_AUTH", "").lower() not in ("true", "1", "yes"):
         origins.update({"http://localhost:4280", "http://localhost:1111"})
+
     return origins
 
 
-# Stable browser origins allowed without infra-provided overrides.
-_ALLOWED_ORIGINS: set[str] = _default_allowed_origins()
-
-# Allow override via env var (comma-separated) for current SWA/default hosts.
-# Only https:// origins are accepted to prevent open CORS misconfiguration.
-_extra = os.environ.get("CORS_ALLOWED_ORIGINS", "")
-if _extra:
-    for origin in _extra.split(","):
-        origin = origin.strip()
-        if origin and origin.startswith("https://"):
-            _ALLOWED_ORIGINS.add(origin)
+_ALLOWED_ORIGINS: set[str] = _build_allowed_origins()
 
 
 def _cors_origin(req: func.HttpRequest) -> str:
@@ -98,10 +125,15 @@ def require_auth(fn):
         if req.method == "OPTIONS":
             return cors_preflight(req)
 
+        import time as _time
+
+        _t0 = _time.monotonic()
         principal_header = req.headers.get("X-MS-CLIENT-PRINCIPAL", "")
         if not principal_header:
             if os.environ.get("REQUIRE_AUTH", "").lower() not in ("true", "1", "yes"):
-                return fn(req, auth_claims={}, user_id="anonymous")
+                resp = fn(req, auth_claims={}, user_id="anonymous")
+                _track_req(req, resp, "anonymous", _t0)
+                return resp
             return error_response(401, "Authentication required", req=req)
 
         try:
@@ -109,7 +141,10 @@ def require_auth(fn):
         except ValueError as exc:
             return error_response(401, str(exc), req=req)
 
-        return fn(req, auth_claims=principal, user_id=get_user_id(principal))
+        uid = get_user_id(principal)
+        resp = fn(req, auth_claims=principal, user_id=uid)
+        _track_req(req, resp, uid, _t0)
+        return resp
 
     # @wraps copies __wrapped__, which makes inspect.signature() expose
     # the inner function's extra parameters (auth_claims, user_id).

--- a/blueprints/billing.py
+++ b/blueprints/billing.py
@@ -6,6 +6,7 @@ cancellation (Consumer Contracts Regulations 2013 — 14-day cooling-off).
 
 import json
 import logging
+import os
 from urllib.parse import urlparse
 
 import azure.functions as func
@@ -153,7 +154,9 @@ def billing_checkout(
         return error_response(503, "Billing not configured", req=req)
 
     stripe = _get_stripe()
-    origin = _cors_origin(req) or "https://canopex.hrdcrprwn.com"
+    origin = _cors_origin(req) or os.environ.get("PRIMARY_SITE_URL", "")
+    if not origin:
+        return error_response(503, "Site URL not configured", req=req)
 
     from treesight.constants import DEFAULT_CURRENCY, SUPPORTED_CURRENCIES
 
@@ -192,7 +195,7 @@ def billing_checkout(
                 "terms_of_service_acceptance": {
                     "message": (
                         "I agree to the [Terms of Service]"
-                        "(https://canopex.hrdcrprwn.com/terms.html)"
+                        f"({origin}/terms.html)"
                         " and acknowledge my right to cancel within"
                         " 14 days under the Consumer Contracts"
                         " Regulations 2013."
@@ -240,7 +243,9 @@ def billing_portal(req: func.HttpRequest, *, auth_claims: dict, user_id: str) ->
         return error_response(404, "No active subscription found", req=req)
 
     stripe = _get_stripe()
-    origin = _cors_origin(req) or "https://canopex.hrdcrprwn.com"
+    origin = _cors_origin(req) or os.environ.get("PRIMARY_SITE_URL", "")
+    if not origin:
+        return error_response(503, "Site URL not configured", req=req)
 
     try:
         session = stripe.billing_portal.Session.create(

--- a/blueprints/ops.py
+++ b/blueprints/ops.py
@@ -14,6 +14,7 @@ Azure Functions worker cannot resolve deferred type annotations at
 function-index time.
 """
 
+import hmac
 import json
 import logging
 import os
@@ -127,9 +128,8 @@ def _check_ops_key(req: func.HttpRequest) -> bool:
 
     auth = req.headers.get("Authorization", "")
     if auth.startswith("Bearer "):
-        return auth[7:].strip() == key
-    # Also accept as query param for curl convenience
-    return req.params.get("key", "") == key
+        return hmac.compare_digest(auth[7:].strip(), key)
+    return False  # header-only auth; query-param keys leak via logs/referrers
 
 
 # ---------------------------------------------------------------------------

--- a/blueprints/ops.py
+++ b/blueprints/ops.py
@@ -1,0 +1,251 @@
+"""Ops dashboard endpoint — live pipeline visibility for operators.
+
+Serves a single JSON payload with:
+- app health / version info
+- active durable orchestrations with phase/step detail
+- recent submissions from Cosmos ``runs`` container
+- basic request-rate counters
+
+Protected by ``OPS_DASHBOARD_KEY`` bearer token (env var).
+Not exposed to end users or CORS origins.
+
+NOTE: Do NOT add ``from __future__ import annotations`` to this module.
+Azure Functions worker cannot resolve deferred type annotations at
+function-index time.
+"""
+
+import json
+import logging
+import os
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import azure.durable_functions as df
+import azure.functions as func
+
+from treesight import __git_sha__, __version__
+
+logger = logging.getLogger(__name__)
+
+bp = func.Blueprint()
+
+# ---------------------------------------------------------------------------
+# In-memory request tracker (lightweight, no external deps)
+# ---------------------------------------------------------------------------
+
+_MAX_RECENT = 200
+_recent_requests: list[dict[str, Any]] = []
+_start_time = time.monotonic()
+
+
+def track_request(
+    *,
+    method: str,
+    path: str,
+    status: int,
+    user_id: str = "",
+    duration_ms: float = 0,
+) -> None:
+    """Record a request for ops visibility. Call from _helpers or middleware."""
+    _recent_requests.append(
+        {
+            "ts": datetime.now(UTC).isoformat(),
+            "method": method,
+            "path": path,
+            "status": status,
+            "user": user_id or "anon",
+            "dur_ms": round(duration_ms, 1),
+        }
+    )
+    # Trim oldest when buffer is full
+    while len(_recent_requests) > _MAX_RECENT:
+        _recent_requests.pop(0)
+
+
+def _active_users(minutes: int = 15) -> list[str]:
+    """Distinct user IDs seen in the last N minutes."""
+    from datetime import timedelta
+
+    cutoff = datetime.now(UTC) - timedelta(minutes=minutes)
+    seen: dict[str, str] = {}
+    for r in reversed(_recent_requests):
+        try:
+            ts = datetime.fromisoformat(r["ts"])
+        except (ValueError, KeyError):
+            continue
+        if ts < cutoff:
+            break
+        uid = r.get("user", "anon")
+        if uid not in seen:
+            seen[uid] = r["ts"]
+    return list(seen.keys())
+
+
+def _request_summary(minutes: int = 15) -> dict[str, Any]:
+    """Summarise recent requests by path and status."""
+    from datetime import timedelta
+
+    cutoff = datetime.now(UTC) - timedelta(minutes=minutes)
+    total = 0
+    by_path: dict[str, int] = {}
+    by_status: dict[int, int] = {}
+    uploads = 0
+    for r in reversed(_recent_requests):
+        try:
+            ts = datetime.fromisoformat(r["ts"])
+        except (ValueError, KeyError):
+            continue
+        if ts < cutoff:
+            break
+        total += 1
+        path = r.get("path", "?")
+        by_path[path] = by_path.get(path, 0) + 1
+        status = r.get("status", 0)
+        by_status[status] = by_status.get(status, 0) + 1
+        if "upload" in path or "submit" in path:
+            uploads += 1
+    return {
+        "total": total,
+        "uploads": uploads,
+        "by_path": dict(sorted(by_path.items(), key=lambda x: -x[1])[:10]),
+        "by_status": by_status,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def _check_ops_key(req: func.HttpRequest) -> bool:
+    """Validate bearer token against OPS_DASHBOARD_KEY."""
+    key = os.environ.get("OPS_DASHBOARD_KEY", "")
+    if not key:
+        # No key configured → allow in dev, block in prod
+        return os.environ.get("REQUIRE_AUTH", "").lower() not in ("true", "1", "yes")
+
+    auth = req.headers.get("Authorization", "")
+    if auth.startswith("Bearer "):
+        return auth[7:].strip() == key
+    # Also accept as query param for curl convenience
+    return req.params.get("key", "") == key
+
+
+# ---------------------------------------------------------------------------
+# Data fetchers
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_orchestrations(
+    client: df.DurableOrchestrationClient,
+) -> list[dict[str, Any]]:
+    """Query Durable Functions for active + recently completed orchestrations."""
+    results: list[dict[str, Any]] = []
+
+    for runtime_filter in [
+        df.OrchestrationRuntimeStatus.Running,
+        df.OrchestrationRuntimeStatus.Pending,
+    ]:
+        try:
+            instances = await client.get_status_by(  # type: ignore[attr-defined]
+                runtime_status=[runtime_filter],
+            )
+            for inst in instances:
+                custom = inst.custom_status or {}
+                if isinstance(custom, str):
+                    try:
+                        custom = json.loads(custom)
+                    except (json.JSONDecodeError, TypeError):
+                        custom = {"raw": custom}
+
+                results.append(
+                    {
+                        "instanceId": inst.instance_id,
+                        "name": inst.name,
+                        "runtimeStatus": inst.runtime_status.value if inst.runtime_status else None,
+                        "createdTime": str(inst.created_time),
+                        "lastUpdatedTime": str(inst.last_updated_time),
+                        "phase": custom.get("phase", "") if isinstance(custom, dict) else "",
+                        "step": custom.get("step", "") if isinstance(custom, dict) else "",
+                        "customStatus": custom,
+                    }
+                )
+        except Exception:
+            logger.debug("Failed to query orchestrations for %s", runtime_filter, exc_info=True)
+
+    return results
+
+
+def _fetch_recent_runs(limit: int = 20) -> list[dict[str, Any]]:
+    """Fetch recent pipeline runs from Cosmos."""
+    from treesight.storage.cosmos import cosmos_available, query_items
+
+    if not cosmos_available():
+        return []
+
+    try:
+        return query_items(
+            "runs",
+            "SELECT TOP @limit c.id, c.submission_id, c.user_id, c.status,"
+            " c.submitted_at, c.feature_count, c.aoi_count,"
+            " c.provider_name, c.processing_mode"
+            " FROM c ORDER BY c.submitted_at DESC",
+            parameters=[{"name": "@limit", "value": limit}],
+        )
+    except Exception:
+        logger.debug("Cosmos query for recent runs failed", exc_info=True)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@bp.route(
+    route="ops/dashboard",
+    methods=["GET"],
+    auth_level=func.AuthLevel.ANONYMOUS,
+)
+@bp.durable_client_input(client_name="client")
+async def ops_dashboard(
+    req: func.HttpRequest,
+    client: df.DurableOrchestrationClient,
+) -> func.HttpResponse:
+    """GET /api/ops/dashboard — live pipeline status for the CLI dashboard."""
+    if not _check_ops_key(req):
+        return func.HttpResponse(
+            json.dumps({"error": "Unauthorized"}),
+            status_code=401,
+            mimetype="application/json",
+        )
+
+    orchestrations = await _fetch_orchestrations(client)
+    recent_runs = _fetch_recent_runs()
+    active_users = _active_users()
+    req_summary = _request_summary()
+    uptime_s = int(time.monotonic() - _start_time)
+
+    payload = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "app": {
+            "version": __version__,
+            "commit": __git_sha__,
+            "uptime_seconds": uptime_s,
+        },
+        "activeUsers": active_users,
+        "activeUserCount": len(active_users),
+        "requests": req_summary,
+        "recentRequests": _recent_requests[-30:],
+        "orchestrations": orchestrations,
+        "orchestrationCount": len(orchestrations),
+        "recentRuns": recent_runs,
+        "recentRunCount": len(recent_runs),
+    }
+
+    return func.HttpResponse(
+        json.dumps(payload, default=str),
+        status_code=200,
+        mimetype="application/json",
+    )

--- a/function_app.py
+++ b/function_app.py
@@ -26,6 +26,7 @@ from blueprints.eudr import bp as eudr_bp
 from blueprints.export import bp as export_bp
 from blueprints.health import bp as health_bp
 from blueprints.monitoring import bp as monitoring_bp
+from blueprints.ops import bp as ops_bp
 from blueprints.pipeline import bp as pipeline_bp
 from blueprints.upload import bp as upload_bp
 
@@ -76,6 +77,9 @@ app.register_functions(upload_bp)
 
 # Register monitoring blueprint (Timer Trigger + HTTP)
 app.register_functions(monitoring_bp)
+
+# Register ops dashboard (operator visibility)
+app.register_functions(ops_bp)
 
 # Register durable pipeline blueprint
 app.register_functions(pipeline_bp)

--- a/infra/tofu/environments/dev.tfvars
+++ b/infra/tofu/environments/dev.tfvars
@@ -17,3 +17,4 @@ custom_domain         = ""
 enable_azure_ai         = false
 enable_stripe           = true
 enable_cosmos_db         = true
+function_min_instances  = 1

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -679,12 +679,10 @@ resource "azapi_resource" "function_app" {
       functionAppConfig = {
         scaleAndConcurrency = {
           maximumInstanceCount = var.function_max_instances
-          alwaysReady = var.function_min_instances > 0 ? [
-            {
-              name          = "http"
-              instanceCount = var.function_min_instances
-            }
-          ] : []
+          # NOTE: alwaysReady (min instances) is managed exclusively by the
+          # deploy pipeline via az rest PATCH. Not declared here because body
+          # is in lifecycle.ignore_changes and would only take effect on first
+          # creation, causing confusing drift.
         }
       }
       siteConfig = {

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -679,6 +679,12 @@ resource "azapi_resource" "function_app" {
       functionAppConfig = {
         scaleAndConcurrency = {
           maximumInstanceCount = var.function_max_instances
+          alwaysReady = var.function_min_instances > 0 ? [
+            {
+              name          = "http"
+              instanceCount = var.function_min_instances
+            }
+          ] : []
         }
       }
       siteConfig = {
@@ -902,7 +908,9 @@ locals {
       WEBSITES_ENABLE_APP_SERVICE_STORAGE = "false"
       AzureWebJobsStorage__accountName    = azurerm_storage_account.main.name
       CORS_ALLOWED_ORIGINS                = join(",", local.browser_allowed_origins)
+      PRIMARY_SITE_URL                    = local.primary_site_url
       REQUIRE_AUTH                        = var.environment == "prd" ? "true" : ""
+      OPS_DASHBOARD_KEY                   = var.ops_dashboard_key
     },
     var.enable_cosmos_db ? {
       COSMOS_ENDPOINT      = azurerm_cosmosdb_account.main[0].endpoint

--- a/infra/tofu/outputs.tf
+++ b/infra/tofu/outputs.tf
@@ -28,6 +28,11 @@ output "function_app_cli_maximum_instance_count" {
   description = "CLI-managed Function App maximum instance count sourced from Terraform."
 }
 
+output "function_app_cli_minimum_instance_count" {
+  value       = var.function_min_instances
+  description = "CLI-managed Function App minimum always-ready instance count."
+}
+
 output "static_web_app_name" {
   value       = azurerm_static_web_app.main.name
   description = "Static Web App name."

--- a/infra/tofu/outputs.tf
+++ b/infra/tofu/outputs.tf
@@ -21,6 +21,7 @@ output "function_app_default_hostname" {
 output "function_app_cli_app_settings" {
   value       = local.function_app_cli_app_settings
   description = "CLI-managed Function App app settings sourced from Terraform."
+  sensitive   = true
 }
 
 output "function_app_cli_maximum_instance_count" {

--- a/infra/tofu/variables.tf
+++ b/infra/tofu/variables.tf
@@ -89,6 +89,19 @@ variable "function_max_instances" {
   default     = 3
 }
 
+variable "function_min_instances" {
+  description = "Minimum always-ready instances. Set to 1 to avoid cold-start 504s."
+  type        = number
+  default     = 0
+}
+
+variable "ops_dashboard_key" {
+  description = "Bearer token for /api/ops/dashboard. Empty = allow unauthenticated (dev only)."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "log_daily_cap_gb" {
   description = "Log Analytics daily ingestion cap in GB. -1 for unlimited."
   type        = number

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -1,0 +1,752 @@
+#!/usr/bin/env python3
+"""Live pipeline dashboard — kanban-style CLI monitor.
+
+Usage:
+    uv run python scripts/dashboard.py                          # auto-detect from infra
+    uv run python scripts/dashboard.py --host func-kmlsat-dev.jollysea-48e72cf8.uksouth.azurecontainerapps.io
+    uv run python scripts/dashboard.py --app-insights 387f53d2-98ef-4fc8-9296-32fda4c74bb3
+
+Requires: ``az`` CLI authenticated, ``rich`` Python package.
+Refreshes every 10 seconds (configurable with --interval).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime
+
+try:
+    from rich.console import Console
+    from rich.layout import Layout
+    from rich.live import Live
+    from rich.panel import Panel
+    from rich.table import Table
+    from rich.text import Text
+except ImportError:
+    print("ERROR: 'rich' is required.  pip install rich")
+    sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PHASE_ORDER = [
+    "uploaded",
+    "ingestion",
+    "acquisition",
+    "fulfilment",
+    "enrichment",
+    "completed",
+    "failed",
+]
+
+_PHASE_STYLE = {
+    "uploaded": "bold cyan",
+    "ingestion": "bold yellow",
+    "acquisition": "bold blue",
+    "fulfilment": "bold magenta",
+    "enrichment": "bold green",
+    "completed": "bold green",
+    "failed": "bold red",
+}
+
+_RUNTIME_TO_PHASE = {
+    "Pending": "uploaded",
+    "Running": None,  # use customStatus
+    "Completed": "completed",
+    "Failed": "failed",
+    "Terminated": "failed",
+    "Canceled": "failed",
+    "Suspended": "uploaded",
+}
+
+
+def _az_query(app_id: str, query: str, timeout: int = 15) -> list[dict]:
+    """Run a KQL query against App Insights via ``az monitor``."""
+    try:
+        proc = subprocess.run(
+            [
+                "az",
+                "monitor",
+                "app-insights",
+                "query",
+                "--app",
+                app_id,
+                "--analytics-query",
+                query,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if proc.returncode != 0:
+            return []
+        data = json.loads(proc.stdout)
+        tables = data.get("tables", [])
+        if not tables:
+            return []
+        cols = [c["name"] for c in tables[0].get("columns", [])]
+        return [dict(zip(cols, row, strict=False)) for row in tables[0].get("rows", [])]
+    except Exception:
+        return []
+
+
+def _http_get(url: str, timeout: int = 8, headers: dict | None = None) -> dict | None:
+    """Simple GET via curl (avoids extra Python deps)."""
+    try:
+        cmd = ["curl", "-sS", "--max-time", str(timeout)]
+        if headers:
+            for k, v in headers.items():
+                cmd.extend(["-H", f"{k}: {v}"])
+        cmd.append(url)
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout + 2)
+        if proc.returncode != 0:
+            return None
+        return json.loads(proc.stdout)
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Data fetchers
+# ---------------------------------------------------------------------------
+
+
+def fetch_health(host: str) -> dict:
+    """Hit /api/health and return status + latency."""
+    start = time.monotonic()
+    result = _http_get(f"https://{host}/api/health")
+    latency_ms = int((time.monotonic() - start) * 1000)
+    if result:
+        return {"status": "healthy", "latency_ms": latency_ms, "detail": result}
+    return {"status": "unreachable", "latency_ms": latency_ms, "detail": {}}
+
+
+def fetch_ops_dashboard(host: str, ops_key: str = "") -> dict | None:
+    """Hit /api/ops/dashboard — returns the full ops payload or None on failure."""
+    url = f"https://{host}/api/ops/dashboard"
+    headers = {}
+    if ops_key:
+        headers["Authorization"] = f"Bearer {ops_key}"
+    return _http_get(url, timeout=10, headers=headers or None)
+
+
+def fetch_requests(app_id: str, minutes: int = 30) -> list[dict]:
+    """Recent HTTP requests from App Insights."""
+    return _az_query(
+        app_id,
+        f"""requests
+        | where timestamp > ago({minutes}m)
+        | project timestamp, name, resultCode, duration,
+                  client_IP, user_AuthenticatedId
+        | order by timestamp desc
+        | take 20""",
+    )
+
+
+def fetch_errors(app_id: str, minutes: int = 60) -> list[dict]:
+    """Recent errors and warnings."""
+    return _az_query(
+        app_id,
+        f"""union traces, exceptions
+        | where timestamp > ago({minutes}m)
+        | where severityLevel >= 3
+              or itemType == "exception"
+        | project timestamp,
+                  message = coalesce(message, outerMessage, ""),
+                  operation_Name, severityLevel, itemType
+        | order by timestamp desc
+        | take 15""",
+    )
+
+
+def fetch_durable_instances(host: str) -> list[dict]:
+    """Query the Durable Functions status endpoint for active instances.
+
+    Requires the system key — returns empty list if unavailable (we fall
+    back to App Insights traces for pipeline visibility).
+    """
+    url = (
+        f"https://{host}/runtime/webhooks/durabletask/instances"
+        f"?runtimeStatus=Running,Pending&top=20"
+        f"&taskHub=TreeSightHub"
+    )
+    result = _http_get(url, timeout=10)
+    if isinstance(result, list):
+        return result
+    return []
+
+
+def fetch_pipeline_activity(app_id: str) -> list[dict]:
+    """Correlate pipeline operations from App Insights into per-run views."""
+    return _az_query(
+        app_id,
+        """requests
+        | where timestamp > ago(6h)
+        | where name has "orchestrator" or name has "pipeline"
+              or name has "parse_kml" or name has "acquire"
+              or name has "download" or name has "post_process"
+              or name has "blob_trigger" or name has "enrich"
+              or name has "submit" or name has "upload"
+              or name has "write_metadata" or name has "prepare_aoi"
+              or name has "store_aoi" or name has "poll"
+              or name has "fulfil"
+        | project timestamp, name, resultCode, duration, operation_Id, success
+        | order by timestamp desc
+        | take 50""",
+    )
+
+
+def fetch_recent_submissions(app_id: str) -> list[dict]:
+    """Recent pipeline submissions (used by fetch_pipeline_activity KQL)."""
+    return fetch_pipeline_activity(app_id)[:20]
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def _ts_short(ts: str | None) -> str:
+    """Format an ISO timestamp to HH:MM:SS."""
+    if not ts:
+        return ""
+    try:
+        # Handle both full ISO and partial
+        s = str(ts).replace("T", " ")[:19]
+        return s[11:19] if len(s) >= 19 else s
+    except Exception:
+        return str(ts)[:8]
+
+
+def _truncate(s: str, n: int) -> str:
+    s = str(s).strip()
+    return s[:n] + "…" if len(s) > n else s
+
+
+def build_health_panel(health: dict, ops_data: dict | None = None) -> Panel:
+    """App health status panel with user count from ops endpoint."""
+    status = health["status"]
+    latency = health["latency_ms"]
+
+    if status == "healthy":
+        style = "green"
+        icon = "●"
+    else:
+        style = "red"
+        icon = "○"
+
+    detail = health.get("detail", {})
+    version = detail.get("version", "?")
+    commit = detail.get("commit", "")[:8]
+
+    text = Text()
+    text.append(f" {icon} ", style=style)
+    text.append(f"{status.upper()}", style=f"bold {style}")
+    text.append(f"  {latency}ms", style="dim")
+    text.append(f"  v{version}", style="dim")
+    if commit:
+        text.append(f"  ({commit})", style="dim")
+
+    if ops_data:
+        app = ops_data.get("app", {})
+        uptime_s = app.get("uptime_seconds", 0)
+        if uptime_s:
+            h, m = divmod(uptime_s // 60, 60)
+            text.append(f"  up {h}h{m}m", style="dim")
+        user_count = ops_data.get("activeUserCount", 0)
+        text.append("  |  ", style="dim")
+        text.append(f"{user_count} active user{'s' if user_count != 1 else ''}", style="bold cyan")
+        req_summary = ops_data.get("requests", {})
+        total = req_summary.get("total", 0)
+        uploads = req_summary.get("uploads", 0)
+        text.append(f"  |  {total} reqs", style="dim")
+        if uploads:
+            text.append(f" ({uploads} uploads)", style="bold yellow")
+
+    return Panel(text, title="Health", border_style=style, height=3)
+
+
+_ACTIVITY_TO_PHASE = {
+    "blob_trigger": "uploaded",
+    "upload": "uploaded",
+    "submit": "uploaded",
+    "parse_kml": "ingestion",
+    "prepare_aoi": "ingestion",
+    "store_aoi": "ingestion",
+    "write_metadata": "ingestion",
+    "load_offloaded": "ingestion",
+    "acquire": "acquisition",
+    "poll_order": "acquisition",
+    "search": "acquisition",
+    "download": "fulfilment",
+    "post_process": "fulfilment",
+    "fulfil": "fulfilment",
+    "batch": "fulfilment",
+    "enrich": "enrichment",
+    "weather": "enrichment",
+    "ndvi": "enrichment",
+    "mosaic": "enrichment",
+    "change_detect": "enrichment",
+}
+
+
+def _classify_activity(name: str) -> str:
+    """Map an activity/function name to a pipeline phase."""
+    name_lower = name.lower()
+    for keyword, phase in _ACTIVITY_TO_PHASE.items():
+        if keyword in name_lower:
+            return phase
+    if "orchestrator" in name_lower or "pipeline" in name_lower:
+        return "ingestion"  # orchestrator start = ingestion
+    return "uploaded"
+
+
+def build_kanban(
+    durable_instances: list[dict],
+    pipeline_activity: list[dict],
+) -> Panel:
+    """Kanban board: one column per pipeline phase."""
+    buckets: dict[str, list[dict]] = {phase: [] for phase in _PHASE_ORDER}
+
+    # Classify durable instances by phase (if status API works)
+    for inst in durable_instances:
+        runtime = inst.get("runtimeStatus", "")
+        custom = inst.get("customStatus") or {}
+
+        # Ops endpoint provides phase/step at top level too
+        if inst.get("phase"):
+            phase = inst["phase"].lower()
+            step = inst.get("step", "")
+        elif isinstance(custom, dict):
+            phase = custom.get("phase", "").lower()
+            step = custom.get("step", "")
+        elif isinstance(custom, str):
+            phase = custom.lower()
+            step = ""
+        else:
+            phase = ""
+            step = ""
+
+        if not phase:
+            phase = _RUNTIME_TO_PHASE.get(runtime, "uploaded")
+        if phase and phase not in buckets:
+            phase = "uploaded"
+
+        if phase:
+            buckets[phase].append(
+                {
+                    "id": _truncate(inst.get("instanceId", "?"), 12),
+                    "step": step,
+                    "name": inst.get("name", ""),
+                    "created": _ts_short(inst.get("createdTime")),
+                    "updated": _ts_short(inst.get("lastUpdatedTime")),
+                }
+            )
+
+    # Group pipeline activity by operation_Id → find latest phase per run
+    runs: dict[str, dict] = {}
+    for act in pipeline_activity:
+        op_id = str(act.get("operation_Id", ""))
+        if not op_id:
+            continue
+        name = str(act.get("name", ""))
+        phase = _classify_activity(name)
+        code = str(act.get("resultCode", ""))
+        success = act.get("success")
+
+        if op_id not in runs:
+            runs[op_id] = {
+                "id": op_id[:12],
+                "phase": phase,
+                "latest_name": name,
+                "code": code,
+                "ts": _ts_short(act.get("timestamp")),
+                "failed": False,
+            }
+        else:
+            # Track the furthest phase reached per run
+            cur_idx = (
+                _PHASE_ORDER.index(runs[op_id]["phase"])
+                if runs[op_id]["phase"] in _PHASE_ORDER
+                else 0
+            )
+            new_idx = _PHASE_ORDER.index(phase) if phase in _PHASE_ORDER else 0
+            if new_idx > cur_idx:
+                runs[op_id]["phase"] = phase
+                runs[op_id]["latest_name"] = name
+                runs[op_id]["code"] = code
+
+        if success is False or (code and not code.startswith("2") and code != "0"):
+            runs[op_id]["failed"] = True
+
+    # Place each run in its phase bucket (or failed if it failed)
+    for run in runs.values():
+        target = "failed" if run["failed"] else run["phase"]
+        if target not in buckets:
+            target = "uploaded"
+        # Avoid duplicating items already from durable instances
+        existing_ids = {item["id"] for item in buckets[target]}
+        if run["id"] not in existing_ids:
+            buckets[target].append(
+                {
+                    "id": run["id"],
+                    "step": run["latest_name"],
+                    "name": "",
+                    "created": run["ts"],
+                    "updated": "",
+                }
+            )
+
+    # Build columns as a single-row Table so all 7 fit without wrapping
+    grid = Table(
+        show_header=True,
+        show_edge=False,
+        pad_edge=False,
+        expand=True,
+        box=None,
+    )
+
+    # Header row with phase names + counts
+    for phase in _PHASE_ORDER:
+        items = buckets[phase]
+        style = _PHASE_STYLE.get(phase, "white")
+        count_str = f" ({len(items)})" if items else ""
+        grid.add_column(
+            f"{phase.upper()}{count_str}",
+            ratio=1,
+            style="dim",
+            header_style=style,
+            overflow="ellipsis",
+            no_wrap=True,
+        )
+
+    # Fill up to 6 rows of items across all columns
+    max_rows = 6
+    for row_idx in range(max_rows):
+        cells = []
+        for phase in _PHASE_ORDER:
+            items = buckets[phase]
+            if row_idx < len(items):
+                item = items[row_idx]
+                step_str = f" [{_truncate(item['step'], 8)}]" if item.get("step") else ""
+                cells.append(Text(f"{item['id']}{step_str}", overflow="ellipsis", no_wrap=True))
+            elif row_idx == 0:
+                cells.append(Text("—", style="dim italic"))
+            else:
+                cells.append(Text(""))
+        grid.add_row(*cells)
+
+    return Panel(
+        grid,
+        title="Pipeline Kanban",
+        border_style="bright_blue",
+    )
+
+
+def build_requests_table(requests: list[dict]) -> Panel:
+    """Recent HTTP requests panel."""
+    table = Table(expand=True, show_edge=False, pad_edge=True)
+    table.add_column("Time", width=8, style="dim")
+    table.add_column("Endpoint", ratio=2)
+    table.add_column("Code", width=5, justify="right")
+    table.add_column("Dur(ms)", width=8, justify="right")
+    table.add_column("User", width=14)
+
+    for req in (requests or [])[:10]:
+        code = str(req.get("resultCode", ""))
+        code_style = (
+            "green" if code.startswith("2") else "yellow" if code.startswith("4") else "red"
+        )
+        user = _truncate(str(req.get("user_AuthenticatedId", "") or "anon"), 14)
+        dur = str(int(float(req.get("duration", 0)))) if req.get("duration") else ""
+        table.add_row(
+            _ts_short(req.get("timestamp")),
+            _truncate(str(req.get("name", "")), 35),
+            Text(code, style=code_style),
+            dur,
+            user,
+        )
+
+    if not requests:
+        table.add_row("", Text("No requests in window", style="dim italic"), "", "", "")
+
+    return Panel(table, title="Recent Requests", border_style="cyan")
+
+
+def build_errors_panel(errors: list[dict]) -> Panel:
+    """Recent errors panel."""
+    table = Table(expand=True, show_edge=False, pad_edge=True)
+    table.add_column("Time", width=8, style="dim")
+    table.add_column("Sev", width=4)
+    table.add_column("Function", width=20)
+    table.add_column("Message", ratio=3)
+
+    for err in (errors or [])[:8]:
+        sev = err.get("severityLevel", 0)
+        sev_str = {1: "WARN", 2: "WARN", 3: "ERR", 4: "CRIT"}.get(int(sev) if sev else 0, str(sev))
+        sev_style = "yellow" if sev_str == "WARN" else "red"
+        table.add_row(
+            _ts_short(err.get("timestamp")),
+            Text(sev_str, style=sev_style),
+            _truncate(str(err.get("operation_Name", "") or ""), 20),
+            _truncate(str(err.get("message", "")), 80),
+        )
+
+    if not errors:
+        table.add_row("", "", "", Text("No errors — all clear", style="dim italic green"))
+
+    return Panel(table, title="Errors & Warnings", border_style="red")
+
+
+def build_users_panel(ops_data: dict | None) -> Panel:
+    """Active users panel — shows who is using the app right now."""
+    table = Table(expand=True, show_edge=False, pad_edge=True)
+    table.add_column("User", ratio=2)
+    table.add_column("Activity", ratio=3)
+
+    if ops_data:
+        users = ops_data.get("activeUsers", [])
+        recent = ops_data.get("recentRequests", [])
+
+        # Build last-seen per user
+        user_last: dict[str, dict] = {}
+        for r in recent:
+            uid = r.get("user", "anon")
+            if uid not in user_last:
+                user_last[uid] = r
+
+        for user in users[:8]:
+            last = user_last.get(user, {})
+            path = last.get("path", "")
+            ts = _ts_short(last.get("ts"))
+            status = last.get("status", "")
+            status_style = "green" if str(status).startswith("2") else "red"
+            activity = Text()
+            if path:
+                activity.append(f"{_truncate(path, 18)}", style="dim")
+            if ts:
+                activity.append(f" {ts}", style="dim italic")
+            if status:
+                activity.append(f" {status}", style=status_style)
+            display_user = "anonymous" if user == "anon" else _truncate(user, 20)
+            table.add_row(display_user, activity)
+
+        if not users:
+            table.add_row(Text("No recent users", style="dim italic"), Text(""))
+    else:
+        table.add_row(Text("Ops endpoint unavailable", style="dim italic"), Text(""))
+
+    return Panel(table, title="Active Users", border_style="cyan")
+
+
+def build_runs_panel(ops_data: dict | None) -> Panel:
+    """Recent pipeline runs from Cosmos."""
+    table = Table(expand=True, show_edge=False, pad_edge=True)
+    table.add_column("Time", width=8, style="dim")
+    table.add_column("ID", width=12)
+    table.add_column("Status", width=10)
+    table.add_column("AOIs", width=5, justify="right")
+    table.add_column("User", ratio=1)
+
+    if ops_data:
+        runs = ops_data.get("recentRuns", [])
+        for run in runs[:8]:
+            status = str(run.get("status", "?"))
+            status_style = (
+                "green"
+                if status in ("completed", "ready", "success")
+                else "yellow"
+                if status in ("pending", "processing", "submitted")
+                else "red"
+            )
+            table.add_row(
+                _ts_short(run.get("submitted_at")),
+                _truncate(str(run.get("submission_id", run.get("id", "?"))), 12),
+                Text(status, style=status_style),
+                str(run.get("aoi_count", "")),
+                _truncate(str(run.get("user_id", "")), 14),
+            )
+        if not runs:
+            table.add_row("", Text("No runs yet", style="dim italic"), "", "", "")
+    else:
+        table.add_row("", Text("Ops endpoint unavailable", style="dim italic"), "", "", "")
+
+    return Panel(table, title="Recent Runs", border_style="magenta")
+
+
+def build_dashboard(
+    health: dict,
+    requests: list[dict],
+    durable_instances: list[dict],
+    pipeline_activity: list[dict],
+    errors: list[dict],
+    refresh_count: int,
+    ops_data: dict | None = None,
+    source: str = "ops",
+) -> Layout:
+    """Compose the full dashboard layout."""
+    layout = Layout()
+
+    # Header
+    now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+    header_text = Text()
+    header_text.append("  CANOPEX PIPELINE DASHBOARD", style="bold bright_white on blue")
+    header_text.append(f"    {now}  ", style="dim")
+    header_text.append(f"  #{refresh_count}", style="dim italic")
+    src_style = "green" if source == "ops" else "red" if source == "offline" else "yellow"
+    header_text.append(f"  [{source}]", style=src_style)
+
+    layout.split_column(
+        Layout(Panel(header_text, style="blue", height=3), name="header", size=3),
+        Layout(name="top", size=4),
+        Layout(name="kanban", size=12),
+        Layout(name="middle"),
+        Layout(name="bottom"),
+    )
+
+    # Top row: health + user count
+    layout["top"].update(build_health_panel(health, ops_data))
+
+    # Middle: kanban
+    layout["kanban"].update(build_kanban(durable_instances, pipeline_activity))
+
+    # Middle row: users + runs side by side
+    layout["middle"].split_row(
+        Layout(build_users_panel(ops_data), name="users", ratio=2),
+        Layout(build_runs_panel(ops_data), name="runs", ratio=3),
+    )
+
+    # Bottom: requests + errors side by side
+    layout["bottom"].split_row(
+        Layout(build_requests_table(requests), name="requests", ratio=3),
+        Layout(build_errors_panel(errors), name="errors", ratio=2),
+    )
+
+    return layout
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Live pipeline monitoring dashboard")
+    parser.add_argument(
+        "--host",
+        default="func-kmlsat-dev.jollysea-48e72cf8.uksouth.azurecontainerapps.io",
+        help="Function app hostname",
+    )
+    parser.add_argument(
+        "--app-insights",
+        default="387f53d2-98ef-4fc8-9296-32fda4c74bb3",
+        help="App Insights app ID (fallback when ops endpoint unavailable)",
+    )
+    parser.add_argument(
+        "--ops-key",
+        default=os.environ.get("OPS_DASHBOARD_KEY", ""),
+        help="Bearer token for /api/ops/dashboard (or set OPS_DASHBOARD_KEY env var)",
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=10,
+        help="Refresh interval in seconds (default: 10)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    console = Console()
+
+    console.print("[bold blue]Starting Canopex Pipeline Dashboard...[/]")
+    console.print(f"  Host: {args.host}")
+    console.print(f"  Ops key: {'set' if args.ops_key else 'not set (dev mode)'}")
+    console.print(f"  App Insights fallback: {args.app_insights}")
+    console.print(f"  Refresh: every {args.interval}s")
+    console.print("[dim]Press Ctrl+C to exit[/]\n")
+
+    refresh_count = 0
+
+    with Live(console=console, refresh_per_second=1, screen=True) as live:
+        while True:
+            refresh_count += 1
+            try:
+                # Always fetch health (fast, direct HTTP)
+                health = fetch_health(args.host)
+
+                # Try ops endpoint first (real-time, sub-second)
+                ops_data = fetch_ops_dashboard(args.host, args.ops_key)
+
+                if ops_data:
+                    source = "ops"
+                    # Extract orchestrations and requests from ops payload
+                    durable = ops_data.get("orchestrations", [])
+                    pipeline = []  # orchestrations already classified
+                    recent_reqs = ops_data.get("recentRequests", [])
+                    # Map in-memory requests to the table format
+                    requests = [
+                        {
+                            "timestamp": r.get("ts", ""),
+                            "name": r.get("path", ""),
+                            "resultCode": str(r.get("status", "")),
+                            "duration": r.get("dur_ms", 0),
+                            "user_AuthenticatedId": r.get("user", ""),
+                        }
+                        for r in recent_reqs
+                    ]
+                    errors = []  # TODO: surface errors from ops endpoint
+                elif health["status"] == "healthy":
+                    # App is up but ops endpoint failed — try App Insights
+                    source = "app-insights"
+                    durable = fetch_durable_instances(args.host)
+                    pipeline = fetch_pipeline_activity(args.app_insights)
+                    requests = fetch_requests(args.app_insights)
+                    errors = fetch_errors(args.app_insights)
+                else:
+                    # App is unreachable — show empty dashboard
+                    source = "offline"
+                    durable = []
+                    pipeline = []
+                    requests = []
+                    errors = []
+
+                dashboard = build_dashboard(
+                    health=health,
+                    requests=requests,
+                    durable_instances=durable,
+                    pipeline_activity=pipeline,
+                    errors=errors,
+                    refresh_count=refresh_count,
+                    ops_data=ops_data,
+                    source=source,
+                )
+                live.update(dashboard)
+
+            except KeyboardInterrupt:
+                break
+            except Exception as exc:
+                live.update(
+                    Panel(
+                        Text(f"Refresh error: {exc}", style="bold red"),
+                        title="Dashboard Error",
+                    )
+                )
+
+            try:
+                time.sleep(args.interval)
+            except KeyboardInterrupt:
+                break
+
+    console.print("\n[dim]Dashboard stopped.[/]")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -2,7 +2,7 @@
 """Live pipeline dashboard — kanban-style CLI monitor.
 
 Usage:
-    uv run python scripts/dashboard.py                          # auto-detect from infra
+    uv run python scripts/dashboard.py                          # use built-in defaults
     uv run python scripts/dashboard.py --host func-kmlsat-dev.jollysea-48e72cf8.uksouth.azurecontainerapps.io
     uv run python scripts/dashboard.py --app-insights 387f53d2-98ef-4fc8-9296-32fda4c74bb3
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,16 @@ os.environ.setdefault("DEMO_VALET_TOKEN_SECRET", "test-secret-key-for-unit-tests
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
-# Canonical test origins — use these instead of hardcoding strings in tests
+# Canonical test origins — mirrors what infra sets via CORS_ALLOWED_ORIGINS.
+# The env var must be set BEFORE _helpers is imported so _build_allowed_origins
+# picks it up at module load time.
 TEST_ORIGIN = "https://canopex.hrdcrprwn.com"
 TEST_LOCAL_ORIGIN = "http://localhost:4280"
+os.environ.setdefault(
+    "CORS_ALLOWED_ORIGINS",
+    f"{TEST_ORIGIN},https://green-moss-0e849ac03.2.azurestaticapps.net",
+)
+os.environ.setdefault("PRIMARY_SITE_URL", TEST_ORIGIN)
 
 
 @pytest.fixture()

--- a/tests/test_frontend_config.py
+++ b/tests/test_frontend_config.py
@@ -207,16 +207,15 @@ class TestCorsConfig:
     def test_cors_origins_from_env_var(self):
         """_build_allowed_origins must populate origins from CORS_ALLOWED_ORIGINS env var."""
         import importlib
-        import sys
 
+        import blueprints._helpers as helpers_mod
         from tests.conftest import TEST_ORIGIN
 
-        helpers_mod = sys.modules["blueprints._helpers"]
         original_cors = os.environ.get("CORS_ALLOWED_ORIGINS", "")
         try:
-            os.environ["CORS_ALLOWED_ORIGINS"] = "https://example.com"
+            os.environ["CORS_ALLOWED_ORIGINS"] = "https://custom.example.org"
             importlib.reload(helpers_mod)
-            assert "https://example.com" in helpers_mod._ALLOWED_ORIGINS
+            assert "https://custom.example.org" in helpers_mod._ALLOWED_ORIGINS
         finally:
             os.environ["CORS_ALLOWED_ORIGINS"] = original_cors or f"{TEST_ORIGIN}"
             importlib.reload(helpers_mod)

--- a/tests/test_frontend_config.py
+++ b/tests/test_frontend_config.py
@@ -8,6 +8,7 @@ correctly configured, catching the class of bugs that caused:
 """
 
 import json
+import os
 import re
 from pathlib import Path
 
@@ -195,9 +196,27 @@ class TestCorsConfig:
         src = HELPERS_PY.read_text()
         assert ".azurestaticapps.net" not in src
 
-    def test_custom_domain_in_cors_origins(self):
-        """The custom domain must remain in the stable allowlist."""
+    def test_no_hardcoded_custom_domain_in_cors_origins(self):
+        """Custom domains must come from CORS_ALLOWED_ORIGINS env var, not hardcoded."""
         src = HELPERS_PY.read_text()
-        assert re.search(r'["\']https://canopex\.hrdcrprwn\.com["\']', src), (
-            "_ALLOWED_ORIGINS must contain the custom domain"
+        assert "canopex.hrdcrprwn.com" not in src, (
+            "Custom domain must not be hardcoded — it should come from "
+            "CORS_ALLOWED_ORIGINS env var set by infra"
         )
+
+    def test_cors_origins_from_env_var(self):
+        """_build_allowed_origins must populate origins from CORS_ALLOWED_ORIGINS env var."""
+        import importlib
+        import sys
+
+        from tests.conftest import TEST_ORIGIN
+
+        helpers_mod = sys.modules["blueprints._helpers"]
+        original_cors = os.environ.get("CORS_ALLOWED_ORIGINS", "")
+        try:
+            os.environ["CORS_ALLOWED_ORIGINS"] = "https://example.com"
+            importlib.reload(helpers_mod)
+            assert "https://example.com" in helpers_mod._ALLOWED_ORIGINS
+        finally:
+            os.environ["CORS_ALLOWED_ORIGINS"] = original_cors or f"{TEST_ORIGIN}"
+            importlib.reload(helpers_mod)

--- a/tests/test_frontend_config.py
+++ b/tests/test_frontend_config.py
@@ -211,11 +211,13 @@ class TestCorsConfig:
         import blueprints._helpers as helpers_mod
         from tests.conftest import TEST_ORIGIN
 
+        custom_origin = "https://custom.example.org"
         original_cors = os.environ.get("CORS_ALLOWED_ORIGINS", "")
         try:
-            os.environ["CORS_ALLOWED_ORIGINS"] = "https://custom.example.org"
+            os.environ["CORS_ALLOWED_ORIGINS"] = custom_origin
             importlib.reload(helpers_mod)
-            assert "https://custom.example.org" in helpers_mod._ALLOWED_ORIGINS
+            # Set membership (not substring) — _ALLOWED_ORIGINS is set[str]
+            assert custom_origin in helpers_mod._ALLOWED_ORIGINS
         finally:
             os.environ["CORS_ALLOWED_ORIGINS"] = original_cors or f"{TEST_ORIGIN}"
             importlib.reload(helpers_mod)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -228,15 +228,16 @@ class TestCorsOriginHardening:
     def _restore(monkeypatch):
         """Reload _helpers back to the test-suite default origins."""
         import importlib
-        import os
         import sys
 
-        from tests.conftest import TEST_ORIGIN
+        from tests.conftest import TEST_LOCAL_ORIGIN, TEST_ORIGIN
 
         helpers_mod = sys.modules["blueprints._helpers"]
+        # Always restore to the known test-suite defaults, not the current
+        # (potentially mutated) env var value.
         monkeypatch.setenv(
             "CORS_ALLOWED_ORIGINS",
-            os.environ.get("CORS_ALLOWED_ORIGINS", TEST_ORIGIN),
+            f"{TEST_ORIGIN},{TEST_LOCAL_ORIGIN}",
         )
         importlib.reload(helpers_mod)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -224,20 +224,34 @@ class TestCorsOriginHardening:
         importlib.reload(helpers_mod)
         return set(helpers_mod._ALLOWED_ORIGINS)
 
+    @staticmethod
+    def _restore(monkeypatch):
+        """Reload _helpers back to the test-suite default origins."""
+        import importlib
+        import os
+        import sys
+
+        from tests.conftest import TEST_ORIGIN
+
+        helpers_mod = sys.modules["blueprints._helpers"]
+        monkeypatch.setenv(
+            "CORS_ALLOWED_ORIGINS",
+            os.environ.get("CORS_ALLOWED_ORIGINS", TEST_ORIGIN),
+        )
+        importlib.reload(helpers_mod)
+
     def test_rejects_http_origin_from_env(self, monkeypatch):
         """An attacker-controlled http:// origin must be rejected."""
         origins = self._reload_with_env(monkeypatch, "http://evil.example.com")
         assert not any(o.startswith("http://evil") for o in origins)
-        # Restore
-        self._reload_with_env(monkeypatch)
+        self._restore(monkeypatch)
 
     def test_accepts_https_origin_from_env(self, monkeypatch):
         """Legitimate https:// origins must be accepted."""
         test_origin = "https://custom.treesight.com"
         origins = self._reload_with_env(monkeypatch, test_origin)
         assert test_origin in origins, f"Expected {test_origin} in CORS origins"
-        # Restore
-        self._reload_with_env(monkeypatch)
+        self._restore(monkeypatch)
 
     def test_cors_headers_accept_env_injected_origin(self, monkeypatch):
         """cors_headers must honor a current SWA hostname injected from env."""
@@ -258,19 +272,19 @@ class TestCorsOriginHardening:
             headers = helpers_mod.cors_headers(req)
             assert headers["Access-Control-Allow-Origin"] == injected_origin
         finally:
-            self._reload_with_env(monkeypatch)
+            self._restore(monkeypatch)
 
     @pytest.mark.parametrize("require_auth", ["true", "1", "yes"])
     def test_excludes_localhost_when_require_auth_enabled(self, monkeypatch, require_auth):
         """Production-style auth mode must not keep localhost in the allowlist."""
         try:
             monkeypatch.setenv("REQUIRE_AUTH", require_auth)
-            origins = self._reload_with_env(monkeypatch, None)
+            origins = self._reload_with_env(monkeypatch, "https://canopex.hrdcrprwn.com")
             assert "http://localhost:4280" not in origins
             assert "http://localhost:1111" not in origins
         finally:
             monkeypatch.delenv("REQUIRE_AUTH", raising=False)
-            self._reload_with_env(monkeypatch)
+            self._restore(monkeypatch)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,0 +1,247 @@
+"""Tests for the ops dashboard endpoint (blueprints/ops.py).
+
+Covers:
+- Auth gating via OPS_DASHBOARD_KEY
+- Dev-mode access when no key is set
+- Prod-mode blocking when REQUIRE_AUTH is set without a key
+- Response payload shape
+- Request tracking
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import azure.functions as func
+import pytest
+
+from blueprints.ops import _check_ops_key, _recent_requests, track_request
+
+_FAKE_STARTER = json.dumps(
+    {
+        "taskHubName": "TestHub",
+        "creationUrls": {
+            "createNewInstancePostUri": "http://localhost/api/orchestrators/{functionName}"
+        },
+        "managementUrls": {
+            "statusQueryGetUri": "http://localhost/api/instances/{instanceId}",
+            "sendEventPostUri": "http://localhost/api/instances/{instanceId}/raiseEvent/{eventName}",
+            "terminatePostUri": "http://localhost/api/instances/{instanceId}/terminate",
+            "purgeHistoryDeleteUri": "http://localhost/api/instances/{instanceId}",
+            "id": "http://localhost/api/instances/{instanceId}",
+        },
+        "baseUrl": "http://localhost",
+        "requiredQueryStringParameters": "",
+    }
+)
+
+
+_FAKE_STARTER = json.dumps(
+    {
+        "taskHubName": "TestHub",
+        "creationUrls": {
+            "createNewInstancePostUri": "http://localhost/api/orchestrators/{functionName}"
+        },
+        "managementUrls": {
+            "statusQueryGetUri": "http://localhost/api/instances/{instanceId}",
+            "sendEventPostUri": "http://localhost/api/instances/{instanceId}/raiseEvent/{eventName}",
+            "terminatePostUri": "http://localhost/api/instances/{instanceId}/terminate",
+            "purgeHistoryDeleteUri": "http://localhost/api/instances/{instanceId}",
+            "id": "http://localhost/api/instances/{instanceId}",
+        },
+        "baseUrl": "http://localhost",
+        "requiredQueryStringParameters": "",
+    }
+)
+
+
+def _make_ops_req(
+    *,
+    bearer: str | None = None,
+    params: dict[str, str] | None = None,
+) -> func.HttpRequest:
+    """Build a minimal HttpRequest for ops endpoint tests."""
+    headers: dict[str, str] = {}
+    if bearer is not None:
+        headers["Authorization"] = f"Bearer {bearer}"
+    return func.HttpRequest(
+        method="GET",
+        url="/api/ops/dashboard",
+        headers=headers,
+        params=params or {},
+        body=b"",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auth: _check_ops_key
+# ---------------------------------------------------------------------------
+
+
+class TestCheckOpsKey:
+    """Verify bearer token validation logic."""
+
+    def test_allows_dev_mode_when_no_key_set(self, monkeypatch):
+        """No OPS_DASHBOARD_KEY and no REQUIRE_AUTH → allow access (dev)."""
+        monkeypatch.delenv("OPS_DASHBOARD_KEY", raising=False)
+        monkeypatch.delenv("REQUIRE_AUTH", raising=False)
+        assert _check_ops_key(_make_ops_req()) is True
+
+    @pytest.mark.parametrize("require_auth", ["true", "1", "yes"])
+    def test_blocks_prod_when_no_key_set(self, monkeypatch, require_auth):
+        """No OPS_DASHBOARD_KEY + REQUIRE_AUTH → deny access."""
+        monkeypatch.delenv("OPS_DASHBOARD_KEY", raising=False)
+        monkeypatch.setenv("REQUIRE_AUTH", require_auth)
+        assert _check_ops_key(_make_ops_req()) is False
+
+    def test_rejects_missing_bearer(self, monkeypatch):
+        """Key is set but request has no Authorization header → deny."""
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", "secret-key-123")
+        assert _check_ops_key(_make_ops_req()) is False
+
+    def test_rejects_wrong_bearer(self, monkeypatch):
+        """Wrong bearer token → deny."""
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", "secret-key-123")
+        assert _check_ops_key(_make_ops_req(bearer="wrong-key")) is False
+
+    def test_accepts_correct_bearer(self, monkeypatch):
+        """Correct bearer token → allow."""
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", "secret-key-123")
+        assert _check_ops_key(_make_ops_req(bearer="secret-key-123")) is True
+
+    def test_rejects_query_param_key(self, monkeypatch):
+        """Query-param key is NOT accepted (header-only auth)."""
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", "secret-key-123")
+        req = _make_ops_req(params={"key": "secret-key-123"})
+        assert _check_ops_key(req) is False
+
+    def test_timing_safe_comparison(self, monkeypatch):
+        """Verify hmac.compare_digest is used (not ==) by checking correct key works."""
+        # If == were used this would still pass, but the implementation
+        # explicitly uses hmac.compare_digest for timing safety.
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", "a" * 64)
+        assert _check_ops_key(_make_ops_req(bearer="a" * 64)) is True
+        assert _check_ops_key(_make_ops_req(bearer="a" * 63 + "b")) is False
+
+
+# ---------------------------------------------------------------------------
+# Request tracking
+# ---------------------------------------------------------------------------
+
+
+class TestRequestTracking:
+    """Verify in-memory request recording."""
+
+    def test_track_request_appends(self):
+        """track_request adds an entry to _recent_requests."""
+        initial_count = len(_recent_requests)
+        track_request(method="GET", path="health", status=200, user_id="u1")
+        assert len(_recent_requests) == initial_count + 1
+        last = _recent_requests[-1]
+        assert last["method"] == "GET"
+        assert last["path"] == "health"
+        assert last["status"] == 200
+        assert last["user"] == "u1"
+        assert "ts" in last
+        assert "dur_ms" in last
+
+    def test_anonymous_user_defaults(self):
+        """Empty user_id defaults to 'anon'."""
+        track_request(method="POST", path="submit", status=201)
+        assert _recent_requests[-1]["user"] == "anon"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint response shape
+# ---------------------------------------------------------------------------
+
+
+class TestOpsDashboardEndpoint:
+    """Integration-style tests for the ops_dashboard function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_401_without_key(self, monkeypatch):
+        """When key is set, missing bearer → 401."""
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", "required-key")
+
+        from blueprints.ops import ops_dashboard
+
+        req = _make_ops_req()
+        resp = await ops_dashboard(req, client=_FAKE_STARTER)
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_returns_200_with_correct_key(self, monkeypatch):
+        """Correct bearer → 200 with expected payload keys."""
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", "good-key")
+
+        from blueprints.ops import ops_dashboard
+
+        mock_client = AsyncMock()
+        mock_client.get_status_by = AsyncMock(return_value=[])
+        req = _make_ops_req(bearer="good-key")
+
+        with patch("blueprints.ops._fetch_recent_runs", return_value=[]):
+            with patch(
+                "azure.durable_functions.DurableOrchestrationClient",
+                return_value=mock_client,
+            ):
+                resp = await ops_dashboard(req, client=_FAKE_STARTER)
+
+        assert resp.status_code == 200
+        body = json.loads(resp.get_body())
+        assert "timestamp" in body
+        assert "app" in body
+        assert "activeUsers" in body
+        assert "activeUserCount" in body
+        assert "requests" in body
+        assert "orchestrations" in body
+        assert "recentRuns" in body
+        assert isinstance(body["activeUserCount"], int)
+        assert isinstance(body["orchestrations"], list)
+
+    @pytest.mark.asyncio
+    async def test_dev_mode_allows_unauthenticated(self, monkeypatch):
+        """No key + no REQUIRE_AUTH → 200 (dev mode)."""
+        monkeypatch.delenv("OPS_DASHBOARD_KEY", raising=False)
+        monkeypatch.delenv("REQUIRE_AUTH", raising=False)
+
+        from blueprints.ops import ops_dashboard
+
+        mock_client = AsyncMock()
+        mock_client.get_status_by = AsyncMock(return_value=[])
+        req = _make_ops_req()
+
+        with patch("blueprints.ops._fetch_recent_runs", return_value=[]):
+            with patch(
+                "azure.durable_functions.DurableOrchestrationClient",
+                return_value=mock_client,
+            ):
+                resp = await ops_dashboard(req, client=_FAKE_STARTER)
+
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_payload_counts_are_consistent(self, monkeypatch):
+        """activeUserCount must equal len(activeUsers)."""
+        monkeypatch.delenv("OPS_DASHBOARD_KEY", raising=False)
+        monkeypatch.delenv("REQUIRE_AUTH", raising=False)
+
+        from blueprints.ops import ops_dashboard
+
+        mock_client = AsyncMock()
+        mock_client.get_status_by = AsyncMock(return_value=[])
+        req = _make_ops_req()
+
+        with patch("blueprints.ops._fetch_recent_runs", return_value=[]):
+            with patch(
+                "azure.durable_functions.DurableOrchestrationClient",
+                return_value=mock_client,
+            ):
+                resp = await ops_dashboard(req, client=_FAKE_STARTER)
+
+        body = json.loads(resp.get_body())
+        assert body["activeUserCount"] == len(body["activeUsers"])
+        assert body["orchestrationCount"] == len(body["orchestrations"])
+        assert body["recentRunCount"] == len(body["recentRuns"])


### PR DESCRIPTION
## Summary

Three related fixes from a live debugging session on `canopex.hrdcrprwn.com`:

### 1. CORS fix — env-var-driven origins
- **Problem**: Hardcoded CORS origins blocked custom domain `canopex.hrdcrprwn.com`
- **Fix**: `_helpers.py` now reads exclusively from `CORS_ALLOWED_ORIGINS` env var
- Billing redirect URL uses `PRIMARY_SITE_URL` env var
- Tests updated for env-var-driven CORS behaviour

### 2. Cold-start 504 mitigation
- **Problem**: Scale-to-zero Container Apps caused 504 Gateway Timeout on first request
- **Fix**: `function_min_instances` variable (default 0, dev=1) sets `minimumElasticInstanceCount`
- Deploy pipeline applies setting via `az rest PATCH` on every deploy

### 3. Real-time ops dashboard
- **New endpoint**: `GET /api/ops/dashboard` ([blueprints/ops.py](blueprints/ops.py))
  - In-memory request tracking wired into `require_auth` decorator
  - Live Durable Functions orchestration status with phase/step
  - Recent pipeline runs from Cosmos `runs` container
  - Active user tracking (distinct users in last 15 min)
  - Protected by `OPS_DASHBOARD_KEY` bearer token (empty = allow in dev)
- **CLI dashboard**: `scripts/dashboard.py` — rich TUI with kanban-style pipeline visualization
  - Primary data source: ops endpoint (sub-second, real-time)
  - Fallback: App Insights KQL queries (2-5 min lag)
  - Panels: health, active users, pipeline kanban, recent runs, requests, errors

### Infra changes (approval-gated)
- `infra/tofu/main.tf`: Added `CORS_ALLOWED_ORIGINS`, `PRIMARY_SITE_URL`, `OPS_DASHBOARD_KEY` to app settings
- `infra/tofu/variables.tf`: New `function_min_instances` and `ops_dashboard_key` variables
- `infra/tofu/outputs.tf`: New `function_app_cli_minimum_instance_count` output
- `.github/workflows/deploy.yml`: Added `az rest` step for min instance count

### Test results
- All 1061 tests pass, 14 skipped, 0 failures
- Lint and format clean (ruff + pyright)