### PR TITLE
fix: billing/status returns 200 with safe defaults when storage unavailable

### DIFF
--- a/blueprints/billing.py
+++ b/blueprints/billing.py
@@ -91,7 +91,7 @@ def _billing_status_payload(user_id: str, req: func.HttpRequest) -> dict:
         effective = {"tier": "free", "status": "none"}
         emulation = None
         capabilities = plan_capabilities("free")
-        usage = {"used": 0, "limit": plan_capabilities("free")["run_limit"]}
+        usage = {"used": 0, "limit": capabilities["run_limit"]}
 
     gated = not billing_allowed(user_id)
 

--- a/blueprints/billing.py
+++ b/blueprints/billing.py
@@ -79,13 +79,21 @@ def _billing_status_payload(user_id: str, req: func.HttpRequest) -> dict:
     from treesight.security.feature_gate import GATED_PRICE_LABELS, billing_allowed
     from treesight.security.quota import get_usage
 
-    subscription = get_subscription(user_id)
-    effective = get_effective_subscription(user_id)
-    emulation = get_subscription_emulation(user_id)
-    capabilities = plan_capabilities(effective.get("tier"))
+    try:
+        subscription = get_subscription(user_id)
+        effective = get_effective_subscription(user_id)
+        emulation = get_subscription_emulation(user_id)
+        capabilities = plan_capabilities(effective.get("tier"))
+        usage = get_usage(user_id)
+    except Exception:
+        logger.exception("Storage error building billing status for user=%s", user_id)
+        subscription = {"tier": "free", "status": "none"}
+        effective = {"tier": "free", "status": "none"}
+        emulation = None
+        capabilities = plan_capabilities("free")
+        usage = {"used": 0, "limit": plan_capabilities("free")["run_limit"]}
 
     gated = not billing_allowed(user_id)
-    usage = get_usage(user_id)
 
     payload = {
         "tier": effective.get("tier", "free"),

--- a/tests/test_billing_endpoints.py
+++ b/tests/test_billing_endpoints.py
@@ -418,3 +418,56 @@ class TestUserIdFromCustomerCosmos:
             "stripe_customer_id": "cus_err",
         }
         assert _user_id_from_customer("cus_err") == "user-fallback"
+
+
+# ---------------------------------------------------------------------------
+# billing/status resilience — returns 200 even when storage is unavailable
+# ---------------------------------------------------------------------------
+
+
+class TestBillingStatusResilience:
+    @patch("treesight.storage.cosmos.cosmos_available", return_value=False)
+    @patch(
+        "treesight.storage.client.BlobStorageClient",
+        side_effect=RuntimeError("connection string missing"),
+    )
+    def test_returns_safe_default_when_all_storage_fails(self, _mock_blob, _mock_cosmos):
+        """billing/status should return 200 with free-tier defaults, not 500."""
+        from blueprints.billing import billing_status
+
+        req = func.HttpRequest(
+            method="GET",
+            url="/api/billing/status",
+            headers={"Origin": _ALLOWED_ORIGIN},
+            body=b"",
+        )
+        resp = billing_status(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["tier"] == "free"
+        assert data["runs_remaining"] >= 0
+        assert data["billing_gated"] is True
+
+    @patch("treesight.storage.cosmos.cosmos_available", return_value=True)
+    @patch("treesight.storage.cosmos.read_item", side_effect=RuntimeError("cosmos down"))
+    @patch(
+        "treesight.storage.client.BlobStorageClient",
+        side_effect=RuntimeError("blob down too"),
+    )
+    def test_returns_safe_default_when_cosmos_and_blob_both_fail(
+        self, _mock_blob, _mock_read, _mock_cosmos
+    ):
+        """Both Cosmos and blob failing should not crash the endpoint."""
+        from blueprints.billing import billing_status
+
+        req = func.HttpRequest(
+            method="GET",
+            url="/api/billing/status",
+            headers={"Origin": _ALLOWED_ORIGIN},
+            body=b"",
+        )
+        resp = billing_status(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["tier"] == "free"
+        assert data["status"] == "none"


### PR DESCRIPTION
## Summary

Wraps `_billing_status_payload` in `try/except` so that when both Cosmos and blob storage are unreachable (e.g. missing connection string, credential timeout), the endpoint returns a 200 with free-tier defaults instead of an unguarded 500.

## Root Cause

The blob fallback lambdas in `get_subscription()` only wrapped `download_json` in try/except — if `BlobStorageClient()` construction itself threw (missing connection string), the exception escaped `read_with_fallback` and crashed the endpoint.

## Changes

- **`blueprints/billing.py`**: Wrap the storage read block in `_billing_status_payload` with try/except, returning safe free-tier defaults on any storage failure. Logs the exception for observability.
- **`tests/test_billing_endpoints.py`**: Add `TestBillingStatusResilience` class with two tests:
  - `test_returns_safe_default_when_all_storage_fails` — Cosmos unavailable, blob construction throws
  - `test_returns_safe_default_when_cosmos_and_blob_both_fail` — both Cosmos reads and blob construction throw

## Impact

- Users who sign in when storage is temporarily unreachable will see free-tier defaults instead of a broken UI
- Server logs get a proper exception trace instead of an unhandled 500
- No behavioral change when storage is healthy

## Validation

- 1077 tests pass (2 new), 13 skipped
- `ruff check` + `ruff format` clean

Fixes #520

**Stage**: 2C (Pipeline Verification & User Journey)