### PR TITLE
docs: restructure roadmap, kill demo mode, prioritize user journey

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,9 +9,11 @@
 
 ## Prioritization
 
-- Finish Stage 2A release-safety work before opening more broad-exposure Stage 3 or Stage 4 implementation, unless the user explicitly overrides that priority.
+- **Stage 2C (Pipeline Verification & User Journey) is the current priority.** Do not open Stage 3+ work until the minimum viable user journey works end-to-end in Azure.
+- Finish Stage 2D (Revenue Enablement) and Stage 2E (Release Safety) before Stage 3 growth features.
 - For every substantial task, identify the primary persona, the job-to-be-done being improved, and the acceptance signal.
 - Prefer thin vertical slices over broad refactors that move several roadmap stages at once.
+- Do not spend engineering time on infrastructure optimisation (T2/T3 split, Container Apps Jobs) until user volume or revenue justifies it.
 
 ## Delivery Workflow
 

--- a/.github/instructions/persona-product.instructions.md
+++ b/.github/instructions/persona-product.instructions.md
@@ -6,10 +6,20 @@ applyTo:
   - "blueprints/export.py"
   - "blueprints/eudr.py"
   - "blueprints/monitoring.py"
-  - "blueprints/demo.py"
   - "blueprints/catalogue.py"
 ---
 # Persona Product Guidelines
+
+## Entry Point Decision (2026-04-12)
+
+The product entry point is the **Free Tier** (authenticated, 5 real analyses/month).
+Demo mode (`?mode=demo`) is deprecated (#532). There is no unauthenticated preview
+of the dashboard. The landing page describes the product; the app requires sign-in.
+
+- **Landing page** → clear value proposition, real prices, "Start Free" CTA → `/app/`
+- **`/app/` unauthenticated** → sign-in gate with free-tier messaging
+- **`/app/` authenticated, first run** → sample KML picker, one-click first analysis
+- **Showcase** (pre-computed static demos for anonymous visitors) → deferred until pipeline is proven
 
 - Start by naming the primary persona: conservation, ESG/EUDR, or agricultural advisor.
 - State the job-to-be-done in operational terms: evidence generation, compliance proof, or batch field decision support.

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -92,22 +92,30 @@ Auth works as follows:
 
 **Known limitation:** The `X-MS-CLIENT-PRINCIPAL` header is client-supplied
 and not cryptographically verified by the FA. A direct HTTP client (not bound
-by CORS) could forge this header. Mitigations planned for a future phase
-include JWT validation or a shared HMAC between SWA and FA.
+by CORS) could forge this header. Tracked as #534 — must be fixed before
+paid tiers go live. Planned approach: HMAC signature with shared secret in
+Key Vault.
 
-#### Showcase vs Tiers
+#### Entry Point
 
-Two distinct concepts serve different purposes — do not conflate them:
+**Decision (2026-04-12):** The product entry point is the **Free Tier**
+(authenticated, real pipeline, 5 runs/month). Demo mode (`?mode=demo`) is
+deprecated and scheduled for removal (#532).
 
 | Concept | Auth | Processing | Purpose |
 |---------|------|-----------|---------|
-| **Showcase** | None (anonymous) | None — pre-computed static blobs from stock AOIs | Marketing. Let visitors see real output quality before signing up. |
-| **Free tier** | SWA auth (authenticated) | Real — own KML/KMZ, low-res, seasonal cadence | Try the product. 5 runs, ≤5 AOIs, 30-day retention, no alerts, all manual. Negligible compute cost. |
-| **Starter / Pro / Team / Enterprise** | SWA auth (authenticated) | Real — full pipeline, higher limits, richer features | Paid plans with increasing AOI counts, cadence, retention, exports, API access. |
+| **Free tier** | SWA auth (authenticated) | Real — own KML/KMZ, 5 runs/month, 30-day retention | Product entry point. Sample KMLs for one-click first run. |
+| **Starter / Pro / Team / Enterprise** | SWA auth (authenticated) | Real — full pipeline, higher limits, richer features | Paid plans: £19 / £49 / £149 / custom. |
+| **Showcase** (deferred) | None (anonymous) | None — pre-computed static blobs | Future. Marketing for anonymous visitors. Not until pipeline is proven e2e. |
 
-The **showcase** is served from `imagery/clipped/showcase/` blobs via valet tokens — no billing tier, no quota tracking, no user record. It exists purely to answer "what does Canopex actually produce?" for anonymous visitors.
+The "demo" billing tier and `?mode=demo` frontend mode are both deprecated.
+Demo mode showed the dashboard UI without auth but couldn't run anything —
+a confused middle ground that added code complexity without demonstrating
+real value. The free tier with sample KMLs replaces both concepts.
 
-The "demo" billing tier is deprecated — it overlapped with Free but was strictly worse (1 AOI, 0 retention). New unauthenticated users see the showcase; new authenticated users land on Free.
+Showcase (pre-computed static blobs for anonymous browsing) is a valid future
+concept but is deferred until after the pipeline is verified end-to-end in
+Azure (#531) and the free-tier entry point is polished (#532).
 
 ### Auth — SWA Built-in Custom Auth + BYOF Forwarding
 

--- a/docs/PROJECT_REVIEW_2026-04-12.md
+++ b/docs/PROJECT_REVIEW_2026-04-12.md
@@ -54,7 +54,7 @@ This is the critical finding. I'll walk through what a new visitor experiences:
    - The "Start Your First Analysis" button requires sign-in. The demo is not a demo — it's a preview of an empty UI.
    - The showcase concept (pre-computed static blobs from stock AOIs) is documented in the architecture but **not visible on the demo page**. `app-shell.js` has no `showcase` or `demo_artifacts` references.
 
-3. **Sign-in** — Uses SWA built-in Azure AD. This means the user signs in with a Microsoft account, Google account, or GitHub. This is fine for developers but may confuse conservation analysts or ESG officers who expect email/password or magic-link auth. The auth provider choice is undocumented on the site.
+3. **Sign-in** — Uses SWA built-in Azure AD via the configured `/.auth/login/aad` flow. This means the user signs in with the Microsoft/Azure AD provider currently configured for the app, not Google or GitHub. This is fine for developers but may confuse conservation analysts or ESG officers who expect email/password or magic-link auth. The auth provider choice is undocumented on the site.
 
 4. **After sign-in** — The user arrives at the same empty dashboard. They need to:
    - Know what a KML file is (the KML guide exists but is linked, not shown inline)
@@ -180,6 +180,8 @@ Pre-compute 3–4 compelling demo analyses using real AOIs:
 These run through the real pipeline, and the outputs (imagery tiles, NDVI charts, weather data, AI narrative) are stored as static blobs. The demo page renders them without auth or pipeline execution. The visitor sees exactly what they'd get as a customer, in 5 seconds, not 5 minutes.
 
 **This is the highest-ROI work in the entire backlog.**
+
+*Post-review note:* The updated roadmap/architecture decision is to defer Showcase implementation until after `#531` and `#532`, prioritising those release-safety items first. Showcase remains a high-value follow-on once that work lands.
 
 #### R2. Fix the Billing/Status 500 (Hours)
 

--- a/docs/PROJECT_REVIEW_2026-04-12.md
+++ b/docs/PROJECT_REVIEW_2026-04-12.md
@@ -1,0 +1,419 @@
+# Canopex — Project & Product Review
+
+**Date:** 12 April 2026  
+**Scope:** Full project review — product, codebase, progress, business model, user journey  
+**Purpose:** Critical assessment with recommendations for reaching a workable platform  
+
+---
+
+## Executive Summary
+
+Canopex has strong technical foundations but is not yet delivering value to users. The project has accumulated significant engineering depth — 1,091 passing tests, 382 commits in 2026, a well-structured Python backend, Rust acceleration, durable orchestration — but the path from "visitor lands on site" to "user pays and gets value" is incomplete. The core pipeline works. The billing integration exists. The auth works. But these pieces don't yet connect into a seamless user journey that a conservation analyst or ESG officer would complete without friction.
+
+**The honest verdict: broadly on the right track, but too much time spent on infrastructure plumbing and not enough on the user-facing experience that converts visitors into paying users.**
+
+---
+
+## 1. What's Working Well
+
+### 1.1 Technical Foundations — Genuinely Strong
+
+- **Pipeline quality.** KML → parse → STAC search → download → clip → NDVI → weather → AI narrative. This is real, works, and is differentiated. No competitor offers this as a single automated workflow.
+- **Test discipline.** 1,091 tests across 55 files, passing in 4.3s. High coverage of parsers, billing, security, pipeline, and API contracts. This is production-grade quality.
+- **Security posture.** Zip bomb protection, XXE-safe XML parsing, auth enforcement, quota gates, SAS token scoping, rate limiting. These aren't afterthoughts — they're built in.
+- **Architecture documentation.** PID, architecture overview, API reference, persona deep dive, system spec, operations runbook. Unusually thorough for a project this size.
+- **Cost-conscious design.** Planetary Computer (free imagery), scale-to-zero compute planning, Container Apps over AKS, blob storage with Cosmos fallback. The architecture respects the £10/month budget target.
+
+### 1.2 Product Thinking — Exceptionally Detailed
+
+The persona deep dive is one of the best product documents I've reviewed. It correctly identifies:
+
+- The "evidence generation platform" positioning (9/10 score — agreed).
+- The GEE commercial licensing gap (genuine competitive advantage).
+- The GFW Pro limitations for small orgs (genuine market opening).
+- The conservation analyst's workflow and time savings (20–170x ROI claim is plausible).
+- The EUDR compliance urgency (SME deadline June 2026 — imminent).
+
+### 1.3 Pricing Strategy — Broadly Correct
+
+The tier structure (Free/Starter/Pro/Team/Enterprise) maps to persona willingness-to-pay. The £19 Starter is below NGO discretionary spend thresholds. The free tier at 5 runs is enough to demonstrate value without creating significant cost exposure.
+
+---
+
+## 2. What's Not Working
+
+### 2.1 The User Journey Is Broken
+
+This is the critical finding. I'll walk through what a new visitor experiences:
+
+1. **Landing page** — Good. Clear positioning ("From Boundary to Evidence in 5 Minutes"), credible content, transparent methodology, well-structured pricing. The page itself is solid.
+
+2. **"Try Live Demo" click** — Takes you to `/app/?mode=demo`. This is where it breaks down:
+   - The user sees "Free plan preview" with a dashboard layout showing "No runs yet."
+   - There is no actual demo content. No sample analysis. No pre-computed showcase. A first-time visitor sees an empty dashboard with placeholders.
+   - The "Start Your First Analysis" button requires sign-in. The demo is not a demo — it's a preview of an empty UI.
+   - The showcase concept (pre-computed static blobs from stock AOIs) is documented in the architecture but **not visible on the demo page**. `app-shell.js` has no `showcase` or `demo_artifacts` references.
+
+3. **Sign-in** — Uses SWA built-in Azure AD. This means the user signs in with a Microsoft account, Google account, or GitHub. This is fine for developers but may confuse conservation analysts or ESG officers who expect email/password or magic-link auth. The auth provider choice is undocumented on the site.
+
+4. **After sign-in** — The user arrives at the same empty dashboard. They need to:
+   - Know what a KML file is (the KML guide exists but is linked, not shown inline)
+   - Have a KML file ready to upload
+   - Upload it and wait for the pipeline to complete
+
+5. **The billing/status endpoint returns 500** (issue #520). A signed-in user hitting the landing page gets a server error on the billing status check. This is a live-site bug that breaks the experience.
+
+**Bottom line:** A visitor cannot see what the product actually produces without signing up, creating a KML, uploading it, and waiting for the pipeline. This is too much friction for conversion. They need to see real output before they invest effort.
+
+### 2.2 The Demo/Showcase Gap
+
+The architecture doc describes a showcase concept: pre-computed analysis outputs from stock AOIs that anonymous visitors can browse. This is exactly the right idea. But it doesn't appear to be implemented in the frontend. The demo mode shows an empty dashboard with sign-in prompts.
+
+**This is the single highest-impact gap.** The landing page promises "From Boundary to Evidence in 5 Minutes" but doesn't show what that evidence looks like. A prospective conservation analyst needs to see a real NDVI analysis, a real weather correlation chart, and a real AI narrative before they'll invest time signing up.
+
+### 2.3 Too Much Infrastructure, Not Enough Product
+
+Look at the commit history and recently completed work:
+
+| Priority | Theme | Status |
+|----------|-------|--------|
+| P0 | Live site fixes (CSP, auth) | ✅ Done |
+| P1 | Event-driven pipeline restructure | ✅ Done |
+| P2 | Code quality and validation | ✅ Done |
+| P3 | BYOF consolidation (delete SWA managed API) | ✅ Done |
+| P4 | Release safety and promotion | 🔄 In progress |
+| P5 | Split T2/T3 (API + Compute) | Not started |
+
+P0–P3 were all architecture/infrastructure work. Necessary, but not user-facing. The BYOF migration alone consumed substantial engineering effort (PRs #510, #512, #515, #516, #521, #523) over multiple weeks, mostly to solve an internal routing problem (SWA managed functions vs Container Apps FA). The user doesn't know or care about this distinction.
+
+Meanwhile, the features that would actually convert users are untouched:
+
+- **Showcase/sample analysis** — not built
+- **Monthly monitoring + alerts** — not built (the single most important retention feature per the persona doc)
+- **Batch upload for ag/ESG personas** — not built
+- **PDF export quality** — "basic" per the persona feature list
+
+The 339 commits since March 1 produced a cleaner architecture but no new user-visible capability.
+
+### 2.4 The £10/Month Budget vs. Min-1-Replica Conflict
+
+The dev environment runs `function_min_instances = 1` with 2 vCPU / 4 GiB. At Azure Container Apps pricing, this is roughly £20/month, already 2x the stated budget. The P5 plan to split into T2 (0.5 vCPU, always-on) + T3 (scale-to-zero) would reduce this to ~£8/month — but P5 hasn't started, and it depends on P4, which depends on P3 (just completed).
+
+For a product with zero paying customers, running £20/month of always-on compute is defensible only if it serves real users. Currently it serves the developer. The cost model works at scale but is disproportionate at zero scale.
+
+### 2.5 Auth Security Caveat
+
+The architecture doc acknowledges a known limitation:
+
+> The `X-MS-CLIENT-PRINCIPAL` header is client-supplied and not cryptographically verified by the FA. A direct HTTP client (not bound by CORS) could forge this header.
+
+This is mitigated by CORS, but CORS is not a security boundary — it's a browser policy. Any HTTP client (curl, Postman, Python requests) can call the API with a forged principal header. For a free-tier product with rate limiting, this is acceptable risk. For a product handling EUDR compliance evidence that customers rely on for regulatory purposes, it is not. This needs to be fixed before paid tiers launch.
+
+### 2.6 The 3,100-Line `app-shell.js`
+
+The main application UI is a single 3,102-line vanilla JavaScript file with no build step, no framework, no components. This was a deliberate choice (documented in the website-js instructions) prioritising simplicity and traceability. For the current scope it's manageable, but it's approaching the limit. Adding monitoring dashboards, batch upload, temporal catalogue browsing, and team workspaces into a single file will become unmaintainable.
+
+This doesn't need to change today, but it should be flagged as a constraint on P6/P7 feature velocity.
+
+---
+
+## 3. Time Allocation Analysis — Was Time Wasted?
+
+### 3.1 Commit Velocity by Month (2026)
+
+| Month | Commits | Primary Theme |
+|-------|---------|---------------|
+| January | ~39 | M4 Revenue, billing, Stripe |
+| February | 43 | Stage 1–2, pipeline modularisation |
+| March | ~203 | SWA auth migration, BYOF, code quality |
+| April (11 days) | 97 | BYOF consolidation, deploy pipeline, ops |
+
+March was extraordinarily high-velocity — 203 commits in 31 days. Nearly all of this was architecture migration: moving from SWA managed functions to Container Apps FA, switching auth from MSAL.js to SWA built-in, and consolidating the API surface. This was driven by real technical debt (SWA managed functions lack managed identity, Key Vault, Durable Functions, and only support Python ≤3.11), but the magnitude of the effort was high for what was essentially an internal refactoring.
+
+### 3.2 Was This the Right Order?
+
+**Partially.** The SWA limitations were genuine blockers for billing (needs Key Vault for Stripe keys) and pipeline (needs Durable Functions). Fixing them was necessary. But the migration consumed 5–6 weeks of engineering time that could have been partially avoided by:
+
+1. Not building on SWA managed functions in the first place (hindsight — the original choice was reasonable at the time).
+2. Making the migration faster by doing a hard cutover rather than an incremental multi-PR approach (B.1–B.12 tracked as 12 separate items, most of which were "already exists" — the endpoints were on Container Apps FA from the start).
+
+**What should have been done instead during March:**
+
+- Build the showcase/sample analysis (2–3 days of work, max)
+- Fix billing/status 500 (issue #520, probably a 1-day fix)
+- Polish the sign-up → first-analysis flow
+- Ship a real "5-minute demo" that a visitor can experience without signing up
+
+These would have more impact on user conversion than a clean BYOF architecture.
+
+### 3.3 Things That Were Not a Waste
+
+- **The persona deep dive** — Genuinely excellent research. This will pay off in positioning and product decisions.
+- **Test infrastructure** — 1,091 tests give confidence to move fast without regression.
+- **Billing integration** — Stripe Checkout with UK VAT, multi-currency, webhook handling. This is correctly built and ready for revenue.
+- **Security hardening** — Zip bomb protection, XXE prevention, rate limiting. These are non-negotiable for a public-facing service.
+- **The Rust NDVI/change-detection module** — Smart performance investment for compute-heavy paths.
+
+### 3.4 Things That Were Premature
+
+- **Azure Batch fallback for 50k+ ha AOIs** — No user has this use case today. The constant is defined; that's enough.
+- **Container Apps Jobs planning (P8)** — Detailed cost modelling for burst compute when there are zero users. Good thinking, wrong timing.
+- **Ops dashboard endpoint and CLI monitor** — The latest PR (#530) adds operational monitoring tools. Useful for a production service under load; premature for a product with no users.
+- **12 enrichment data sources on the roadmap** — MODIS, ESA CCI Land Cover, ALOS Forest, IO LULC, etc. The current sources (Sentinel-2, NAIP, Open-Meteo, FIRMS, EA flood) are sufficient for launch. Ship with what works.
+
+---
+
+## 4. Recommendations: The Critical Path to a Workable Platform
+
+### 4.1 The Minimum Viable User Journey (Priority 1 — Do Now)
+
+These are the items that must work before inviting any user:
+
+#### R1. Build the Showcase (1–3 days)
+
+Pre-compute 3–4 compelling demo analyses using real AOIs:
+
+1. **A tropical deforestation case** (Central Africa or SE Asia) — shows NDVI drop, no drought correlation, AI narrative saying "likely anthropogenic clearing." This is the conservation money shot.
+2. **A UK/EU agricultural parcel** — shows seasonal NDVI cycle, weather correlation, crop health interpretation. Speaks to the ag advisor.
+3. **A supply chain plot** — shows "no deforestation since 2020" evidence for EUDR. Speaks to the ESG buyer.
+
+These run through the real pipeline, and the outputs (imagery tiles, NDVI charts, weather data, AI narrative) are stored as static blobs. The demo page renders them without auth or pipeline execution. The visitor sees exactly what they'd get as a customer, in 5 seconds, not 5 minutes.
+
+**This is the highest-ROI work in the entire backlog.**
+
+#### R2. Fix the Billing/Status 500 (Hours)
+
+Issue #520 — the `/api/billing/status` endpoint returns 500 for signed-in users. This breaks the landing page experience for anyone who's logged in. Fix it.
+
+#### R3. Polish the First-Run Flow (1–2 days)
+
+After sign-in, the user should:
+
+1. See their plan (Free) and remaining runs (5) prominently.
+2. Be offered a **sample KML** they can run with one click (not just told to create one). Include 2–3 pre-made KMLs: "Amazon Forest Plot," "UK Farm," "Palm Oil Concession."
+3. See their first analysis complete and be able to browse results.
+4. See a clear upgrade prompt showing what Starter/Pro adds.
+
+#### R4. Fix Auth Header Verification (1–2 days)
+
+The forged `X-MS-CLIENT-PRINCIPAL` risk. Options:
+
+- **Simplest:** Add an SWA-injected custom header that the FA validates (SWA can add headers on the proxy path).
+- **Better:** Sign the principal with a shared HMAC secret in Key Vault.
+- **This must be done before billing goes live** — you can't charge users through an auth system that can be trivially bypassed.
+
+### 4.2 Revenue Enablement (Priority 2 — Do This Month)
+
+#### R5. Verify End-to-End Billing Flow
+
+Test the complete journey: Free user → "Upgrade to Starter" → Stripe Checkout → payment → plan upgrade reflected in dashboard → increased quota → real pipeline run on Starter limits. This likely works but hasn't been validated end-to-end on the live site.
+
+#### R6. Show Real Prices on the Pricing Page
+
+The landing page shows "$ Starter", "$$ Pro", "$$$ Team" — placeholder symbols, not real prices. The persona doc says £19 Starter, £49 Pro, £149 Team. Put the actual numbers on the page. Users who see "Express Interest" instead of a price assume the product isn't ready. (This may be intentional for early access, but it reduces conversion.)
+
+#### R7. Cost Containment for Zero-Revenue Phase
+
+Until paying customers exist:
+
+- Reduce `function_min_instances` to 0 (accept cold starts for now — there are no latency-sensitive users).
+- Keep Cosmos DB on serverless provisioning (RU/s auto-scaling from 0).
+- Verify the Stripe test-mode configuration matches live mode (so the first real payment doesn't fail on a config mismatch).
+
+### 4.3 Persona-Specific Gaps (Priority 3 — Next 1–2 Months)
+
+#### Conservation ("Pat")
+
+- **What they need now:** The showcase (R1) with a deforestation case. The sample KML one-click run (R3). The PDF export being good enough to include in a donor report.
+- **What they need soon:** Monthly monitoring + alerts (P6/3.1 on roadmap). This is the retention driver — without it, Canopex is a one-shot tool. But it requires subscription revenue to justify the compute cost of scheduled re-runs.
+- **Recommendation:** Ship the showcase and first-run flow. Get 5–10 conservation users on the free tier. Validate they complete the flow and find the output useful. THEN build monitoring.
+
+#### Agriculture ("Ag Advisor")
+
+- **What they need now:** Batch upload for multiple parcels (they have 50–500 parcels, not 1). Multi-polygon KML already works, but the UX needs to clearly show per-polygon results.
+- **What they need soon:** CSV export with per-parcel NDVI time series. This is their working format.
+- **Honest assessment:** At 50% fit (per the persona doc), the ag persona is a stretch for launch. Focus on conservation and ESG first. Ag becomes viable when batch upload and per-parcel CSV are built.
+
+#### ESG/EUDR ("Elena")
+
+- **What they need now:** The showcase (R1) with a "no deforestation since 2020" case. The EUDR methodology page (exists and is good). Batch processing for 50+ supply chain locations.
+- **What they need soon:** A downloadable evidence pack that an auditor recognises (timestamped PDF with methodology description, satellite images, NDVI metrics, and a clear statement of findings).
+- **EUDR timing:** SME enforcement is June 2026 — two months away. If you can get a working evidence workflow to 5 beta ESG customers in the next month, you have a real revenue opportunity. If you miss this window, the next regulatory pressure point is the first enforcement actions (likely late 2026).
+
+### 4.4 Architecture Simplification (Priority 4 — Ongoing)
+
+#### R8. Stop the T2/T3 Split Work Until You Have Users
+
+The P5 plan to split into API + Compute images is a cost optimisation that saves ~£12/month. At zero users, this is irrelevant. At 10 users, it's a nice-to-have. At 100 users, it's important. Don't spend engineering time on it until the user count justifies the savings.
+
+#### R9. Don't Start P7/P8 (Team, Enterprise, ML, React Frontend)
+
+The roadmap correctly says "Do not start until Stage 4 is generating revenue." Enforce this. Team workspaces (#313), React frontend (#86), tree detection (#82), annotation tools (#87) — all of these are post-revenue features. They should not consume any engineering time until there are paying customers.
+
+#### R10. Contain Feature Creep in Enrichment Sources
+
+The roadmap lists 5+ additional enrichment sources (MODIS, ESA CCI, ALOS, IO LULC, GFW alerts). Each is "a single PR" but also adds testing surface, failure modes, and maintenance burden. The current sources (Sentinel-2, NAIP, Open-Meteo, FIRMS fire, EA flood) are sufficient for launch and cover all three personas. Add more only when a customer asks for them.
+
+---
+
+## 5. Business Model Assessment
+
+### 5.1 Cost Structure
+
+| Component | Monthly Cost (Current) | At Scale (100 users) |
+|-----------|----------------------|---------------------|
+| Container Apps FA (min 1 replica, 2 vCPU) | ~£20 | ~£20–40 (auto-scale) |
+| Cosmos DB (serverless) | ~£1–5 | ~£5–15 |
+| Blob Storage | <£1 | ~£2–5 |
+| Static Web App (free tier) | £0 | £0 |
+| AI Foundry (GPT for narratives) | ~£0.50/analysis | ~£50 (at 100 analyses/day? unlikely) |
+| Planetary Computer | Free | Free |
+| Open-Meteo | Free | Free |
+| **Total** | **~£25/month** | **~£30–65/month** |
+
+### 5.2 Revenue Model
+
+| Tier | Price | Users Needed to Cover Costs |
+|------|-------|-----------------------------|
+| Free | £0 | — |
+| Starter | £19/month (est.) | 2 users = £38 |
+| Pro | £49/month (est.) | 1 user = £49 |
+| Team | £149/month (est.) | 1 user = £149 |
+
+**Break-even: 2 Starter users or 1 Pro user.** This is an excellent cost structure. The Planetary Computer free imagery and Open-Meteo free weather data mean the primary costs are compute (processing) and AI (narratives). Both scale linearly with usage, not with user count.
+
+### 5.3 Risk: AI Costs at Scale
+
+The AI narrative feature uses GPT (via Azure AI Foundry). At ~£0.30–0.50 per analysis, this is a marginal cost that scales with usage. For Pro users (50 analyses/month), that's £15–25/month in AI costs against £49 revenue — manageable but worth watching. For Team users (200 analyses/month), it's £60–100 against £149 — tighter. Consider caching AI narratives for identical NDVI/weather patterns and batching requests.
+
+### 5.4 The Partnering Model Is Correct
+
+Using Planetary Computer for imagery (free, Microsoft-backed, stable) and Open-Meteo for weather (free, open-source) is the right strategy. These are not vendor dependencies that could be pulled — Planetary Computer is Microsoft's strategic commitment to open geospatial data, and Open-Meteo is community-maintained.
+
+The risk is Planetary Computer imposing rate limits or usage tiers (they currently don't for STAC search and blob access). Mitigation: the provider adapter pattern means switching to USGS EarthExplorer or Copernicus Data Space would be an implementation change, not an architecture change.
+
+### 5.5 Scale-to-Zero Reality
+
+The architecture is designed for scale-to-zero but doesn't currently achieve it (min 1 replica). The P5 split would enable it for the compute tier. Until then, the fixed cost is ~£20/month regardless of usage. This is the right trade-off for a product targeting its first users (cold-start latency on the first request would be a terrible first impression), but should be reevaluated if user acquisition stalls.
+
+---
+
+## 6. The Landing Page — Specific Feedback
+
+### 6.1 What's Good
+
+- **Headline** ("From Boundary to Evidence in 5 Minutes") — perfect. Clear, specific, action-oriented.
+- **Problem section** — resonates with anyone who's used manual GIS workflows.
+- **Pipeline workflow** — clear 6-step visual explanation.
+- **Data sources & methodology** — unusually transparent. Builds trust with technical evaluators.
+- **Known limitations** — honest about cloud filtering, weather centroid, and NAIP cycle. This builds more trust than omitting them.
+- **FAQ** — answers real questions. Good.
+- **Legal** — Terms, privacy, UK consumer regulations, VAT handling. All present and correct.
+
+### 6.2 What Needs Fixing
+
+- **No visual evidence of output.** The page describes what you get but never shows it. Add screenshots or an interactive sample of a completed analysis (the showcase).
+- **Pricing shows symbols not numbers.** "$", "$$", "$$$" — not real prices. Even if final pricing isn't set, show indicative ranges ("from £19/month").
+- **"Express Interest" vs. "Sign Up"** for paid tiers. This signals "not ready." When the product is ready, change to "Subscribe" with direct Stripe Checkout links.
+- **The "Early Access" form** at the bottom asks for organisation and use case. This is good for lead generation but should be supplemented with a direct sign-up path for users who are ready now.
+- **No social proof.** No testimonials, no case studies, no "used by" logos. Understandable at this stage, but plan for it. Even "3 analyses run this week" or "50+ AOIs processed" would help.
+- **The custom domain `hrdcrprwn.com`** is a developer-internal domain. It needs to change to something user-facing before sharing publicly (canopex.io, canopex.earth, etc.). This may already be planned.
+
+---
+
+## 7. Open Issues Assessment — Priority Triage
+
+Of the 35 open issues, here is a ruthless triage:
+
+### Do Now (Blocks User Conversion)
+
+| # | Title | Why Now |
+|---|-------|---------|
+| #520 | `/api/billing/status` returns 500 | Landing page is broken for signed-in users |
+| — | Build showcase/sample analysis | Visitors can't see product value without signing up |
+| — | Add sample KMLs to first-run flow | Users shouldn't need to create KML to try the product |
+
+### Do This Month (Enables Revenue)
+
+| # | Title | Why This Month |
+|---|-------|----------------|
+| #528/#529 | Split BFF + pipeline (if needed for scaling) | Only if cost reduction is critical |
+| #402 | Gate production deploys on security | Before billing goes live |
+| #403 | Production rollout with smoke gates | Before billing goes live |
+
+### Do Later (Post-Revenue)
+
+| # | Title | When |
+|---|-------|------|
+| #488 | Pipeline perf optimisation | When processing volume justifies it |
+| #466 | Container Apps split | When cost exceeds revenue |
+| #313 | Team workspaces | When Team tier has customers |
+| #82/#83/#84 | Tree detection / health / ML | Stage 5+ |
+| #86 | React frontend | Stage 5+ |
+| #87 | Annotation tools | Stage 5+ |
+
+### Close or Deprioritise
+
+| # | Title | Rationale |
+|---|-------|-----------|
+| #467 | Container Apps Jobs burst compute | Phase 3 of a plan that hasn't started Phase 2. Premature. |
+| #252 | Rate limiter persistence (Redis/Cosmos) | Only relevant at multi-instance scale. Close until needed. |
+| #228 | Distributed replay store for valet tokens | Same — multi-instance concern. Not relevant now. |
+| #474 | Migrate remaining browser-facing endpoints to SWA | Already superseded by BYOF — should be closed |
+
+---
+
+## 8. Summary: The 30-Day Plan
+
+If you want to have a shareable, working product within a month:
+
+**Week 1:**
+
+- Fix #520 (billing/status 500)
+- Build showcase with 3 pre-computed demo analyses
+- Add showcase rendering to the demo page
+- Put real indicative prices on the pricing page
+
+**Week 2:**
+
+- Add sample KML one-click run to the signed-in first-run flow
+- Verify end-to-end Stripe billing on dev (free → Starter upgrade → payment → quota increase → run analysis)
+- Fix auth header verification (HMAC or SWA-injected header)
+
+**Week 3:**
+
+- Polish PDF export for a conservation donor report use case
+- Add EUDR evidence section to export (date range, "no deforestation" statement)
+- Write 3 blog posts: "GFW vs Canopex," "Satellite Analysis Without Code," "EUDR Evidence in 5 Minutes"
+
+**Week 4:**
+
+- Get 5–10 beta users (conservation contacts, ESG contacts, your network)
+- Monitor their experience: do they complete the flow? Where do they drop off?
+- Fix what breaks
+
+**After that:**
+
+- Monthly monitoring + alerts (the retention feature)
+- Batch upload (the ESG/ag feature)
+- T2/T3 split (when costs require it)
+
+---
+
+## 9. Final Assessment
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| **Technical quality** | 8/10 | Strong foundations, good tests, security-aware. |
+| **Architecture** | 7/10 | Sound design, maybe over-engineered for current scale. |
+| **Product-market thinking** | 9/10 | Persona analysis is exceptional. Positioning is sharp. |
+| **User journey** | 3/10 | Broken demo, empty dashboard, no showcase, billing 500. |
+| **Time allocation** | 5/10 | Too much infra, not enough user-facing work. |
+| **Business model** | 8/10 | Excellent cost structure. Free data sources. Low break-even. |
+| **Launch readiness** | 4/10 | Architecture is ready. Experience is not. |
+
+**The core problem is a gap between exceptional product thinking and incomplete product delivery.** The team knows exactly what to build (the persona doc proves this) but has been pulled into infrastructure work that, while necessary, doesn't help users. The next month should be entirely focused on the user journey: see value → sign up → run analysis → see results → upgrade.
+
+The product itself — automated satellite evidence from a KML upload — is genuinely differentiated and serves real needs. The competitive analysis is accurate. The pricing is right. The technology works. What's missing is the last mile: letting a visitor experience it without friction.
+
+**Stop building infrastructure. Start shipping experience.**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,7 +13,7 @@ Last updated: 2026-04-12 (roadmap restructure per project review)
 
 - **Free tier** = authenticated, 5 real analyses/month, sample KMLs for one-click first run
 - **Showcase** = deferred. Pre-computed static samples for anonymous visitors are a nice-to-have after the real pipeline is proven end-to-end. Not current priority.
-- **Demo mode** = removed. It was a UI preview that couldn't run anything — confused middle ground between showcase and free tier.
+- **Demo mode** = deprecated; scheduled for removal (#532). It was a UI preview that couldn't run anything — confused middle ground between showcase and free tier.
 
 See `docs/ARCHITECTURE_OVERVIEW.md` § "Entry Point" for details.
 
@@ -65,7 +65,7 @@ min 1 replica (warm BFF), max 10 replicas (KEDA). ~£20/month baseline.
 | **Phase 3** (#467) | T2 + Container Apps Jobs | ~£8/mo + burst | Deferred |
 
 The T2/T3 split saves ~£12/month. Do not start until user count justifies
-the engineering effort. See § "Stage 5" for details.
+the engineering effort.
 
 ---
 
@@ -80,7 +80,7 @@ Complete each group before starting the next.
 
 ---
 
-## Completed Stages (P0–P3)
+## Completed Stages (legacy P0–P3 numbering)
 
 <details>
 <summary>Expand completed stages</summary>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,19 @@
 **Single source of truth for what to build next.**
 Issues hold the detail. This list holds the order.
 
-Last updated: 2026-04-11 (deploy fix: CORS verify localhost filter + 200/204 status)
+Last updated: 2026-04-12 (roadmap restructure per project review)
+
+---
+
+## Architecture Decision: Entry Point
+
+**Decision (2026-04-12):** The product entry point is the **Free Tier** (authenticated, real pipeline, 5 runs). Demo mode (`?mode=demo`) is deprecated and will be removed (#532). The landing page directs users to sign in and run a real analysis.
+
+- **Free tier** = authenticated, 5 real analyses/month, sample KMLs for one-click first run
+- **Showcase** = deferred. Pre-computed static samples for anonymous visitors are a nice-to-have after the real pipeline is proven end-to-end. Not current priority.
+- **Demo mode** = removed. It was a UI preview that couldn't run anything — confused middle ground between showcase and free tier.
+
+See `docs/ARCHITECTURE_OVERVIEW.md` § "Entry Point" for details.
 
 ---
 
@@ -35,259 +47,283 @@ Last updated: 2026-04-11 (deploy fix: CORS verify localhost filter + 200/204 sta
 
 ## Architecture Direction
 
-**2-tier Container Apps split** (tracking issue: #463).
+**Single Container Apps FA** — all endpoints + pipeline in one image.
 
-SWA managed functions are deprecated — they lack managed identity, Key Vault
-refs, Durable Functions, and are pinned to Python ≤3.11. All API endpoints
-consolidate onto the Container Apps Function App (BYOF via `api-config.json`
-hostname injection). The split is driven by **resource density**: BFF endpoints
-need 0.25 vCPU always-on; compute activities need 4 vCPU occasionally.
+SWA managed functions are deleted. All API endpoints are on the Container
+Apps Function App (BYOF via `api-config.json` hostname injection). SWA
+serves static files and auth only.
 
-| Phase | Topology | Baseline cost | Notes |
-|-------|----------|---------------|-------|
-| **Phase 1 (P3)** | Single Container Apps FA — all endpoints + pipeline | ~£20/mo (min 1 replica, 2 vCPU / 4 GiB) | Delete SWA managed API (~900 lines). One codebase. |
-| **Phase 2 (P5)** | T2 (API+orchestrator) + T3 (compute, scale-to-zero) | ~£8/mo (T2 min 1 @ 0.5 vCPU) | Shared Durable task hub. T3 pays only when running. |
-| **Phase 3 (P8)** | T2 + Container Apps Jobs for burst compute | ~£8/mo + ~£0.80/500-AOI run | 50 concurrent Jobs vs 10 replicas = 3× faster. |
+**Current topology (Phase 1):** Single Container Apps FA — 2 vCPU / 4 GiB,
+min 1 replica (warm BFF), max 10 replicas (KEDA). ~£20/month baseline.
 
-**Scale target (500-AOI KMZ):** ~45 min wall-clock with Jobs (Phase 3) vs
-~2.5 hours with replicas (Phase 2). Azure Batch stays for AOIs ≥50k ha.
+**Future split (deferred until user volume justifies it):**
 
-### Resource demand summary
+| Phase | Topology | Baseline cost | Status |
+|-------|----------|---------------|--------|
+| **Phase 1** (current) | Single FA | ~£20/mo | ✅ Active |
+| **Phase 2** (#466) | T2 API + T3 Compute (scale-to-zero) | ~£8/mo | Deferred |
+| **Phase 3** (#467) | T2 + Container Apps Jobs | ~£8/mo + burst | Deferred |
 
-| Component | CPU | RAM | Duration |
-|-----------|-----|-----|----------|
-| BFF endpoints | <0.25 vCPU | <128 MiB | <100ms |
-| Orchestrator | negligible | <1 MiB | coordinates only |
-| Ingestion (parse + prepare) | 100–500ms burst | 10–50 MiB | <10s |
-| Acquisition (STAC + polling) | minimal | <5 MiB | 10–30 min (I/O) |
-| Post-process (rasterio) | **2–30s per scene** | **50–500 MiB** | 5–30s per AOI |
-| Enrichment NDVI (Rust) | **500ms–2s per frame** | **500 MiB–1 GiB** | 2–5 min (8 threads) |
-| Change detection (Rust) | 100–500ms per pair | 100 MiB | 30s–2 min |
-
-Migration is phased across P3/P5/P8. Each phase is independently shippable and reversible.
+The T2/T3 split saves ~£12/month. Do not start until user count justifies
+the engineering effort. See § "Stage 5" for details.
 
 ---
 
 ## Priority Order
 
-Work items are ordered by dependency and impact. Complete each group before starting the next, unless explicitly overridden.
+Priorities are restructured per the 2026-04-12 project review. The core
+finding: **the pipeline works, the architecture is sound, but the user
+journey is broken.** All new work prioritises the path from "visitor lands"
+to "user pays and gets value."
 
-### P0 — Live Site Fixes
-
-Bugs visible to real users right now.
-
-| Order | Issue | Title | Status |
-|-------|-------|-------|--------|
-| 0.1 | #438 | Fix live site: CSP violations + deploy health check regression | ✅ PR #442 (CSP + auth); #367 already resolved |
-| 0.2 | #446 | Fix auth: SWA strips Authorization header → switch to built-in auth (BFF) | ✅ PR #472 |
-
-**Exit criteria:** Auth works reliably. No CSP errors. Demo dismiss works. Telemetry flows.
-
-**Architecture decision (2026-04-08, revised 2026-04-10):** SWA built-in
-custom auth is the single auth mechanism. MSAL.js is dropped. The Container
-Apps Function App is the BFF — the only API surface. SWA routes `/api/*` to
-it via `api-config.json` hostname injection. SWA managed functions are
-deprecated (no managed identity, no Key Vault refs, no Durable Functions,
-Python ≤3.11). See `docs/ARCHITECTURE_OVERVIEW.md`.
+Complete each group before starting the next.
 
 ---
 
-### P1 — Stage 2B Completion (event-driven pipeline + BFF)
+## Completed Stages (P0–P3)
 
-Finish the event-driven restructure. SWA becomes the sole public API surface (BFF). Parent issues: #420, #463.
+<details>
+<summary>Expand completed stages</summary>
+
+### P0 — Live Site Fixes ✅
+
+| Order | Issue | Title | Status |
+|-------|-------|-------|--------|
+| 0.1 | #438 | Fix live site: CSP violations + deploy health check regression | ✅ PR #442 |
+| 0.2 | #446 | Fix auth: SWA strips Authorization header → switch to built-in auth | ✅ PR #472 |
+
+### P1 — Stage 2B: Event-Driven Pipeline + BFF ✅
 
 | Order | Issue | Title | Status |
 |-------|-------|-------|--------|
 | 2B.1 | #421 | KML/KMZ input sanitisation — zip bomb + XML validation | ✅ PR #425 |
-| 2B.2 | #422 | SWA API function for SAS token minting + status polling | ✅ PR #427 |
-| 2B.3 | #423 | Unify on event-driven path — remove direct orchestrator start | ✅ Merged |
-| 2B.4 | #424 | Migrate read-only endpoints to SWA functions (analysis/history done) | ✅ PR #444, #481, #483, #484 |
-| 2B.5 | #446 | Switch SWA auth to built-in custom auth — drop MSAL.js | ✅ PR #472 |
-| 2B.6 | #464 | Add Application Insights instrumentation to SWA managed API | ✅ PR #478 |
+| 2B.2 | #422 | SAS token minting + status polling | ✅ PR #427 |
+| 2B.3 | #423 | Unify on event-driven path | ✅ Merged |
+| 2B.4 | #424 | Migrate read-only endpoints | ✅ PR #444, #481, #483, #484 |
+| 2B.5 | #446 | Switch to SWA built-in auth | ✅ PR #472 |
+| 2B.6 | #464 | App Insights instrumentation | ✅ PR #478 |
 
-**Exit criteria:** Upload goes via SAS URL → blob → Event Grid → orchestrator. Read-only endpoints served from Container Apps FA (formerly SWA managed functions, now consolidated). All browser API calls go through SWA `/api/*` → Container Apps FA. SWA API has full App Insights telemetry.
-
----
-
-### P2 — Code Quality & Validation
-
-Prove claims, close scanning alerts, finish simplicity fixes. Each is one PR.
+### P2 — Code Quality & Validation ✅
 
 | Order | Issue | Title | Status |
 |-------|-------|-------|--------|
-| Q.1 | #452 | Decompose 338-line orchestrator into phase functions | ✅ PR #487 |
-| Q.2 | #457 | Chained .get() patterns with fragile fallbacks | ✅ PR #487 |
-| Q.3 | #458 | app-shell.js — fetch swallowing, innerHTML XSS, code quality | ✅ PR #487 |
-| Q.4 | #459 | landing.js — missing response.ok, .then() chains, var usage | ✅ PR #487 |
-| Q.5 | #437 | End-to-end validation: prove 200+ AOI KMZ processing at scale | Partial — enrichment parallelised in #487; deeper optimisation tracked in #488 |
-| Q.6 | #439 | Close remaining code scanning alerts (CodeQL + Trivy IaC) | ✅ Closed |
-| Q.7 | #381 | Resolve code scanning alerts: URL sanitisation, quality, encryption | ✅ PR #490 |
-| Q.8 | #440 | Periodic check: libpng CVE fix in Debian bookworm | ✅ Closed — CVE fixed via apt-get upgrade |
+| Q.1–Q.4 | #452, #457, #458, #459 | Orchestrator decomp, code quality | ✅ PR #487 |
+| Q.5 | #437 | E2E validation (200+ AOI) | Partial (#488 tracks deeper work) |
+| Q.6–Q.8 | #439, #381, #440 | Scanning alerts, CVEs | ✅ Closed |
 
-**Exit criteria:** Orchestrator decomposed (prerequisite for #466). Scale claim proven. Code scanning clean. Simplicity violations fixed.
+### P3 — BYOF Consolidation ✅
+
+All 12 items completed. SWA managed API deleted. All `/api/*` endpoints on
+Container Apps FA. Frontend uses BYOF routing via `api-config.json`.
+
+</details>
 
 ---
 
-### P3 — BYOF Consolidation: Delete SWA Managed API
+### Stage 2C — Pipeline Verification & User Journey (NOW)
 
-Consolidate all BFF endpoints onto the Container Apps Function App. Delete
-the SWA managed API (~900 lines of duplicated code). SWA serves static files
-only; all `/api/*` calls route to Container Apps via `api-config.json`
-hostname injection.
+**This is the current focus.** Prove the pipeline works end-to-end in Azure,
+fix the bugs that break the signed-in experience, and make the product
+entry point unambiguous.
 
-**Why:** SWA managed functions lack managed identity (#498), Key Vault refs
-(#506), Durable Functions, and are pinned to Python ≤3.11. Every capability
-must be re-implemented. The Container Apps FA already has all 15+ endpoints,
-managed identity, Key Vault, Python 3.12, and Durable Functions.
-
-**BFF contract:** All endpoints use the stable camelCase API contract defined
-in `docs/openapi.yaml` v2.0.0. Response shapes are decoupled from internal
-Cosmos documents and blob JSON — the BFF handles all translation.
+#### 2C.1 — Pipeline End-to-End Verification
 
 | Order | Issue | Title | Status |
 |-------|-------|-------|--------|
-| B.1 | #498 | Root cause: SWA managed functions don't support managed identity | ✅ Superseded by BYOF |
-| B.2 | #506 | Stripe Key Vault refs don't resolve in SWA managed functions | ✅ Superseded by BYOF |
-| B.3 | #511 | Delete `website/api/` managed function code | ✅ PR #512 |
-| B.4 | #511 | Configure `api-config.json` to route `/api/*` to Container Apps FA | ✅ PR #512 |
-| B.5 | #511 | Update deploy workflow to skip SWA managed API build | ✅ PR #512 |
-| B.6 | #499 | Add orchestrator status endpoint (on Container Apps) | ✅ Already exists |
-| B.7 | #500 | Add timelapse-data read endpoint (on Container Apps) | ✅ Already exists |
-| B.8 | #501 | Add timelapse-analysis-load endpoint (on Container Apps) | ✅ Already exists |
-| B.9 | #503 | Add timelapse-analysis-save endpoint (on Container Apps) | ✅ Already exists |
-| B.10 | #502 | Add timelapse-analysis compute endpoint (on Container Apps) | ✅ Already exists |
-| B.11 | #504 | Add EUDR assessment endpoint (on Container Apps) | ✅ Already exists |
-| B.12 | #505 | Add export endpoint — SAS redirect for large files (on Container Apps) | ✅ Already exists |
+| E.1 | #531 | Verify e2e pipeline in Azure: sign in → upload KML → results | Open |
+| E.2 | #520 | Fix `/api/billing/status` returns 500 for signed-in users | Open |
 
-**Container Apps FA sizing (Phase 1):** 2 vCPU, 4 GiB, min 1 replica (warm
-BFF), max 10 replicas (KEDA on activity queue depth). ~£20/month baseline.
+**Exit criteria:** A user can sign in on the live SWA URL, upload a sample
+KML, and see a completed analysis with imagery, NDVI, weather, and AI
+narrative. Billing/status returns 200.
 
-**Exit criteria:** SWA managed API deleted. All `/api/*` endpoints served by
-Container Apps FA. Frontend uses single camelCase shape. Auth via SWA built-in
-→ `x-ms-client-principal` header forwarded to Container Apps. No #498/#506
-blockers.
-
----
-
-### P4 — Stage 2A: Release Safety & Promotion
-
-Make production safe to promote into. Build once in CI, promote the same immutable artifact dev → prod.
+#### 2C.2 — Unify Entry Point (Kill Demo Mode)
 
 | Order | Issue | Title | Status |
 |-------|-------|-------|--------|
-| 2A.1 | #401 | Separate dev and prod deployment flows (immutable artifact promotion) | 🔄 In PR |
-| 2A.2 | #404 | Structured JSON logging at Azure Functions startup | ✅ Closed |
-| 2A.3 | #405 | Reduce Function App config drift between OpenTofu and az CLI | Open — depends #401 |
-| 2A.4 | #402 | Gate production deploys on security workflow results | Open — depends #401 |
-| 2A.5 | #406 | Reconcile README, runbook, and API contracts with live routes | Open — depends #401 |
-| 2A.6 | #403 | Production rollout: preview users, smoke gates, promotion/demotion | Open — depends #401, #402, #405 |
+| U.1 | #532 | Remove demo mode — unify on Free Tier with sample KMLs | Open |
 
-**Exit criteria:** Dev/prod promotion path explicit. Preview-user rollout exists. Production deploy security-gated. Docs match code.
+The entry point is the Free Tier (5 runs, authenticated, real pipeline).
+Demo mode (`?mode=demo`) is removed. Landing page says "Start Free" →
+sign in → sample KML picker → one-click first run.
 
----
+**Exit criteria:** No `?mode=demo` handling in frontend. Unauthenticated
+`/app/` shows sign-in gate with free-tier messaging. First-run flow offers
+sample KMLs. All demo-specific code removed.
 
-### P5 — Split T2 (API + Orchestrator) / T3 (Compute)
+#### 2C.3 — Pricing Clarity
 
-Split the single Container Apps FA into two apps for resource efficiency.
-Both share the same Durable Functions task hub (`KmlSatelliteHub`) and
-storage account. Activities auto-route via the shared work queue.
+| Order | Issue | Title | Status |
+|-------|-------|-------|--------|
+| P.1 | #533 | Show real prices on pricing page | Open |
 
-**T2 — API + Orchestrator** (`func-kmlsat-{env}-api`)
+**Exit criteria:** Pricing cards show £0/£19/£49/£149 with clear limits.
+"Express Interest" replaced with actionable subscribe buttons for
+Starter/Pro. Enterprise remains "Contact Us."
 
-- Image: ~300 MB (no GDAL, no rasterio, no Rust)
-- Functions: BFF endpoints, orchestrator, parse_kml, prepare_aoi, acquire_imagery, poll_order
-- Resources: 0.5 vCPU, 1 GiB, **min 1 replica** (always-warm BFF)
-- Cost: ~£8/month (mostly idle rate)
-
-**T3 — Compute** (`func-kmlsat-{env}-compute`)
-
-- Image: ~1.2 GB (GDAL + rasterio + Rust/PyO3)
-- Functions: download_imagery, post_process_imagery, run_enrichment
-- Resources: 4 vCPU, 8 GiB, **min 0** (scale-to-zero), max 10 replicas
-- KEDA trigger: Durable Functions activity queue depth
-- Cost: £0 idle, ~£0.40–1.60/hour during pipeline runs
-
-| Order | Issue | Title | Depends On |
-|-------|-------|-------|------------|
-| T2.1 | #466 | Split Container Apps into API + compute images | #452, #401 |
-
-**Exit criteria:** T2 image <300 MB (no GDAL). T3 image has full GDAL+Rust
-stack. Both share Durable task hub. T2 cold-start <3s. T3 scales to zero
-when no pipeline work. Baseline cost drops from ~£20 → ~£8/month.
+**Stage 2C exit criteria:** The minimum viable user journey works. A visitor
+can: see what Canopex does (landing page) → sign in (free) → run analysis
+(sample KML) → see results → understand upgrade path (real prices).
 
 ---
 
-### P6 — Stage 3: Growth & Retention
+### Stage 2D — Revenue Enablement (This Month)
 
-Features that make Canopex a habit. **Do not open Stage 3 work until P1–P5 are materially complete.**
+Security and billing verification required before accepting real payments.
 
-| Order | Issue | Title | Depends On |
-|-------|-------|-------|------------|
-| 3.1 | #310 | Scheduled monitoring + change alerts | ✅ PR #394 merged |
-| 3.2 | #400 | Pipeline run telemetry — log per-job stats to Cosmos | — |
-| 3.3 | #399 | Pipeline ETA estimator (needs ~100 runs of telemetry data from #400) | #400 |
-| 3.4 | #78 | Temporal catalogue in Cosmos DB | — |
-| 3.5 | #79 | Catalogue API endpoints | #78 |
-| 3.6 | #177 | H3-derived imagery/stat products | — |
+| Order | Issue | Title | Status | Depends On |
+|-------|-------|-------|--------|------------|
+| R.1 | #534 | Auth header verification: prevent X-MS-CLIENT-PRINCIPAL forgery | Open | — |
+| R.2 | #535 | Verify end-to-end Stripe billing flow on live site | Open | #520 |
+| R.3 | #406 | Reconcile README, runbook, and API contracts with live routes | Open | — |
+
+**Exit criteria:** Auth is cryptographically verified (forged headers
+rejected). Free → Starter upgrade → Stripe payment → quota increase → run
+analysis works end-to-end. API docs match live behavior.
+
+---
+
+### Stage 2E — Release Safety & Promotion
+
+Build once in CI, promote the same immutable artifact dev → prod.
+
+| Order | Issue | Title | Status |
+|-------|-------|-------|--------|
+| 2A.1 | #401 | Separate dev and prod deployment flows | 🔄 In PR |
+| 2A.2 | #405 | Reduce config drift between OpenTofu and az CLI | Open — depends #401 |
+| 2A.3 | #402 | Gate production deploys on security workflow results | Open — depends #401 |
+| 2A.4 | #403 | Production rollout: smoke gates, promotion/demotion | Open — depends #401 |
+
+**Exit criteria:** Dev/prod promotion path explicit. Production deploy
+security-gated. Smoke checks pass before traffic shift.
+
+---
+
+### Stage 3 — Growth & Retention
+
+Features that make Canopex a habit. **Do not start until Stage 2C–2E are
+materially complete.**
+
+| Order | Issue | Title | Status |
+|-------|-------|-------|--------|
+| 3.1 | #310 | Scheduled monitoring + change alerts | ✅ PR #394 |
+| 3.2 | #400 | Pipeline run telemetry — per-job stats | Open |
+| 3.3 | #399 | Pipeline ETA estimator | Open (needs #400) |
+| 3.4 | #78 | Temporal catalogue in Cosmos DB | Open |
+| 3.5 | #79 | Catalogue API endpoints | Open (needs #78) |
+| 3.6 | #488 | Pipeline performance optimisation | Open |
 | 3.7 | — | Shareable analysis links | — |
 
-**Enrichment sources** (each is a single PR — add when approaching):
+**Enrichment sources** (add when a user requests them):
 
-- MODIS Burned Area (`modis-64A1-061`)
-- ESA CCI Land Cover (`esa-cci-lc`)
-- IO LULC Annual V2 (`io-lulc-annual-v02`)
-- ALOS Forest/Non-Forest (`alos-fnf-mosaic`)
-- GFW deforestation alerts (GLAD + RADD)
+- MODIS Burned Area, ESA CCI Land Cover, IO LULC, ALOS Forest, GFW alerts
 
-**Exit criteria:** Users on monitoring subs. Catalogue browsable. 3+ enrichment data sources added.
+**Exit criteria:** Users on monitoring subs. Catalogue browsable.
 
 ---
 
-### P7 — Stage 4: Team & API
+### Stage 4 — Team & API
 
-Unlock Team tier (£149/mo) and programmatic access.
-
-| Order | Issue | Title | Depends On |
-|-------|-------|-------|------------|
-| 4.1 | #313 | Team workspaces + tenant segregation | — |
-| 4.2 | — | API documentation (interactive OpenAPI portal) | #406 |
-| 4.3 | — | Webhook / Slack notifications | #310 |
-
-**Exit criteria:** Team tier selling. API used programmatically. ARR > £30K.
-
----
-
-### P8 — Stage 5: Enterprise, ML & Burst Compute (Horizon)
-
-Advanced features, enterprise deals, competitive moats. **Do not start until Stage 4 is generating revenue.**
+Unlock Team tier (£149/mo) and programmatic access. **Do not start until
+Stage 3 features are retaining users.**
 
 | Order | Issue | Title |
 |-------|-------|-------|
-| 5.1 | #467 | Container Apps Jobs for burst compute (Phase 3 — replaces T3 replicas with per-AOI jobs) |
-| 5.2 | #82 | Tree detection model + inference pipeline |
-| 5.3 | #83 | Tree health classification + temporal tracking |
-| 5.4 | #84 | Annotation-driven model fine-tuning |
-| 5.5 | #87 | Annotation tools and storage |
-| 5.6 | #86 | Web frontend (React / Next.js) |
+| 4.1 | #313 | Team workspaces + tenant segregation |
+| 4.2 | — | Interactive OpenAPI portal |
+| 4.3 | — | Webhook / Slack notifications |
 
-**Container Apps Jobs detail (#467):** Replace T3 activity replicas with
-event-triggered Jobs (one per AOI). 4 vCPU / 8 GiB per Job, max 50
-concurrent. Orchestrator dispatches via storage queue, polls blob for
-completion. 500-AOI run: ~45 min (50 Jobs) vs ~2.5 hours (10 T3 replicas).
-Azure Batch stays for AOIs ≥50k ha and future GPU workloads.
+---
+
+### Stage 5 — Infrastructure Optimisation, Enterprise & ML (Horizon)
+
+**Do not start until Stage 4 is generating revenue.** These are post-revenue
+features and cost optimisations.
+
+| Order | Issue | Title |
+|-------|-------|-------|
+| 5.1 | #466 | Split Container Apps into API + compute images (T2/T3) |
+| 5.2 | #467 | Container Apps Jobs for burst compute |
+| 5.3 | #82 | Tree detection model + inference pipeline |
+| 5.4 | #83 | Tree health classification + temporal tracking |
+| 5.5 | #84 | Annotation-driven model fine-tuning |
+| 5.6 | #87 | Annotation tools and storage |
+| 5.7 | #86 | Web frontend (React / Next.js) |
+| 5.8 | #177 | H3-derived imagery/stat products |
+
+---
+
+## Issue Triage (2026-04-12)
+
+Per the project review, open issues are triaged as follows:
+
+### Active — Do Now (Stage 2C)
+
+| # | Title | Priority |
+|---|-------|----------|
+| #531 | Pipeline e2e verification in Azure | P0 |
+| #520 | billing/status 500 | P0 |
+| #532 | Remove demo mode — Free Tier entry point | P1 |
+| #533 | Real prices on pricing page | P1 |
+
+### Active — This Month (Stage 2D)
+
+| # | Title |
+|---|-------|
+| #534 | Auth header verification (HMAC) |
+| #535 | E2e Stripe billing flow |
+| #406 | Reconcile docs with live routes |
+
+### Active — Release Safety (Stage 2E)
+
+| # | Title |
+|---|-------|
+| #401 | Dev/prod deploy flows |
+| #405 | Config drift reduction |
+| #402 | Security-gated deploys |
+| #403 | Production rollout gates |
+
+### Deferred — Post-Revenue
+
+| # | Title | When |
+|---|-------|------|
+| #466 | T2/T3 split | When cost exceeds revenue |
+| #467 | Container Apps Jobs | After T2/T3 split |
+| #313 | Team workspaces | When Team tier has customers |
+| #82, #83, #84 | Tree detection / health / ML | Stage 5 |
+| #86 | React frontend | Stage 5 |
+| #87 | Annotation tools | Stage 5 |
+
+### Closed (2026-04-12)
+
+| # | Title | Reason |
+|---|-------|--------|
+| #474 | Migrate remaining browser-facing endpoints to SWA | Superseded by BYOF |
+
+### Low Priority / Bundle with Adjacent Work
+
+| # | Title | Bundle with |
+|---|-------|-------------|
+| #252 | Rate limiter persistence | Stage 4 multi-instance |
+| #228 | Distributed replay store | Stage 4 multi-instance |
+| #488 | Pipeline perf optimisation | Stage 3 |
+| #513 | Infracost usage metric name | Next infra PR |
+| #517 | CSP img-src unused CartoDB | Next CSP change |
+| #518 | CSP connect-src missing unpkg | Next CSP change |
+| #519 | Self-host Leaflet | Nice-to-have |
+| #525 | Skip unchanged app settings | Next deploy PR |
+| #526 | Batch tofu output calls | Next deploy PR |
+| #527 | CSP blocks Leaflet source map | Next CSP change |
+| #528, #529 | Duplicate split FA issues | Superseded by #466 |
 
 ---
 
 ## Housekeeping (attach to adjacent feature work)
 
-These are not standalone PRs — bundle with the next PR that touches the same area.
-
 | Issue | Title | Bundle with |
 |-------|-------|-------------|
 | #252 | Rate limiter persistence (Redis/Cosmos) | Stage 4 multi-instance work |
 | #228 | Distributed replay store for valet tokens | Stage 4 multi-instance work |
-| — | Pydantic V2 request/response models | Next API surface change |
-| — | Extract provider stubs from production code to test helpers | Next provider refactor |
 
 ---
 
@@ -298,3 +334,5 @@ When working on any task:
 1. **Log issues you find.** If you encounter a bug, deprecation warning, test flake, or code smell that isn't the current task, check if a GitHub issue already exists. If not, create one with the `discovered` label. Don't fix it inline — track it.
 2. **Update the roadmap.** When a PR merges, update "Recently Landed" and mark the corresponding stage item as ✅.
 3. **Keep context lean.** Reference issue numbers, not full descriptions. The issue holds the detail; the roadmap holds the order.
+4. **User journey first.** Do not open Stage 3+ work while the minimum viable user journey (Stage 2C) is incomplete.
+5. **No infrastructure without users.** T2/T3 split, Container Apps Jobs, and ML work are deferred until user volume or revenue justifies them.


### PR DESCRIPTION
## Summary

Responds to the PROJECT_REVIEW_2026-04-12.md findings by making key architectural decisions, restructuring the roadmap, and updating all guidance documentation.

## Key Decisions

1. **Demo mode killed** — entry point is Free Tier (authenticated, 5 runs). `?mode=demo` is deprecated. Showcase (pre-computed static demos) deferred until pipeline proven.
2. **Roadmap restructured** — old P0-P8 numbering replaced with Stages 2C-2E. User journey is now the #1 priority over infrastructure.
3. **Pipeline e2e verification is P0** — nothing else matters until sign-in → upload → results works in Azure.

## Changes

- **`docs/ROADMAP.md`**: Full rewrite — completed stages collapsed, new Stage 2C (Pipeline Verification & User Journey), 2D (Revenue Enablement), 2E (Release Safety). Issue triage table added.
- **`docs/PROJECT_REVIEW_2026-04-12.md`**: Added to repo (the review document that drove this restructure).
- **`docs/ARCHITECTURE_OVERVIEW.md`**: "Showcase vs Tiers" section replaced with "Entry Point" section documenting the demo mode kill decision.
- **`.github/copilot-instructions.md`**: Prioritization section updated — Stage 2C is current priority, no infrastructure optimization until user volume justifies it.
- **`.github/instructions/persona-product.instructions.md`**: Entry point decision added, `blueprints/demo.py` removed from applyTo list.

## New Issues Created

| Issue | Title |
|-------|-------|
| #531 | Pipeline e2e verification in Azure |
| #532 | Remove demo mode — Free Tier entry point |
| #533 | Show real prices on pricing page |
| #534 | Auth header HMAC verification |
| #535 | Verify e2e Stripe billing flow |

## Issue Closed

- #474 (superseded by BYOF consolidation)

## Validation

- All 1075 tests pass
- `ruff check` + `ruff format` clean
- Pre-commit hooks pass

**Stage**: 2C (Planning & Documentation)