### PR TITLE
fix: merge scaling PATCHes into single call to avoid 409 Conflict

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -360,28 +360,28 @@ jobs:
             --url "${FUNC_ID}/config/web?api-version=2024-04-01" \
             --body "$CORS_BODY"
 
-          # Apply scaling cap from Terraform output (body is ignore_changes in tofu)
+          # Apply scaling config from Terraform outputs (body is ignore_changes
+          # in tofu due to the azapi identity bug).  Single PATCH to avoid 409
+          # Conflict race between back-to-back updates on the same resource.
           MAX_INSTANCES=$(tofu output -raw function_app_cli_maximum_instance_count)
-          az rest --method PATCH \
-            --url "${FUNC_ID}?api-version=2024-04-01" \
-            --body "{\"properties\":{\"functionAppConfig\":{\"scaleAndConcurrency\":{\"maximumInstanceCount\":${MAX_INSTANCES}}}}}"
-
-          # Apply minimum always-ready instances to avoid cold-start 504s
-          # Uses functionAppConfig.scaleAndConcurrency.alwaysReady for Container Apps
           MIN_INSTANCES=$(tofu output -raw function_app_cli_minimum_instance_count)
           if [ "$MIN_INSTANCES" -gt 0 ]; then
             ALWAYS_READY='[{"name":"http","instanceCount":'"${MIN_INSTANCES}"'}]'
           else
             ALWAYS_READY='[]'
           fi
+          SCALE_BODY=$(jq -cn \
+            --argjson max "$MAX_INSTANCES" \
+            --argjson ready "$ALWAYS_READY" \
+            '{properties:{functionAppConfig:{scaleAndConcurrency:{maximumInstanceCount:$max,alwaysReady:$ready}}}}')
           az rest --method PATCH \
             --url "${FUNC_ID}?api-version=2024-04-01" \
-            --body "{\"properties\":{\"functionAppConfig\":{\"scaleAndConcurrency\":{\"alwaysReady\":${ALWAYS_READY}}}}}"
+            --body "$SCALE_BODY"
 
-          # Verify min instances applied
+          # Verify scaling config applied
           ACTUAL=$(az rest --method GET --url "${FUNC_ID}?api-version=2024-04-01" \
-            | jq '.properties.functionAppConfig.scaleAndConcurrency.alwaysReady // []')
-          echo "Always-ready config: $ACTUAL"
+            | jq '{max: .properties.functionAppConfig.scaleAndConcurrency.maximumInstanceCount, alwaysReady: (.properties.functionAppConfig.scaleAndConcurrency.alwaysReady // [])}')
+          echo "Scaling config: $ACTUAL"
 
       - name: Verify browser CORS contract
         id: verify-browser-cors


### PR DESCRIPTION
## Problem

The deploy workflow makes two back-to-back `az rest --method PATCH` calls to the same Function App resource:
1. `maximumInstanceCount` PATCH
2. `alwaysReady` PATCH

Azure rejects the second while the first is still processing, returning **409 Conflict**: _"Cannot modify this site because another operation is in progress."_

This blocked PR #530 from deploying (deploy run `24305783865` failed twice).

## Fix

Combine both scaling properties into a single PATCH payload using `jq`. This eliminates the race entirely — no sleep/retry needed.

### Why not move it all back to OpenTofu?

The `azapi_resource` for the Function App has `lifecycle { ignore_changes = [identity, body] }` due to an [azapi v2 bug](https://github.com/Azure/terraform-provider-azapi/issues/XXX) where the ARM API omits identity from update responses, crashing the provider. Until that upstream bug is fixed, `body` changes (image, CORS, scaling) must be applied via CLI in the deploy pipeline.

The CORS PATCH targets a different sub-resource (`/config/web`), so it doesn't race with scaling. Only the two scaling calls needed merging.

## Verification

The combined PATCH now verifies both `maximumInstanceCount` and `alwaysReady` in a single GET after applying.