### PR TITLE
fix: include custom domain in dev CORS origins — unblocks live site

### DIFF
--- a/infra/tofu/environments/dev.tfvars
+++ b/infra/tofu/environments/dev.tfvars
@@ -13,7 +13,7 @@ default_tags = {
 }
 budget_amount         = 10
 budget_contact_emails = ["j.brewster@outlook.com"]
-custom_domain         = ""
+custom_domain         = "canopex.hrdcrprwn.com"
 enable_azure_ai         = false
 enable_stripe           = true
 enable_cosmos_db         = true

--- a/infra/tofu/environments/dev.tfvars
+++ b/infra/tofu/environments/dev.tfvars
@@ -13,6 +13,8 @@ default_tags = {
 }
 budget_amount         = 10
 budget_contact_emails = ["j.brewster@outlook.com"]
+# NOTE: Apex domain is intentionally assigned to dev (the only deployed env).
+# Clear this before applying prd.tfvars — a domain can only bind to one SWA.
 custom_domain         = "canopex.hrdcrprwn.com"
 enable_azure_ai         = false
 enable_stripe           = true


### PR DESCRIPTION
## Problem

The live site at `https://canopex.hrdcrprwn.com` shows "Unavailable" and all API calls fail with CORS errors. Uploads fail with "Could not prepare upload."

## Root Cause

`dev.tfvars` had `custom_domain = ""` while the SWA custom domain DNS actually points at the dev environment. This meant `browser_allowed_origins` only included `https://green-moss-....azurestaticapps.net` — not `https://canopex.hrdcrprwn.com`.

Every cross-origin request from the custom domain to the Function App (health probe, upload/token, billing/status) was rejected by CORS.

## Fix

Set `custom_domain = "canopex.hrdcrprwn.com"` in `dev.tfvars`. On next deploy, OpenTofu will include the custom domain in:
- Function App CORS allowed origins (platform-level `/config/web`)
- `CORS_ALLOWED_ORIGINS` env var (application-level `_helpers.py`)
- Storage account blob CORS (for direct SAS uploads)

## Approval gate

⚠️ Infrastructure change — `dev.tfvars` update. Deploy will modify CORS config on Function App and storage account.

Partial fix for #531.