### PR TITLE
fix: update launch readiness test for custom domain in dev

### DIFF
--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -226,13 +226,14 @@ class TestLogAnalyticsCap:
             "until Log Analytics proves its value"
         )
 
-    def test_dev_custom_domain_is_disabled(self):
+    def test_dev_custom_domain_is_set(self):
+        """Dev is the only deployed environment; it must own the apex domain."""
         tfvars = DEV_TFVARS.read_text()
         match = re.search(r'^custom_domain\s*=\s*"([^"]*)"', tfvars, re.MULTILINE)
         assert match, "dev.tfvars must set custom_domain explicitly"
-        assert match.group(1) == "", (
-            "dev.tfvars must leave custom_domain empty so clean-slate dev "
-            "redeploys do not depend on public DNS"
+        assert match.group(1) != "", (
+            "dev.tfvars must set custom_domain to the apex domain so the "
+            "Function App CORS allow-list includes it"
         )
 
 


### PR DESCRIPTION
Superseded by PR #546 which included the same test fix alongside the demo mode removal.\n\nClosing as the fix was merged via #546 → `82ab8b6`.