### PR TITLE
fix: enforce REQUIRE_AUTH in all deployed environments

### DIFF
--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -915,7 +915,7 @@ locals {
       AzureWebJobsStorage__accountName    = azurerm_storage_account.main.name
       CORS_ALLOWED_ORIGINS                = join(",", local.browser_allowed_origins)
       PRIMARY_SITE_URL                    = local.primary_site_url
-      REQUIRE_AUTH                        = var.environment == "prd" ? "true" : ""
+      REQUIRE_AUTH                        = "true"
       OPS_DASHBOARD_KEY                   = var.ops_dashboard_key
     },
     var.enable_cosmos_db ? {

--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -6,7 +6,7 @@ accidentally removed or misconfigured.  They cover:
 1. Container Apps scaling limits (maxReplicas)
 2. App Insights browser analytics on all pages
 3. Auth enforcement on pipeline submission endpoint
-4. REQUIRE_AUTH wired into production app settings
+4. REQUIRE_AUTH unconditionally enabled for all deployed environments
 5. Log Analytics daily ingestion cap
 6. detect-secrets in CI security workflow
 7. App Insights availability test (URL ping)

--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -171,30 +171,31 @@ class TestSubmissionAuthRequirement:
 
 
 # ---------------------------------------------------------------------------
-# 4. REQUIRE_AUTH in production
+# 4. REQUIRE_AUTH in all deployed environments
 # ---------------------------------------------------------------------------
 
 
 class TestRequireAuth:
-    """Ensure REQUIRE_AUTH is wired into the Function App for production."""
+    """Ensure REQUIRE_AUTH is unconditionally enabled for all deployed environments."""
 
     def test_require_auth_in_app_settings(self):
         tf = MAIN_TF.read_text()
         assert "REQUIRE_AUTH" in tf, (
             "main.tf must include REQUIRE_AUTH in appSettings "
-            "to prevent silent anonymous fallback in production"
+            "to prevent silent anonymous fallback in deployed environments"
         )
 
-    def test_require_auth_conditional_on_environment(self):
+    def test_require_auth_unconditional(self):
+        """REQUIRE_AUTH must be 'true' unconditionally — no per-env conditional."""
         tf = MAIN_TF.read_text()
         match = re.search(
             r"REQUIRE_AUTH\s*=\s*(.+)",
             tf,
         )
         assert match, "REQUIRE_AUTH app setting not found"
-        value_expr = match.group(1)
-        assert "prd" in value_expr, (
-            "REQUIRE_AUTH should be enabled for production (prd) environment"
+        value_expr = match.group(1).strip()
+        assert value_expr == '"true"', (
+            f"REQUIRE_AUTH must be unconditionally '\"true\"', got: {value_expr}"
         )
 
 


### PR DESCRIPTION
## Summary

Set `REQUIRE_AUTH = "true"` unconditionally for all deployed environments instead of only for `prd`.

## Problem

`REQUIRE_AUTH` was set to `""` (empty) in dev, meaning any anonymous request could:
1. Mint SAS upload tokens via `POST /api/upload/token`
2. Upload KML files to blob storage
3. Trigger the full analysis pipeline (ingestion → acquisition → fulfilment → enrichment)

Confirmed by running a full anonymous E2E pipeline test — 5 Sentinel-2 images acquired, clipped, and enriched without authentication.

## Changes

- **`infra/tofu/main.tf`**: `REQUIRE_AUTH = "true"` unconditionally (was `var.environment == "prd" ? "true" : ""`)
- **`tests/test_launch_readiness.py`**: Updated `TestRequireAuth` to verify REQUIRE_AUTH is unconditionally `"true"` (renamed test, updated assertions)

## Local dev impact

The anonymous fallback in `_helpers.py` remains for `func start` local dev (where `REQUIRE_AUTH` is unset). Only deployed environments are affected.

## Contains approval-gated content

**Yes** — infra change (`main.tf`) requires review before merge.

fixes #553