### PR TITLE
docs: add UX review and integrate dashboard overhaul into roadmap (#555)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,7 @@
 **Single source of truth for what to build next.**
 Issues hold the detail. This list holds the order.
 
-Last updated: 2026-04-12 (merge PR #546 — demo mode removed)
+Last updated: 2026-04-12 (UX review + auth hardening)
 
 ---
 
@@ -35,13 +35,13 @@ See `docs/ARCHITECTURE_OVERVIEW.md` § "Entry Point" for details.
 ## Recently Landed
 
 | PR | Summary |
-|----|---------|| #546 | Remove frontend demo mode (`?mode=demo`), unify on Free Tier entry (closes #532) |
-| #545 | CORS fix: set custom_domain in dev.tfvars for apex domain || #543 | Fix deploy: merge scaling PATCHes into single call to avoid 409 Conflict |
-| #530 | Ops dashboard, CORS hardening, always-ready instances, timing-safe auth |
+|----|---------|
+| #554 | Enforce REQUIRE_AUTH in all deployed environments (fixes #553) |
+| #549 | Fix deploy: declarative import block for custom domain |
+| #546 | Remove frontend demo mode (`?mode=demo`), unify on Free Tier entry (closes #532) |
+| #545 | CORS fix: set custom_domain in dev.tfvars for apex domain |
+| #543 | Fix deploy: merge scaling PATCHes into single call to avoid 409 Conflict |
 | #540 | Cosmos-only storage: remove cosmos_or_blob dual-write, fix RLock deadlock, fix exception cache poisoning |
-| #537 | Roadmap restructure per project review: kill demo mode, prioritize user journey |
-| #536 | billing/status returns 200 with safe defaults when storage unavailable (fixes #520) |
-| #523 | Fix deploy: filter localhost from CORS verify; accept 200 or 204 for OPTIONS |
 
 ---
 
@@ -130,12 +130,14 @@ entry point unambiguous.
 
 | Order | Issue | Title | Status |
 |-------|-------|-------|--------|
-| E.1 | #531 | Verify e2e pipeline in Azure: sign in → upload KML → results | Open |
-| E.2 | #520 | Fix `/api/billing/status` returns 500 for signed-in users | Open |
+| E.1 | #531 | Verify e2e pipeline in Azure: sign in → upload KML → results | ✅ Verified 2026-04-12 |
+| E.2 | #520 | Fix `/api/billing/status` returns 500 for signed-in users | ✅ PR #536 |
 
-**Exit criteria:** A user can sign in on the live SWA URL, upload a sample
+**Exit criteria:** ✅ A user can sign in on the live SWA URL, upload a sample
 KML, and see a completed analysis with imagery, NDVI, weather, and AI
-narrative. Billing/status returns 200.
+narrative. Billing/status returns 200. Pipeline verified end-to-end on
+2026-04-12 (1 feature, 5 Sentinel-2 images acquired, clipped, enriched
+in 42s).
 
 #### 2C.2 — Unify Entry Point (Kill Demo Mode)
 
@@ -165,6 +167,24 @@ Starter/Pro. Enterprise remains "Contact Us."
 can: see what Canopex does (landing page) → sign in (free) → run analysis
 (sample KML) → see results → understand upgrade path (real prices).
 
+#### 2C.4 — Dashboard UX Overhaul
+
+| Order | Issue | Title | Status |
+|-------|-------|-------|--------|
+| UX.1 | #555 | Reorder layout: submission above evidence | Open |
+| UX.2 | #555 | Replace jargon with user language | Open |
+| UX.3 | #555 | Collapse first-load noise for new users | Open |
+| UX.4 | #555 | Auto-scroll to results on completion | Open |
+| UX.5 | #555 | Streamline submission form | Open |
+| UX.6 | #555 | Deduplicate export buttons | Open |
+
+See `docs/UX_REVIEW_2026-04-12.md` for full findings and implementation
+plan. All slices are frontend-only. Recommended order: 1 → 2 → 3 → 4 → 5 → 6.
+
+**Exit criteria:** File upload is visible without scrolling. Results auto-
+scroll on completion. Zero "signed-in" / "workspace lens" / "durable" jargon
+in user-facing strings. First-load elements <12 (currently ~25).
+
 ---
 
 ### Stage 2D — Revenue Enablement (This Month)
@@ -173,6 +193,7 @@ Security and billing verification required before accepting real payments.
 
 | Order | Issue | Title | Status | Depends On |
 |-------|-------|-------|--------|------------|
+| R.0 | #553 | Enforce REQUIRE_AUTH in all deployed environments | ✅ PR #554 | — |
 | R.1 | #534 | Auth header verification: prevent X-MS-CLIENT-PRINCIPAL forgery | Open | — |
 | R.2 | #535 | Verify end-to-end Stripe billing flow on live site | Open | #520 |
 | R.3 | #406 | Reconcile README, runbook, and API contracts with live routes | Open | — |
@@ -261,15 +282,17 @@ Per the project review, open issues are triaged as follows:
 
 | # | Title | Priority |
 |---|-------|----------|
-| #531 | Pipeline e2e verification in Azure | P0 |
-| #520 | billing/status 500 | P0 |
-| #532 | Remove demo mode — Free Tier entry point | P1 |
+| #531 | Pipeline e2e verification in Azure | ✅ Verified |
+| #520 | billing/status 500 | ✅ PR #536 |
+| #532 | Remove demo mode — Free Tier entry point | ✅ PR #546 |
+| #555 | Dashboard UX overhaul (6 slices) | P0 |
 | #533 | Real prices on pricing page | P1 |
 
 ### Active — This Month (Stage 2D)
 
 | # | Title |
 |---|-------|
+| #553 | Enforce REQUIRE_AUTH in all environments |
 | #534 | Auth header verification (HMAC) |
 | #535 | E2e Stripe billing flow |
 | #406 | Reconcile docs with live routes |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -179,7 +179,8 @@ can: see what Canopex does (landing page) → sign in (free) → run analysis
 | UX.6 | #555 | Deduplicate export buttons | Open |
 
 See `docs/UX_REVIEW_2026-04-12.md` for full findings and implementation
-plan. All slices are frontend-only. Recommended order: 1 → 2 → 3 → 4 → 5 → 6.
+plan. All slices are frontend-only. Recommended order: UX.1 → UX.2 →
+UX.3 → UX.4 → UX.5 → UX.6.
 
 **Exit criteria:** File upload is visible without scrolling. Results auto-
 scroll on completion. Zero "signed-in" / "workspace lens" / "durable" jargon

--- a/docs/UX_REVIEW_2026-04-12.md
+++ b/docs/UX_REVIEW_2026-04-12.md
@@ -1,0 +1,372 @@
+# Canopex — Dashboard UX Review
+
+**Date:** 12 April 2026
+**Status:** Critical review with implementation plan
+**Scope:** Dashboard user journey — from landing to submission to results
+**Audience:** Engineering team, product owner
+**Tracking:** GitHub issue #555
+**Roadmap stage:** 2C.4 — Dashboard UX Overhaul
+
+---
+
+## Executive Summary
+
+The pipeline works. The architecture is sound. But the dashboard is built
+around **system architecture** (history rail, run rail, evidence hero,
+content rail, workflow stage) rather than the three questions every user
+arrives with:
+
+1. "How do I submit my data?"
+2. "What's happening with my run?"
+3. "Where are my results?"
+
+The visual hierarchy is inverted: the primary action (upload KML) is buried
+at the bottom of the page, below a large empty evidence panel. After a run
+completes, the user is told to "check history" instead of being shown
+results. Internal jargon saturates the UI.
+
+This review identifies 9 issues ranked by severity and proposes 6 ordered
+implementation slices.
+
+---
+
+## Findings
+
+### F1. CRITICAL — Visual hierarchy is inverted
+
+When a user arrives at the dashboard, they see (top to bottom):
+
+1. Welcome bar (name, plan, runs left, mode, active run)
+2. **Evidence hero** — a large empty card: "Select a completed run..."
+3. **History rail** (left) + **New Analysis rail** (right) — below the fold
+
+The primary action (submit KML) is in the bottom-right, inside the
+non-focused panel (opacity 0.72, scaled to 0.965). A first-time user sees
+an empty TV screen before they've been told where the remote control is.
+
+**Persona impact:** Conservation officers and EUDR compliance teams arrive
+with a KML in hand. They need the upload form immediately, not an empty
+evidence viewer. Every second of confusion increases the risk they close
+the tab and go back to manual QGIS workflows.
+
+### F2. CRITICAL — Completion sends users on a scavenger hunt
+
+The completion message reads:
+
+> "Analysis completed. Use history to reopen this run or resume another
+> active submission from this workspace."
+
+This is an architectural instruction, not user guidance. The evidence
+surface silently populates above the fold while the user watches the
+progress tracker at the bottom. There is no scroll, no transition, no
+attention signal. The user completed a 45-second pipeline and is now
+stranded.
+
+**What should happen:** On completion, auto-scroll to the evidence surface,
+show a clear "Your results are ready" banner with direct links to the map,
+NDVI summary, and export actions.
+
+### F3. SEVERE — Pervasive internal jargon
+
+| UI string | Problem |
+|-----------|---------|
+| "Workspace lens: Conservation evidence run" | Users don't know what a "workspace lens" is |
+| "Frame this run around vegetation change..." | Reads like internal product docs |
+| "Next surface: Prepare evidence brief" | "Surface" is an engineering concept |
+| "Signed-in workspace", "signed-in history" | "Signed-in" appears ~40 times in UI strings. Users don't think about auth while working |
+| "Durable run state" | Azure Durable Functions implementation detail |
+| "ingestion", "acquisition", "fulfilment", "enrichment" | Code-level pipeline phase names, not user language |
+
+**What users understand:** "Uploading", "Finding imagery", "Processing",
+"Building report". The pipeline phases should be described in terms of what
+the user is getting, not what the system is doing.
+
+### F4. SEVERE — Information overload on first load
+
+The dashboard presents ~25 distinct UI elements before the user types a
+single character:
+
+- Welcome bar: 4 stat pills
+- Evidence hero: 3 status blocks
+- History rail: snapshot card + 3 line items
+- New Analysis rail: lens card, file input, textarea, preflight card
+  (4 stats + warnings list), progress tracker (6 steps), status card,
+  4 detail cards
+
+Compare to competitors: Google Earth Engine shows a code editor and a map.
+Global Forest Watch shows a map with a search bar. Sentinel Hub shows a map
+with a date picker. All of them present one primary interaction surface.
+
+### F5. MODERATE — History panel wastes space for first-time users
+
+The two-column layout (History + New Analysis) gives equal visual weight to
+both panels. For a first-time user with no runs, the History rail contains:
+"No runs yet / Your next signed-in submission becomes the first item..."
+
+This is wasted screen real estate that pushes the submission form further
+right and further down. The equal-weight layout implies both panels are
+equally important, when for a new user, only one matters.
+
+### F6. MODERATE — Role and preference configuration is premature
+
+The Conservation / EUDR / Portfolio Ops role switcher plus Investigate /
+Monitor / Report preference switcher are in Workspace Settings. These
+actively change dashboard copy and behavior. A new user hasn't formed a
+mental model of the product yet; asking them to pick a "workspace lens"
+before their first run puts configuration before value.
+
+The role system is correctly behind a disclosure (`<details>`), which helps.
+But the lens card is still visible in the New Analysis rail, taking up
+space above the file input.
+
+### F7. MODERATE — Preflight card is useful but overweighted
+
+The preflight summary (Features, AOIs, Spread, Quota Impact) is one of the
+few genuinely useful UI elements. But it occupies the same visual weight as
+the submission form itself, making the "Queue Analysis" button feel like an
+afterthought below the stats.
+
+### F8. MINOR — Results appear at the wrong scroll position
+
+When evidence loads, it populates the evidence hero above the workflow
+stage. But the user's eyes are at the bottom of the page, watching the
+pipeline progress tracker. Results appear where the user isn't looking.
+
+### F9. MINOR — Export buttons are duplicated
+
+Export buttons (GeoJSON, CSV, PDF) appear in two places:
+
+1. Inside the evidence surface export bar
+2. Inside the run detail grid (4th card, "Run Link")
+
+Both follow different visibility and enable/disable logic. This creates
+confusion about which is the "real" export action.
+
+---
+
+## Persona Impact Summary
+
+| Persona | Primary pain point | Severity |
+|---------|-------------------|----------|
+| Conservation officer | Upload is buried, completion redirects to history | Critical |
+| EUDR compliance team | Can't find EUDR assessment after run completes | Critical |
+| Agricultural advisor | Batch upload flow unclear, results navigation confusing | Severe |
+| First-time user (any) | 25 UI elements before first interaction, jargon barrier | Severe |
+| Returning user | History panel useful, but completion flow still broken | Moderate |
+
+---
+
+## Implementation Plan
+
+Six ordered slices. Each is independently deployable and testable. Each
+slice improves the experience for the stated persona without depending on
+subsequent slices.
+
+### Slice 1 — Reorder: submission above evidence
+
+**What:** Move the two-column workflow stage (History + New Analysis) above
+the evidence hero in HTML. New Analysis is the first thing users see after
+the welcome bar.
+
+**Why:** Fixes F1 (hierarchy inverted). The primary action is now at the
+top. Evidence appears below, populated when a run completes.
+
+**Scope:**
+
+- Reorder `<section>` elements in `app/index.html`
+- Update CSS to ensure the workflow stage works above the evidence hero
+- Verify first-run hero still toggles correctly
+
+**Validation:** Load `/app/` as a new user → file input is visible without
+scrolling. Load as returning user → file input still prominent, history
+shows previous runs.
+
+**Files:** `website/app/index.html`, `website/css/app.css`
+
+---
+
+### Slice 2 — Auto-scroll to results on completion
+
+**What:** When `runtimeStatus` transitions to `Completed`, scroll the
+evidence hero into view and show an inline "Results ready" banner with
+plain-English summary.
+
+**Why:** Fixes F2 (scavenger hunt) and F8 (wrong scroll position).
+
+**Scope:**
+
+- In `pollAnalysisRun` → `Completed` branch: call
+  `scrollIntoView({ behavior: 'smooth' })` on the evidence hero
+- Replace the completion message with a user-facing summary:
+  "Analysis complete — {N} images processed for {AOI name}. Scroll down
+  to view satellite imagery, vegetation health, and export options."
+- Add a "View Results" anchor button in the progress tracker completion
+  state that scrolls to the evidence hero
+
+**Validation:** Queue an analysis → watch pipeline tracker → on completion,
+page scrolls to evidence surface. No manual clicking required.
+
+**Files:** `website/js/app-shell.js`
+
+---
+
+### Slice 3 — Replace jargon with user language
+
+**What:** Replace internal/architectural terminology with plain English
+throughout `app-shell.js` UI strings and `app/index.html` static text.
+
+**Why:** Fixes F3 (jargon barrier).
+
+**Key replacements:**
+
+| Current | Replacement |
+|---------|-------------|
+| "Workspace lens" | "Analysis type" or remove label entirely |
+| "Conservation evidence run" | "Conservation analysis" |
+| "Due diligence evidence run" | "EUDR compliance check" |
+| "Portfolio triage run" | "Batch analysis" |
+| "Surface" (as noun) | "view" or "section" |
+| "Signed-in workspace/history/analysis" | "your workspace/history/analysis" |
+| "Durable run state" | "Analysis details" |
+| "ingestion" | "Parsing your file" |
+| "acquisition" | "Finding satellite imagery" |
+| "fulfilment" | "Downloading and processing" |
+| "enrichment" | "Building your report" |
+| "Prepare evidence brief" | "Review results" |
+| All ~40 "signed-in" occurrences | Remove or replace with "your" |
+
+**Validation:** Search for "signed-in", "surface" (noun), "durable",
+"workspace lens" in UI-visible strings — zero hits.
+
+**Files:** `website/js/app-shell.js`, `website/app/index.html`
+
+---
+
+### Slice 4 — Collapse first-load noise
+
+**What:** For first-time users (no history), hide the History rail entirely
+and make the New Analysis form full-width. Move the lens card below the
+file input. Reduce the welcome bar to 2 stat pills (Plan, Runs Left).
+
+**Why:** Fixes F4 (information overload) and F5 (empty history). Reduces
+initial UI elements from ~25 to ~10.
+
+**Scope:**
+
+- When `analysisHistoryRuns.length === 0 && analysisHistoryLoaded`:
+  hide history rail, make analysis rail full-width
+- Move the `app-mode-card` (lens description) below the file input and
+  above the preflight card, or collapse it into a single-line label
+- Welcome bar: hide Mode and Active Run pills when no history exists.
+  Show them once the user has at least one run
+- Re-show history rail once a run completes
+
+**Validation:** New user → sees welcome (Plan + Runs Left) and full-width
+submission form. After first run completes → history rail appears.
+
+**Files:** `website/app/index.html`, `website/css/app.css`,
+`website/js/app-shell.js`
+
+---
+
+### Slice 5 — Streamline the New Analysis form
+
+**What:** Reorder form elements for a cleaner top-to-bottom flow:
+File input → paste area → preflight → Queue button. Remove the lens card
+from the form (it's configuration, not submission). Make the Queue button
+more prominent.
+
+**Why:** Fixes F7 (preflight overweighted) and clarifies the call to action.
+
+**Scope:**
+
+- Remove `app-mode-card` from inside the form (lens info is in Settings)
+- Reorder: file input → paste area → preflight → Queue Analysis button
+- Make Queue Analysis button full-width, primary style, larger text
+- Reduce preflight card to a compact inline summary unless warnings exist
+
+**Validation:** Upload a KML file → preflight appears as compact summary →
+Queue button is the obvious next step with no visual competition.
+
+**Files:** `website/app/index.html`, `website/css/app.css`,
+`website/js/app-shell.js`
+
+---
+
+### Slice 6 — Deduplicate exports
+
+**What:** Remove the export buttons from the run detail grid (4th card).
+Keep exports only in the evidence surface export bar, which is the
+canonical location.
+
+**Why:** Fixes F9 (duplicate export actions).
+
+**Scope:**
+
+- Remove `app-run-export-actions` div and its buttons from the run
+  detail grid
+- Keep the evidence surface `app-evidence-export-bar` as the only
+  export location
+- Update `app-run-link` card to show only the permalink
+
+**Validation:** Completed run → export buttons appear in exactly one
+location (evidence surface export bar).
+
+**Files:** `website/app/index.html`, `website/js/app-shell.js`
+
+---
+
+## Dependency Graph
+
+```text
+Slice 1 (reorder)
+  └── Slice 2 (auto-scroll) — depends on knowing where evidence is
+  └── Slice 4 (collapse noise) — depends on knowing layout ordering
+
+Slice 3 (jargon) — independent, can ship anytime
+Slice 5 (streamline form) — ideally after Slice 1 + 4
+Slice 6 (dedup exports) — independent, can ship anytime
+```
+
+**Recommended order:** 1 → 3 → 4 → 2 → 5 → 6
+
+Slices 3 and 6 are safe, low-risk changes that can be batched into a
+single PR if desired. Slices 1 and 4 are structural and should be tested
+together. Slice 2 requires Slice 1 to land so completed runs scroll to the
+correct position. Slice 5 benefits from having the simplified layout in
+place.
+
+---
+
+## What This Does NOT Cover
+
+- Landing page redesign (the landing page is adequate for now)
+- New features (monitoring dashboard, batch upload, scheduling)
+- Mobile layout (existing responsive CSS is passable)
+- Role/preference system removal (it's behind a disclosure, low harm)
+- Backend changes (all changes are frontend-only)
+
+## Stage Alignment
+
+This work is Stage 2C (Pipeline Verification & User Journey). The pipeline
+is proven end-to-end (#531 — anonymous pipeline test completed successfully
+on 2026-04-12). This fixes the product experience around the working
+pipeline, completing the "user journey" half of Stage 2C.
+
+All 6 slices are frontend-only. No backend, infra, or auth changes.
+
+---
+
+## Success Metrics
+
+After all 6 slices:
+
+1. **First-action time:** New user can reach the file upload in <5 seconds
+   without scrolling (currently requires scrolling past the evidence hero)
+2. **Completion-to-results:** User sees their results within 2 seconds of
+   pipeline completion without any manual clicks (currently requires
+   finding and clicking history)
+3. **Jargon count:** Zero instances of "signed-in", "surface", "durable",
+   or "workspace lens" in user-visible UI strings
+4. **First-load elements:** <12 visible UI components on first dashboard
+   load (currently ~25)

--- a/docs/UX_REVIEW_2026-04-12.md
+++ b/docs/UX_REVIEW_2026-04-12.md
@@ -348,10 +348,11 @@ place.
 
 ## Stage Alignment
 
-This work is Stage 2C (Pipeline Verification & User Journey). The pipeline
-is proven end-to-end (#531 — anonymous pipeline test completed successfully
-on 2026-04-12). This fixes the product experience around the working
-pipeline, completing the "user journey" half of Stage 2C.
+This work is Stage 2C (Pipeline Verification & User Journey). The signed-in
+Azure journey was verified end-to-end (#531 — signed-in Azure journey
+completed successfully on 2026-04-12). This fixes the product experience
+around the working pipeline, completing the "user journey" half of Stage
+2C.
 
 All 6 slices are frontend-only. No backend, infra, or auth changes.
 


### PR DESCRIPTION
## Summary

Add the UX review doc and integrate UX overhaul work into the roadmap.

## Changes

### New file: `docs/UX_REVIEW_2026-04-12.md`
- 9 findings from Senior UX Designer review of the dashboard user journey
- 6 implementation slices (frontend-only), with dependency graph and recommended order
- Success metrics and persona impact analysis

### Updated: `docs/ROADMAP.md`
- **2C.1 marked ✅** — Pipeline verified end-to-end on 2026-04-12 (1 feature, 5 images, 42s)
- **#520 marked ✅** — Fixed by PR #536
- **Added 2C.4 — Dashboard UX Overhaul** — 6 ordered items (UX.1–UX.6) referencing #555
- **Added R.0 (#553)** — Auth hardening to Stage 2D (PR #554)
- **Recently Landed** — Added PRs #549, #554; trimmed to 6 most recent
- **Issue Triage** — Updated statuses for #531, #520, #532; added #555 as P0; added #553

## Docs-only change — no code changes.

refs #555