### PR TITLE
feat(ux): dashboard UX overhaul — layout, jargon, exports (#555)

### DIFF
--- a/website/app/index.html
+++ b/website/app/index.html
@@ -108,7 +108,129 @@
         </article>
       </div>
 
-      <!-- ── Evidence hero (full-width, prominent) ── -->
+      <!-- ── Two-column workflow: history + new analysis ── -->
+      <div class="app-workflow-stage" id="app-workflow-stage" data-focus="run">
+        <article class="app-workflow-rail app-rail-history" id="app-history-card" data-focus-target="history">
+          <div class="app-rail-header">
+            <div>
+              <div class="section-label">History</div>
+              <h3>History &amp; Resume</h3>
+            </div>
+          </div>
+          <p class="app-rail-copy" id="app-history-copy">Reopen a previous run or resume an active one.</p>
+          <div class="app-run-snapshot">
+            <span class="app-run-label">Selected status</span>
+            <strong id="app-history-latest-status">Loading recent runs</strong>
+            <span id="app-history-latest-note">Restoring signed-in history and checking for an active run to resume.</span>
+          </div>
+          <div class="app-mini-list">
+            <div class="app-mini-item"><span>Instance</span><strong id="app-history-latest-instance">…</strong></div>
+            <div class="app-mini-item"><span>Phase</span><strong id="app-history-latest-phase">loading</strong></div>
+            <div class="app-mini-item"><span>Next surface</span><strong id="app-history-latest-path">Checking workspace</strong></div>
+          </div>
+          <div class="app-history-list" id="app-history-list" aria-live="polite">Restoring signed-in history…</div>
+          <div class="app-rail-footer">Select a run to reopen this workspace state.</div>
+        </article>
+
+        <article class="app-workflow-rail app-rail-run" id="app-analysis-card" data-focus-target="run">
+          <div class="app-rail-header">
+            <div>
+              <div class="section-label">New Analysis</div>
+              <h3>Launch and Track</h3>
+            </div>
+          </div>
+          <p class="app-rail-copy" id="app-run-copy">Upload KML, queue the pipeline, and monitor progress.</p>
+          <!-- ── Auth gate overlay for analysis form ── -->
+          <div class="app-analysis-auth-gate" id="app-analysis-auth-gate" hidden>
+            <div class="app-panel">
+              <h4>Sign in to run your own analysis</h4>
+              <p>Sign in to upload KML and queue analysis runs. 5 free analyses per month, no credit card required.</p>
+              <div class="app-gate-actions">
+                <button class="btn btn-primary" id="app-analysis-sign-in-btn" type="button">Sign In</button>
+                <a class="btn btn-secondary" href="/#pricing">View Plans</a>
+              </div>
+            </div>
+          </div>
+          <div id="app-analysis-form-fields" hidden>
+          <div class="app-mode-card">
+            <span class="app-run-label">Workspace lens</span>
+            <strong id="app-analysis-lens-title">Conservation evidence run</strong>
+            <p id="app-analysis-lens-note">Frame this run around vegetation change, weather context, and plain-English proof. Bias the workspace toward outputs, evidence language, and what the next saved surface needs to deliver.</p>
+          </div>
+          <label class="app-field-label" for="app-analysis-file">KML or KMZ file</label>
+          <input id="app-analysis-file" type="file" accept=".kml,.kmz,application/vnd.google-earth.kml+xml,application/vnd.google-earth.kmz">
+          <p class="app-note" id="app-analysis-file-note">Choose a KML or KMZ file, or paste KML below.</p>
+          <label class="app-field-label" for="app-analysis-kml">KML Content</label>
+          <textarea id="app-analysis-kml" placeholder="Paste KML content for a signed-in analysis request…"></textarea>
+          <div class="app-preflight-card" id="app-analysis-preflight">
+            <div class="app-preflight-header">
+              <div>
+                <div class="section-label">Preflight</div>
+                <h4 id="app-preflight-headline">Awaiting KML</h4>
+              </div>
+              <span class="app-preflight-badge" id="app-preflight-mode">No file yet</span>
+            </div>
+            <p class="app-note" id="app-preflight-summary">Paste KML to see feature count, AOI spread, and signed-in product guidance before queueing.</p>
+            <div class="app-preflight-grid">
+              <div><span>Features</span><strong id="app-preflight-features">0</strong></div>
+              <div><span>AOIs</span><strong id="app-preflight-aois">0</strong></div>
+              <div><span>Spread</span><strong id="app-preflight-spread">—</strong></div>
+              <div><span>Quota impact</span><strong id="app-preflight-quota">—</strong></div>
+            </div>
+            <div class="app-preflight-list" id="app-preflight-warnings">
+              <div class="app-preflight-item" data-tone="info">Preflight will surface warnings here after you paste or upload KML.</div>
+            </div>
+          </div>
+          <div class="app-select-row app-analysis-actions">
+            <button class="btn btn-primary" id="app-analysis-submit-btn" type="button">Queue Analysis</button>
+          </div>
+          </div><!-- /app-analysis-form-fields -->
+          <div class="app-callout" id="app-analysis-status" hidden></div>
+          <div id="app-analysis-progress" class="app-pipeline-progress" hidden>
+            <div class="pipeline-step" data-phase="submit"><span class="step-icon">○</span> Uploading KML and reserving pipeline capacity</div>
+            <div class="pipeline-step" data-phase="ingestion"><span class="step-icon">○</span> Parsing AOIs and validating geometry</div>
+            <div class="pipeline-step" data-phase="acquisition"><span class="step-icon">○</span> Searching NAIP and Sentinel-2 imagery</div>
+            <div class="pipeline-step" data-phase="fulfilment"><span class="step-icon">○</span> Downloading scenes, clipping, and reprojection</div>
+            <div class="pipeline-step" data-phase="enrichment"><span class="step-icon">○</span> Building NDVI, weather, and cache layers</div>
+            <div class="pipeline-step" data-phase="complete"><span class="step-icon">○</span> Complete</div>
+          </div>
+          <dl class="app-stats compact" id="app-analysis-run" hidden>
+            <div><dt>Instance</dt><dd id="app-analysis-instance">—</dd></div>
+            <div><dt>Status</dt><dd id="app-analysis-runtime">—</dd></div>
+            <div><dt>Phase</dt><dd id="app-analysis-phase">—</dd></div>
+          </dl>
+          <div class="app-run-detail-grid" id="app-run-detail-grid">
+            <div class="app-detail-card">
+              <span class="app-content-label">Submitted</span>
+              <strong id="app-run-submitted">—</strong>
+              <p id="app-run-submitted-note">Signed-in run detail restores here after reload.</p>
+            </div>
+            <div class="app-detail-card">
+              <span class="app-content-label">Scope</span>
+              <strong id="app-run-scope">—</strong>
+              <p id="app-run-scope-note">Feature and AOI counts appear when known.</p>
+            </div>
+            <div class="app-detail-card">
+              <span class="app-content-label">Delivery</span>
+              <strong id="app-run-delivery">—</strong>
+              <p id="app-run-delivery-note">Failure counts and tracked artifacts will appear here.</p>
+            </div>
+            <div class="app-detail-card">
+              <span class="app-content-label">Run Link</span>
+              <strong id="app-run-link-label">Dashboard state</strong>
+              <a class="app-inline-link" id="app-run-link" href="/app/">Open durable run state</a>
+              <div class="app-run-action-row" id="app-run-export-actions">
+                <button class="btn btn-secondary app-run-action-btn" id="app-run-export-geojson" type="button" data-export-format="geojson" disabled>GeoJSON</button>
+                <button class="btn btn-secondary app-run-action-btn" id="app-run-export-csv" type="button" data-export-format="csv" disabled>CSV</button>
+                <button class="btn btn-secondary app-run-action-btn" id="app-run-export-pdf" type="button" data-export-format="pdf" disabled>PDF</button>
+              </div>
+              <p class="app-note" id="app-run-export-note">Completed runs can download GeoJSON, CSV, and PDF exports here.</p>
+            </div>
+          </div>
+        </article>
+      </div>
+
+      <!-- ── Evidence hero (populated when a run completes) ── -->
       <div class="app-evidence-hero" id="app-evidence-hero">
         <article class="app-card app-evidence-hero-card" id="app-content-card" data-focus-target="content">
           <div class="app-evidence-hero-header">
@@ -234,128 +356,6 @@
           </div>
 
           <div class="app-rail-footer" id="app-content-footer">Select a completed run from history to view evidence.</div>
-        </article>
-      </div>
-
-      <!-- ── Two-column workflow: history + run ── -->
-      <div class="app-workflow-stage" id="app-workflow-stage" data-focus="run">
-        <article class="app-workflow-rail app-rail-history" id="app-history-card" data-focus-target="history">
-          <div class="app-rail-header">
-            <div>
-              <div class="section-label">History</div>
-              <h3>History &amp; Resume</h3>
-            </div>
-          </div>
-          <p class="app-rail-copy" id="app-history-copy">Reopen a previous run or resume an active one.</p>
-          <div class="app-run-snapshot">
-            <span class="app-run-label">Selected status</span>
-            <strong id="app-history-latest-status">Loading recent runs</strong>
-            <span id="app-history-latest-note">Restoring signed-in history and checking for an active run to resume.</span>
-          </div>
-          <div class="app-mini-list">
-            <div class="app-mini-item"><span>Instance</span><strong id="app-history-latest-instance">…</strong></div>
-            <div class="app-mini-item"><span>Phase</span><strong id="app-history-latest-phase">loading</strong></div>
-            <div class="app-mini-item"><span>Next surface</span><strong id="app-history-latest-path">Checking workspace</strong></div>
-          </div>
-          <div class="app-history-list" id="app-history-list" aria-live="polite">Restoring signed-in history…</div>
-          <div class="app-rail-footer">Select a run to reopen this workspace state.</div>
-        </article>
-
-        <article class="app-workflow-rail app-rail-run" id="app-analysis-card" data-focus-target="run">
-          <div class="app-rail-header">
-            <div>
-              <div class="section-label">New Analysis</div>
-              <h3>Launch and Track</h3>
-            </div>
-          </div>
-          <p class="app-rail-copy" id="app-run-copy">Upload KML, queue the pipeline, and monitor progress.</p>
-          <!-- ── Auth gate overlay for analysis form ── -->
-          <div class="app-analysis-auth-gate" id="app-analysis-auth-gate" hidden>
-            <div class="app-panel">
-              <h4>Sign in to run your own analysis</h4>
-              <p>Sign in to upload KML and queue analysis runs. 5 free analyses per month, no credit card required.</p>
-              <div class="app-gate-actions">
-                <button class="btn btn-primary" id="app-analysis-sign-in-btn" type="button">Sign In</button>
-                <a class="btn btn-secondary" href="/#pricing">View Plans</a>
-              </div>
-            </div>
-          </div>
-          <div id="app-analysis-form-fields" hidden>
-          <div class="app-mode-card">
-            <span class="app-run-label">Workspace lens</span>
-            <strong id="app-analysis-lens-title">Conservation evidence run</strong>
-            <p id="app-analysis-lens-note">Frame this run around vegetation change, weather context, and plain-English proof. Bias the workspace toward outputs, evidence language, and what the next saved surface needs to deliver.</p>
-          </div>
-          <label class="app-field-label" for="app-analysis-file">KML or KMZ file</label>
-          <input id="app-analysis-file" type="file" accept=".kml,.kmz,application/vnd.google-earth.kml+xml,application/vnd.google-earth.kmz">
-          <p class="app-note" id="app-analysis-file-note">Choose a KML or KMZ file, or paste KML below.</p>
-          <label class="app-field-label" for="app-analysis-kml">KML Content</label>
-          <textarea id="app-analysis-kml" placeholder="Paste KML content for a signed-in analysis request…"></textarea>
-          <div class="app-preflight-card" id="app-analysis-preflight">
-            <div class="app-preflight-header">
-              <div>
-                <div class="section-label">Preflight</div>
-                <h4 id="app-preflight-headline">Awaiting KML</h4>
-              </div>
-              <span class="app-preflight-badge" id="app-preflight-mode">No file yet</span>
-            </div>
-            <p class="app-note" id="app-preflight-summary">Paste KML to see feature count, AOI spread, and signed-in product guidance before queueing.</p>
-            <div class="app-preflight-grid">
-              <div><span>Features</span><strong id="app-preflight-features">0</strong></div>
-              <div><span>AOIs</span><strong id="app-preflight-aois">0</strong></div>
-              <div><span>Spread</span><strong id="app-preflight-spread">—</strong></div>
-              <div><span>Quota impact</span><strong id="app-preflight-quota">—</strong></div>
-            </div>
-            <div class="app-preflight-list" id="app-preflight-warnings">
-              <div class="app-preflight-item" data-tone="info">Preflight will surface warnings here after you paste or upload KML.</div>
-            </div>
-          </div>
-          <div class="app-select-row app-analysis-actions">
-            <button class="btn btn-primary" id="app-analysis-submit-btn" type="button">Queue Analysis</button>
-          </div>
-          </div><!-- /app-analysis-form-fields -->
-          <div class="app-callout" id="app-analysis-status" hidden></div>
-          <div id="app-analysis-progress" class="app-pipeline-progress" hidden>
-            <div class="pipeline-step" data-phase="submit"><span class="step-icon">○</span> Uploading KML and reserving pipeline capacity</div>
-            <div class="pipeline-step" data-phase="ingestion"><span class="step-icon">○</span> Parsing AOIs and validating geometry</div>
-            <div class="pipeline-step" data-phase="acquisition"><span class="step-icon">○</span> Searching NAIP and Sentinel-2 imagery</div>
-            <div class="pipeline-step" data-phase="fulfilment"><span class="step-icon">○</span> Downloading scenes, clipping, and reprojection</div>
-            <div class="pipeline-step" data-phase="enrichment"><span class="step-icon">○</span> Building NDVI, weather, and cache layers</div>
-            <div class="pipeline-step" data-phase="complete"><span class="step-icon">○</span> Complete</div>
-          </div>
-          <dl class="app-stats compact" id="app-analysis-run" hidden>
-            <div><dt>Instance</dt><dd id="app-analysis-instance">—</dd></div>
-            <div><dt>Status</dt><dd id="app-analysis-runtime">—</dd></div>
-            <div><dt>Phase</dt><dd id="app-analysis-phase">—</dd></div>
-          </dl>
-          <div class="app-run-detail-grid" id="app-run-detail-grid">
-            <div class="app-detail-card">
-              <span class="app-content-label">Submitted</span>
-              <strong id="app-run-submitted">—</strong>
-              <p id="app-run-submitted-note">Signed-in run detail restores here after reload.</p>
-            </div>
-            <div class="app-detail-card">
-              <span class="app-content-label">Scope</span>
-              <strong id="app-run-scope">—</strong>
-              <p id="app-run-scope-note">Feature and AOI counts appear when known.</p>
-            </div>
-            <div class="app-detail-card">
-              <span class="app-content-label">Delivery</span>
-              <strong id="app-run-delivery">—</strong>
-              <p id="app-run-delivery-note">Failure counts and tracked artifacts will appear here.</p>
-            </div>
-            <div class="app-detail-card">
-              <span class="app-content-label">Run Link</span>
-              <strong id="app-run-link-label">Dashboard state</strong>
-              <a class="app-inline-link" id="app-run-link" href="/app/">Open durable run state</a>
-              <div class="app-run-action-row" id="app-run-export-actions">
-                <button class="btn btn-secondary app-run-action-btn" id="app-run-export-geojson" type="button" data-export-format="geojson" disabled>GeoJSON</button>
-                <button class="btn btn-secondary app-run-action-btn" id="app-run-export-csv" type="button" data-export-format="csv" disabled>CSV</button>
-                <button class="btn btn-secondary app-run-action-btn" id="app-run-export-pdf" type="button" data-export-format="pdf" disabled>PDF</button>
-              </div>
-              <p class="app-note" id="app-run-export-note">Completed runs can download GeoJSON, CSV, and PDF exports here.</p>
-            </div>
-          </div>
         </article>
       </div>
 

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -70,13 +70,13 @@
       <div class="app-welcome-bar">
         <div class="app-welcome-identity">
           <h2>Welcome back, <span id="app-user-name">there</span></h2>
-          <p id="app-account-note" class="app-welcome-note">Signed-in workspace</p>
+          <p id="app-account-note" class="app-welcome-note">Your workspace</p>
         </div>
         <div class="app-welcome-stats">
           <div class="app-stat-pill"><span class="app-utility-label">Plan</span><strong id="app-hero-plan">Loading…</strong><span class="app-utility-note" id="app-hero-plan-note">Checking entitlement…</span></div>
           <div class="app-stat-pill"><span class="app-utility-label">Runs Left</span><strong id="app-hero-runs">—</strong><span class="app-utility-note" id="app-hero-runs-note">Quota refreshes with your plan.</span></div>
           <div class="app-stat-pill"><span class="app-utility-label">Mode</span><strong id="app-hero-mode">Analysis workspace</strong><span class="app-utility-note" id="app-hero-mode-note">Capability summary loading…</span></div>
-          <div class="app-stat-pill"><span class="app-utility-label">Active Run</span><strong id="app-hero-active-run">Checking recent runs</strong><span class="app-utility-note" id="app-hero-active-run-note">Restoring signed-in history and active run state.</span></div>
+          <div class="app-stat-pill"><span class="app-utility-label">Active Run</span><strong id="app-hero-active-run">Checking recent runs</strong><span class="app-utility-note" id="app-hero-active-run-note">Loading your recent runs.</span></div>
         </div>
         <div class="app-welcome-actions">
           <a class="btn btn-primary" id="app-new-analysis-btn" href="#app-analysis-card">New Analysis</a>
@@ -121,14 +121,14 @@
           <div class="app-run-snapshot">
             <span class="app-run-label">Selected status</span>
             <strong id="app-history-latest-status">Loading recent runs</strong>
-            <span id="app-history-latest-note">Restoring signed-in history and checking for an active run to resume.</span>
+            <span id="app-history-latest-note">Loading your history and checking for active runs.</span>
           </div>
           <div class="app-mini-list">
             <div class="app-mini-item"><span>Instance</span><strong id="app-history-latest-instance">…</strong></div>
             <div class="app-mini-item"><span>Phase</span><strong id="app-history-latest-phase">loading</strong></div>
-            <div class="app-mini-item"><span>Next surface</span><strong id="app-history-latest-path">Checking workspace</strong></div>
+            <div class="app-mini-item"><span>Next step</span><strong id="app-history-latest-path">Checking workspace</strong></div>
           </div>
-          <div class="app-history-list" id="app-history-list" aria-live="polite">Restoring signed-in history…</div>
+          <div class="app-history-list" id="app-history-list" aria-live="polite">Loading your history…</div>
           <div class="app-rail-footer">Select a run to reopen this workspace state.</div>
         </article>
 
@@ -153,15 +153,15 @@
           </div>
           <div id="app-analysis-form-fields" hidden>
           <div class="app-mode-card">
-            <span class="app-run-label">Workspace lens</span>
-            <strong id="app-analysis-lens-title">Conservation evidence run</strong>
-            <p id="app-analysis-lens-note">Frame this run around vegetation change, weather context, and plain-English proof. Bias the workspace toward outputs, evidence language, and what the next saved surface needs to deliver.</p>
+            <span class="app-run-label">Analysis type</span>
+            <strong id="app-analysis-lens-title">Conservation analysis</strong>
+            <p id="app-analysis-lens-note">Focus on vegetation change, weather context, and plain-English findings for field teams.</p>
           </div>
           <label class="app-field-label" for="app-analysis-file">KML or KMZ file</label>
           <input id="app-analysis-file" type="file" accept=".kml,.kmz,application/vnd.google-earth.kml+xml,application/vnd.google-earth.kmz">
           <p class="app-note" id="app-analysis-file-note">Choose a KML or KMZ file, or paste KML below.</p>
           <label class="app-field-label" for="app-analysis-kml">KML Content</label>
-          <textarea id="app-analysis-kml" placeholder="Paste KML content for a signed-in analysis request…"></textarea>
+          <textarea id="app-analysis-kml" placeholder="Paste KML content here…"></textarea>
           <div class="app-preflight-card" id="app-analysis-preflight">
             <div class="app-preflight-header">
               <div>
@@ -170,7 +170,7 @@
               </div>
               <span class="app-preflight-badge" id="app-preflight-mode">No file yet</span>
             </div>
-            <p class="app-note" id="app-preflight-summary">Paste KML to see feature count, AOI spread, and signed-in product guidance before queueing.</p>
+            <p class="app-note" id="app-preflight-summary">Paste KML to see feature count, area spread, and guidance before queueing.</p>
             <div class="app-preflight-grid">
               <div><span>Features</span><strong id="app-preflight-features">0</strong></div>
               <div><span>AOIs</span><strong id="app-preflight-aois">0</strong></div>
@@ -178,7 +178,7 @@
               <div><span>Quota impact</span><strong id="app-preflight-quota">—</strong></div>
             </div>
             <div class="app-preflight-list" id="app-preflight-warnings">
-              <div class="app-preflight-item" data-tone="info">Preflight will surface warnings here after you paste or upload KML.</div>
+              <div class="app-preflight-item" data-tone="info">Preflight will show warnings here after you paste or upload KML.</div>
             </div>
           </div>
           <div class="app-select-row app-analysis-actions">
@@ -203,7 +203,7 @@
             <div class="app-detail-card">
               <span class="app-content-label">Submitted</span>
               <strong id="app-run-submitted">—</strong>
-              <p id="app-run-submitted-note">Signed-in run detail restores here after reload.</p>
+              <p id="app-run-submitted-note">Run details restore here after reload.</p>
             </div>
             <div class="app-detail-card">
               <span class="app-content-label">Scope</span>
@@ -218,7 +218,7 @@
             <div class="app-detail-card">
               <span class="app-content-label">Run Link</span>
               <strong id="app-run-link-label">Dashboard state</strong>
-              <a class="app-inline-link" id="app-run-link" href="/app/">Open durable run state</a>
+              <a class="app-inline-link" id="app-run-link" href="/app/">Open run details</a>
               <div class="app-run-action-row" id="app-run-export-actions">
                 <button class="btn btn-secondary app-run-action-btn" id="app-run-export-geojson" type="button" data-export-format="geojson" disabled>GeoJSON</button>
                 <button class="btn btn-secondary app-run-action-btn" id="app-run-export-csv" type="button" data-export-format="csv" disabled>CSV</button>
@@ -400,7 +400,7 @@
               </div>
               <p class="app-lens-copy" id="app-preference-summary">Stay centered on the live run while you prove what changed, why it changed, and what to do next.</p>
               <div class="app-action-stack">
-                <button class="btn btn-primary" id="app-guided-primary-btn" type="button">Start evidence run</button>
+                <button class="btn btn-primary" id="app-guided-primary-btn" type="button">Start analysis</button>
                 <button class="btn btn-secondary" id="app-guided-secondary-btn" type="button">Review latest incident</button>
               </div>
               <div class="app-mini-list app-mini-list-tight">
@@ -430,7 +430,7 @@
 
             <article class="app-card app-support-card" id="app-tier-emulation-card" hidden>
               <h3>Plan Emulation</h3>
-              <p>Local development only. Override this signed-in account to test plan-gated behavior without changing the billing record.</p>
+              <p>Local development only. Override your account to test plan-gated behavior without changing the billing record.</p>
               <label class="app-field-label" for="app-tier-emulation-select">Effective plan</label>
               <div class="app-select-row">
                 <select id="app-tier-emulation-select">

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -219,12 +219,6 @@
               <span class="app-content-label">Run Link</span>
               <strong id="app-run-link-label">Dashboard state</strong>
               <a class="app-inline-link" id="app-run-link" href="/app/">Open run details</a>
-              <div class="app-run-action-row" id="app-run-export-actions">
-                <button class="btn btn-secondary app-run-action-btn" id="app-run-export-geojson" type="button" data-export-format="geojson" disabled>GeoJSON</button>
-                <button class="btn btn-secondary app-run-action-btn" id="app-run-export-csv" type="button" data-export-format="csv" disabled>CSV</button>
-                <button class="btn btn-secondary app-run-action-btn" id="app-run-export-pdf" type="button" data-export-format="pdf" disabled>PDF</button>
-              </div>
-              <p class="app-note" id="app-run-export-note">Completed runs can download GeoJSON, CSV, and PDF exports here.</p>
             </div>
           </div>
         </article>

--- a/website/css/app.css
+++ b/website/css/app.css
@@ -230,9 +230,6 @@
 .app-detail-card p{font-size:.82rem;line-height:1.55;color:var(--c-muted)}
 .app-inline-link{color:var(--app-role-accent);font-size:.84rem;font-weight:600;text-decoration:none}
 .app-inline-link:hover{text-decoration:underline}
-.app-run-action-row{display:flex;gap:8px;flex-wrap:wrap;margin-top:4px}
-.app-run-action-btn{padding:8px 12px;min-width:0}
-.app-run-action-btn:disabled{opacity:.55;cursor:not-allowed}
 
 .btn:focus-visible,.auth-btn:focus-visible,.app-lens-chip:focus-visible,.app-history-item:focus-visible,.app-inline-link:focus-visible,.app-workflow-rail input[type=file]:focus-visible,.app-workflow-rail textarea:focus-visible,.app-card input[type=file]:focus-visible,.app-card textarea:focus-visible,.app-select-row select:focus-visible{outline:2px solid var(--app-role-accent);outline-offset:2px}
 

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -1748,7 +1748,7 @@
       deliveryNoteEl.textContent = 'Failure counts and tracked artifacts will appear here.';
       linkLabelEl.textContent = 'Dashboard state';
       linkEl.href = '/app/';
-      linkEl.textContent = 'Open run details';
+      linkEl.textContent = 'Open dashboard';
       document.querySelectorAll('[data-export-format]').forEach(function(button) {
         button.disabled = true;
       });
@@ -2137,7 +2137,7 @@
       processingMode: processingMode,
       quotaImpact: latestBillingStatus && latestBillingStatus.runs_remaining != null
         ? '1 of ' + latestBillingStatus.runs_remaining + ' runs'
-        : '1 queued run',
+        : '1 analysis',
       summary: parsed.featureCount + ' features across ' + parsed.polygons.length + ' AOIs covering about ' + formatHectares(totalAreaHa) + '. ' + processingMode + ' keeps the ' + preference.focusLabel.toLowerCase() + ' in focus for this request.'
     };
     preflight.warnings = buildPreflightWarnings(preflight);

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -1737,8 +1737,7 @@
     var deliveryNoteEl = document.getElementById('app-run-delivery-note');
     var linkLabelEl = document.getElementById('app-run-link-label');
     var linkEl = document.getElementById('app-run-link');
-    var exportNoteEl = document.getElementById('app-run-export-note');
-    if (!submittedEl || !submittedNoteEl || !scopeEl || !scopeNoteEl || !deliveryEl || !deliveryNoteEl || !linkLabelEl || !linkEl || !exportNoteEl) return;
+    if (!submittedEl || !submittedNoteEl || !scopeEl || !scopeNoteEl || !deliveryEl || !deliveryNoteEl || !linkLabelEl || !linkEl) return;
 
     if (!data) {
       submittedEl.textContent = '—';
@@ -1750,7 +1749,6 @@
       linkLabelEl.textContent = 'Dashboard state';
       linkEl.href = '/app/';
       linkEl.textContent = 'Open run details';
-      exportNoteEl.textContent = 'Completed runs can download GeoJSON, CSV, and PDF exports here.';
       document.querySelectorAll('[data-export-format]').forEach(function(button) {
         button.disabled = true;
       });
@@ -1782,15 +1780,12 @@
     if (runtimeStatus === 'Completed') {
       deliveryEl.textContent = artifactCount ? artifactCount + ' tracked outputs' : 'Exports ready';
       deliveryNoteEl.textContent = failureSummary || 'GeoJSON, CSV, and PDF exports are ready for this completed run.';
-      exportNoteEl.textContent = 'Use these export actions to inspect or download your completed results.';
     } else if (runtimeStatus === 'Failed' || runtimeStatus === 'Canceled' || runtimeStatus === 'Terminated') {
       deliveryEl.textContent = 'Run interrupted';
       deliveryNoteEl.textContent = failureSummary || 'This run stopped before producing a complete result set.';
-      exportNoteEl.textContent = 'Exports stay unavailable when the real pipeline does not complete.';
     } else {
       deliveryEl.textContent = 'Tracking live pipeline';
       deliveryNoteEl.textContent = failureSummary || 'Results will unlock here when the run completes.';
-      exportNoteEl.textContent = 'Exports unlock automatically after the enrichment manifest is ready.';
     }
 
     linkLabelEl.textContent = 'Run details';

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -14,17 +14,17 @@
       risk: 'No silent fallback',
       rhythm: 'Monthly watchlist',
       historyCopy: 'Keep the most recent incident visible while you compare new reports against what already ran.',
-      runCopy: 'Queue a signed-in analysis for a protected area or reported clearing.',
+      runCopy: 'Queue an analysis for a protected area or reported clearing.',
       contentCopy: 'Use this rail to understand what evidence is being assembled and what will be ready for a field or donor brief.',
-      runLensTitle: 'Conservation evidence run',
+      runLensTitle: 'Conservation analysis',
       runLensNote: 'Frame this run around vegetation change, weather context, and plain-English proof.',
-      readyNote: 'Launch a signed-in conservation evidence run from this workspace.',
-      emptyHistoryNote: 'Your next signed-in submission becomes the first item in the field evidence queue.',
+      readyNote: 'Ready to run a conservation analysis.',
+      emptyHistoryNote: 'Your next submission will appear here.',
       activeHistoryContext: 'field evidence',
       completedHistoryOutcome: 'shareable evidence brief',
       activePath: 'Tracking evidence build',
-      completedPath: 'Prepare evidence brief',
-      runLabel: 'Start evidence run',
+      completedPath: 'Review results',
+      runLabel: 'Start analysis',
       reviewLabel: 'Review latest incident',
       deliverableLabel: 'Open evidence rail',
       emptyContent: {
@@ -37,7 +37,7 @@
       },
       completedContent: {
         exportsTitle: 'Evidence pack next',
-        exportsNote: 'The next signed-in slice should reopen this run into maps, narrative, and a field-ready evidence pack.'
+        exportsNote: 'Maps, narrative, and a field-ready evidence pack will be available after results load.'
       }
     },
     eudr: {
@@ -49,12 +49,12 @@
       risk: 'Audit-ready trust',
       rhythm: 'Quarterly refresh cadence',
       historyCopy: 'Keep the most recent assessment visible while you decide whether another supplier plot needs review.',
-      runCopy: 'Queue a signed-in due diligence run with explicit product-path status.',
+      runCopy: 'Queue a due diligence run with explicit product-path status.',
       contentCopy: 'Use this rail to understand what audit evidence is forming before it becomes a saved due diligence dossier.',
-      runLensTitle: 'Due diligence evidence run',
+      runLensTitle: 'EUDR compliance check',
       runLensNote: 'Keep baseline integrity, plain-English findings, and product-path reliability front and center.',
-      readyNote: 'Launch a signed-in due diligence run from this workspace.',
-      emptyHistoryNote: 'Your next signed-in submission becomes the first item in the due diligence queue.',
+      readyNote: 'Ready to run a due diligence check.',
+      emptyHistoryNote: 'Your next submission will appear here.',
       activeHistoryContext: 'audit context',
       completedHistoryOutcome: 'due diligence dossier',
       activePath: 'Tracking audit evidence',
@@ -72,7 +72,7 @@
       },
       completedContent: {
         exportsTitle: 'Audit dossier next',
-        exportsNote: 'The next signed-in slice should reopen this run with coordinates, methods, and exportable due diligence evidence.'
+        exportsNote: 'Coordinates, methods, and exportable due diligence evidence will be available after results load.'
       }
     },
     portfolio: {
@@ -84,12 +84,12 @@
       risk: 'Scale without guesswork',
       rhythm: 'Event-driven review',
       historyCopy: 'Keep the most recent batch visible so you can triage new uploads against what already moved.',
-      runCopy: 'Queue a signed-in batch-style analysis and keep scale warnings visible.',
+      runCopy: 'Queue a batch-style analysis and keep scale warnings visible.',
       contentCopy: 'Use this rail to understand what the current run is building before you reopen it as a parcel-level review.',
       runLensTitle: 'Portfolio triage run',
       runLensNote: 'Bias the workspace toward batch readiness, AOI spread, and which runs need deeper follow-up.',
-      readyNote: 'Launch a signed-in portfolio triage run from this workspace.',
-      emptyHistoryNote: 'Your next signed-in submission becomes the first item in the batch review queue.',
+      readyNote: 'Ready to run a batch analysis.',
+      emptyHistoryNote: 'Your next submission will appear here.',
       activeHistoryContext: 'batch context',
       completedHistoryOutcome: 'triage summary',
       activePath: 'Tracking batch progress',
@@ -107,7 +107,7 @@
       },
       completedContent: {
         exportsTitle: 'Triage summary next',
-        exportsNote: 'The next signed-in slice should reopen this run into parcel-level review and export actions.'
+        exportsNote: 'Parcel-level review and export actions will be available after results load.'
       }
     }
   };
@@ -140,7 +140,7 @@
       label: 'Report',
       tag: 'Deliverable-first',
       title: 'Package findings for action',
-      summary: 'Bias the workspace toward outputs, evidence language, and what the next saved surface needs to deliver.',
+      summary: 'Focus on outputs, evidence language, and what to deliver next.',
       deliverable: 'Decision packet',
       stance: 'Translate signal into action',
       focusLabel: 'Content rail',
@@ -174,7 +174,7 @@
     acquisition: 'Searching NAIP and Sentinel-2 coverage to find the best imagery for each AOI.',
     fulfilment: 'Downloading scenes, clipping to your AOIs, and reprojecting them into the output stack.',
     enrichment: 'Adding NDVI, weather context, and cached artifacts so the workspace has richer outputs ready.',
-    complete: 'Analysis completed. Use history to reopen this run or resume another active submission from this workspace.'
+    complete: 'Analysis complete — scroll down to review satellite imagery, vegetation health, and export options.'
   };
 
   function authEnabled() { return true; /* SWA built-in auth — always available */ }
@@ -275,7 +275,7 @@
     var noteEl = document.getElementById('app-hero-active-run-note');
     if (!titleEl || !noteEl) return;
     titleEl.textContent = title || 'Ready to queue';
-    noteEl.textContent = note || 'Launch a signed-in analysis from this workspace.';
+    noteEl.textContent = note || 'Ready to run an analysis.';
   }
 
   function setWorkflowFocus(focus) {
@@ -411,7 +411,7 @@
 
     if (!latestAnalysisRun) {
       if (!analysisHistoryLoaded && currentAccount) {
-        setHeroRunSummary('Checking recent runs', 'Restoring signed-in history and active run state.');
+        setHeroRunSummary('Checking recent runs', 'Loading your recent runs.');
       } else {
         setHeroRunSummary('Ready to queue', role.readyNote);
       }
@@ -509,7 +509,7 @@
     planEl.textContent = (caps.label || data.tier || 'Free') + (data.tier_source === 'emulated' ? ' (emulated)' : '');
     planNoteEl.textContent = data.tier_source === 'emulated'
       ? 'Local override for product testing.'
-      : 'Driven by the signed-in account state.';
+      : 'Based on your account.';
     runsEl.textContent = data.runs_remaining == null ? '—' : String(data.runs_remaining);
     runsNoteEl.textContent = data.runs_remaining == null
       ? 'Quota unavailable in this environment.'
@@ -530,7 +530,7 @@
     if (!data) {
       if (!analysisHistoryLoaded && currentAccount) {
         statusEl.textContent = 'Loading recent runs';
-        noteEl.textContent = 'Restoring signed-in history and checking for an active run to resume.';
+        noteEl.textContent = 'Loading your history and checking for active runs.';
         instanceEl.textContent = '…';
         phaseEl.textContent = 'loading';
         pathEl.textContent = role.activePath;
@@ -549,8 +549,8 @@
     var phase = displayAnalysisPhase(data.customStatus, runtimeStatus);
     var timing = summarizeRunTiming(data);
     var summaryLabel = analysisHistoryRuns.length > 1 && selectedAnalysisRunId
-      ? 'Selected signed-in analysis'
-      : 'Latest signed-in analysis';
+      ? 'Selected analysis'
+      : 'Latest analysis';
     statusEl.textContent = runtimeStatus;
     noteEl.textContent = runtimeStatus === 'Completed'
       ? summaryLabel + ' completed and is ready to become a ' + role.completedHistoryOutcome + '.'
@@ -665,7 +665,7 @@
     if (!analysisHistoryLoaded && currentAccount) {
       var loading = document.createElement('div');
       loading.className = 'app-history-empty';
-      loading.textContent = 'Restoring signed-in history…';
+      loading.textContent = 'Loading your history…';
       container.appendChild(loading);
       return;
     }
@@ -721,9 +721,9 @@
 
       note.className = 'app-history-item-note';
       if (historyRunIsActive(run)) {
-        note.textContent = 'Resume this run from ' + phase + ' and keep polling the signed-in pipeline.';
+        note.textContent = 'Resume this run from ' + phase + '.';
       } else if (runtimeStatus === 'Completed') {
-        note.textContent = 'Reopen the completed workspace state and use the run rail to download signed-in exports.';
+        note.textContent = 'View completed results and download exports.';
       } else {
         note.textContent = 'Review this run state.';
       }
@@ -1712,7 +1712,7 @@
 
     if (phase === 'fulfilment') {
       imageryEl.textContent = 'Clipping and reprojection';
-      imageryNoteEl.textContent = 'The pipeline is producing the concrete imagery assets that the signed-in workspace should eventually reopen.';
+      imageryNoteEl.textContent = 'The pipeline is producing imagery assets for your analysis.';
       enrichmentEl.textContent = 'Preparing next';
       enrichmentNoteEl.textContent = 'NDVI and weather context will follow immediately after fulfilment finishes.';
       exportsEl.textContent = 'Outputs staging next';
@@ -1724,8 +1724,8 @@
     imageryNoteEl.textContent = 'Core imagery is in place and the workspace is adding the last supporting layers.';
     enrichmentEl.textContent = 'Context packaging';
     enrichmentNoteEl.textContent = 'NDVI, weather, and derived context are being assembled for the run detail experience.';
-    exportsEl.textContent = 'Preparing reopen surface';
-    exportsNoteEl.textContent = 'The next signed-in slices should turn this into saved outputs, exports, and revisit paths.';
+    exportsEl.textContent = 'Preparing results view';
+    exportsNoteEl.textContent = 'Saved outputs, exports, and revisit paths will be available shortly.';
   }
 
   function updateRunDetail(data) {
@@ -1742,14 +1742,14 @@
 
     if (!data) {
       submittedEl.textContent = '—';
-      submittedNoteEl.textContent = 'Signed-in run detail restores here after reload.';
+      submittedNoteEl.textContent = 'Run details restore here after reload.';
       scopeEl.textContent = '—';
       scopeNoteEl.textContent = 'Feature and AOI counts appear when known.';
       deliveryEl.textContent = '—';
       deliveryNoteEl.textContent = 'Failure counts and tracked artifacts will appear here.';
       linkLabelEl.textContent = 'Dashboard state';
       linkEl.href = '/app/';
-      linkEl.textContent = 'Open durable run state';
+      linkEl.textContent = 'Open run details';
       exportNoteEl.textContent = 'Completed runs can download GeoJSON, CSV, and PDF exports here.';
       document.querySelectorAll('[data-export-format]').forEach(function(button) {
         button.disabled = true;
@@ -1775,25 +1775,25 @@
     submittedEl.textContent = formatHistoryTimestamp(data.submittedAt || data.createdTime);
     submittedNoteEl.textContent = timing.sinceUpdate
       ? 'Last backend update ' + timing.sinceUpdate + ' ago.'
-      : 'Signed-in run history keeps this state durable across reloads.';
+      : 'Your run history preserves this state across reloads.';
     scopeEl.textContent = scopeSummary || 'Scope loading';
     scopeNoteEl.textContent = scopeNote || 'Preflight detail appears when the run metadata is available.';
 
     if (runtimeStatus === 'Completed') {
       deliveryEl.textContent = artifactCount ? artifactCount + ' tracked outputs' : 'Exports ready';
       deliveryNoteEl.textContent = failureSummary || 'GeoJSON, CSV, and PDF exports are ready for this completed run.';
-      exportNoteEl.textContent = 'Use these export actions to inspect or download the completed signed-in result set.';
+      exportNoteEl.textContent = 'Use these export actions to inspect or download your completed results.';
     } else if (runtimeStatus === 'Failed' || runtimeStatus === 'Canceled' || runtimeStatus === 'Terminated') {
       deliveryEl.textContent = 'Run interrupted';
       deliveryNoteEl.textContent = failureSummary || 'This run stopped before producing a complete result set.';
       exportNoteEl.textContent = 'Exports stay unavailable when the real pipeline does not complete.';
     } else {
       deliveryEl.textContent = 'Tracking live pipeline';
-      deliveryNoteEl.textContent = failureSummary || 'Results will unlock here when the signed-in run completes.';
+      deliveryNoteEl.textContent = failureSummary || 'Results will unlock here when the run completes.';
       exportNoteEl.textContent = 'Exports unlock automatically after the enrichment manifest is ready.';
     }
 
-    linkLabelEl.textContent = 'Durable run state';
+    linkLabelEl.textContent = 'Run details';
     linkEl.href = selectedRunPermalink(data.instanceId || data.instance_id, 'run');
     linkEl.textContent = 'Open this run directly';
 
@@ -1874,7 +1874,7 @@
     setHeroRunSummary(
       runtimeStatus,
       runtimeStatus === 'Completed'
-        ? 'Pipeline finished successfully and is ready for the next signed-in surface.'
+        ? 'Pipeline finished successfully — results are ready.'
         : 'Current phase: ' + phase + '.' + (timing.elapsed ? ' Elapsed ' + timing.elapsed + '.' : '')
     );
     updateHistorySummary(data);
@@ -2100,7 +2100,7 @@
       warnings.push({ tone: 'info', text: 'This due diligence lens frames evidence for review and audit support. It is not a legal compliance certificate.' });
     }
     if (workspaceRole === 'portfolio' && preflight.aoiCount > 10) {
-      warnings.push({ tone: 'info', text: 'Large parcel sets are a good fit for later batch surfaces. This run still enters the tracked signed-in workflow today.' });
+      warnings.push({ tone: 'info', text: 'Large parcel sets work well with batch analysis. This run still enters your tracked workflow.' });
     }
     if (!warnings.length) {
       warnings.push({ tone: 'info', text: 'No warnings. This will queue as one tracked analysis run.' });
@@ -2115,7 +2115,7 @@
     var parsed = parseKmlGeometry(trimmed);
     if (parsed.error) return { error: parsed.error };
     if (!parsed.polygons || !parsed.polygons.length) {
-      return { error: 'No polygon boundaries were detected. Canopex expects polygon AOIs in the signed-in workflow.' };
+      return { error: 'No polygon boundaries were detected. Canopex expects polygon AOIs.' };
     }
 
     var centroids = parsed.polygons.map(function(polygon) { return polygonCentroid(polygon.coords); });
@@ -2142,7 +2142,7 @@
       processingMode: processingMode,
       quotaImpact: latestBillingStatus && latestBillingStatus.runs_remaining != null
         ? '1 of ' + latestBillingStatus.runs_remaining + ' runs'
-        : '1 signed-in run',
+        : '1 queued run',
       summary: parsed.featureCount + ' features across ' + parsed.polygons.length + ' AOIs covering about ' + formatHectares(totalAreaHa) + '. ' + processingMode + ' keeps the ' + preference.focusLabel.toLowerCase() + ' in focus for this request.'
     };
     preflight.warnings = buildPreflightWarnings(preflight);
@@ -2178,12 +2178,12 @@
       analysisDraftSummary = null;
       headlineEl.textContent = 'Awaiting KML';
       modeEl.textContent = 'No file yet';
-      summaryEl.textContent = 'Paste KML to see feature count, AOI spread, and signed-in product guidance for the ' + role.label + ' view.';
+      summaryEl.textContent = 'Paste KML to see feature count, area spread, and guidance for the ' + role.label + ' view.';
       featuresEl.textContent = '0';
       aoisEl.textContent = '0';
       spreadEl.textContent = '—';
       quotaEl.textContent = '—';
-      renderPreflightWarnings([{ tone: 'info', text: 'Preflight will surface warnings here after you paste or upload KML.' }]);
+      renderPreflightWarnings([{ tone: 'info', text: 'Preflight will show warnings here after you paste or upload KML.' }]);
       return null;
     }
 
@@ -2262,7 +2262,7 @@
       var name = file.name.toLowerCase();
       var content = name.endsWith('.kmz') ? await readKmzFile(file) : await readKmlFile(file);
       textarea.value = content;
-      note.textContent = 'Loaded ' + file.name + ' into the signed-in analysis form.';
+      note.textContent = 'Loaded ' + file.name + ' into the analysis form.';
       updateAnalysisPreflight(content);
     } catch (err) {
       note.textContent = err.message || 'Could not read file';
@@ -2525,7 +2525,7 @@
 
     select.value = data.emulation.active ? data.emulation.tier : 'actual';
     if (data.emulation.active) {
-      note.textContent = 'Currently emulating ' + (data.capabilities.label || data.tier) + ' for this signed-in account. Billing remains ' + ((data.subscription && data.subscription.tier) || 'free') + '.';
+      note.textContent = 'Currently emulating ' + (data.capabilities.label || data.tier) + ' for your account. Billing remains ' + ((data.subscription && data.subscription.tier) || 'free') + '.';
     } else {
       note.textContent = 'Using the actual billing state for this account.';
     }
@@ -2614,7 +2614,7 @@
       document.getElementById('app-billing-note').textContent = 'Could not load billing state';
       document.getElementById('app-manage-billing-btn').style.display = 'none';
       updateCapabilityFields({});
-      setHeroRunSummary('Ready to queue', 'Billing is unavailable, but signed-in analysis can still be launched locally.');
+      setHeroRunSummary('Ready to queue', 'Billing is unavailable, but analysis can still be launched locally.');
     }
   }
 
@@ -2691,7 +2691,7 @@
       dashboard.hidden = false;
       userName.textContent = displayName;
       accountIdentifier.textContent = identifier;
-      accountNote.textContent = 'This is now the dedicated signed-in home for Canopex. Choose the role view and work preference that match the job at hand.';
+      accountNote.textContent = 'This is your Canopex dashboard. Choose the analysis type and work preference that match the job at hand.';
       var analysisAuthGate = document.getElementById('app-analysis-auth-gate');
       var analysisFormFields = document.getElementById('app-analysis-form-fields');
       var historyCard = document.getElementById('app-history-card');
@@ -2699,7 +2699,7 @@
       if (analysisFormFields) analysisFormFields.hidden = false;
       if (historyCard) historyCard.hidden = false;
       if (!analysisHistoryLoaded && !latestAnalysisRun) {
-        setHeroRunSummary('Checking recent runs', 'Restoring signed-in history and active run state.');
+        setHeroRunSummary('Checking recent runs', 'Loading your recent runs.');
         updateHistorySummary(null);
         renderAnalysisHistoryList();
       }


### PR DESCRIPTION
# Dashboard UX Overhaul

Implements three slices from the UX review documented in #555.

## Changes

### Slice 1 — Layout reorder
Move the submission/workflow stage above the evidence hero so that the primary action (start analysis) is visible without scrolling. The evidence section now sits below, where results appear after a run completes.

### Slice 3 — Jargon replacement
Replace internal vocabulary with plain-language alternatives throughout the dashboard HTML and JS:
- **"signed-in"** → "your" or removed
- **"Workspace lens"** → "Analysis type"
- **"Conservation evidence run"** → "Conservation analysis"
- **"Due diligence evidence run"** → "EUDR compliance check"
- **"durable run state"** → "run details"
- **"surface"** (noun) → "view", "step", or "results"
- **"Prepare evidence brief"** → "Review results"
- All `WORKSPACE_ROLES` and `WORKSPACE_PREFERENCES` config strings updated
- Phase completion text simplified

### Slice 6 — Deduplicate exports
Remove the duplicate GeoJSON/CSV/PDF export buttons from the run detail card. Exports are now available only in the evidence section export bar, eliminating user confusion about which buttons to click. Orphaned CSS rules cleaned up.

## Validation
- All 1066 tests pass (28 skipped)
- `ruff check` + `ruff format` clean
- No orphaned element references in JS
- No orphaned CSS rules

## Files changed
- `website/app/index.html` — layout reorder, jargon, export dedup
- `website/js/app-shell.js` — all WORKSPACE_ROLES/PREFERENCES config strings, scattered UI strings, updateRunDetail cleanup
- `website/css/app.css` — removed unused `.app-run-action-row` / `.app-run-action-btn` rules

Fixes #555 (partial — frontend slices 1, 3, 6)