### PR TITLE
feat(ux): UX.3/.4/.5 — collapse noise, auto-scroll, streamline form

### DIFF
--- a/website/app/index.html
+++ b/website/app/index.html
@@ -152,11 +152,6 @@
             </div>
           </div>
           <div id="app-analysis-form-fields" hidden>
-          <div class="app-mode-card">
-            <span class="app-run-label">Analysis type</span>
-            <strong id="app-analysis-lens-title">Conservation analysis</strong>
-            <p id="app-analysis-lens-note">Focus on vegetation change, weather context, and plain-English findings for field teams.</p>
-          </div>
           <label class="app-field-label" for="app-analysis-file">KML or KMZ file</label>
           <input id="app-analysis-file" type="file" accept=".kml,.kmz,application/vnd.google-earth.kml+xml,application/vnd.google-earth.kmz">
           <p class="app-note" id="app-analysis-file-note">Choose a KML or KMZ file, or paste KML below.</p>
@@ -181,8 +176,8 @@
               <div class="app-preflight-item" data-tone="info">Preflight will show warnings here after you paste or upload KML.</div>
             </div>
           </div>
-          <div class="app-select-row app-analysis-actions">
-            <button class="btn btn-primary" id="app-analysis-submit-btn" type="button">Queue Analysis</button>
+          <div class="app-analysis-actions">
+            <button class="btn btn-primary app-analysis-queue-btn" id="app-analysis-submit-btn" type="button">Queue Analysis</button>
           </div>
           </div><!-- /app-analysis-form-fields -->
           <div class="app-callout" id="app-analysis-status" hidden></div>

--- a/website/css/app.css
+++ b/website/css/app.css
@@ -97,6 +97,7 @@
 /* First-run: hide history rail → analysis rail goes full-width */
 .app-workflow-stage.first-run{grid-template-columns:1fr}
 .app-workflow-rail{padding:22px;border:1px solid var(--c-border);border-radius:18px;background:rgba(13,17,23,.62);box-shadow:var(--shadow);display:flex;flex-direction:column;gap:14px;position:relative;overflow:hidden;transition:transform .25s ease,opacity .25s ease,border-color .25s ease,box-shadow .25s ease;cursor:pointer;opacity:.78;transform:scale(.965)}
+.app-workflow-rail[hidden]{display:none}
 .app-workflow-rail::after{content:"";position:absolute;inset:0;background:linear-gradient(180deg, rgba(255,255,255,.02), rgba(255,255,255,0));pointer-events:none}
 .app-workflow-stage[data-focus="history"] .app-rail-history,
 .app-workflow-stage[data-focus="run"] .app-rail-run{opacity:1;transform:translateY(-6px) scale(1.01);border-color:var(--app-role-border);box-shadow:0 20px 48px rgba(0,0,0,.28)}

--- a/website/css/app.css
+++ b/website/css/app.css
@@ -29,6 +29,7 @@
 .app-welcome-actions{grid-column:2;grid-row:1;display:flex;gap:10px;align-items:center;flex-shrink:0}
 .app-welcome-stats{grid-column:1 / -1;grid-row:2;display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px}
 .app-stat-pill{display:flex;flex-direction:column;gap:3px;padding:8px 12px;background:rgba(13,17,23,.18);border:1px solid rgba(230,237,243,.08);border-radius:12px}
+.app-stat-pill[hidden]{display:none}
 .app-utility-label{font-size:.68rem;letter-spacing:.08em;text-transform:uppercase;color:var(--c-muted)}
 .app-stat-pill strong{font-size:.88rem;letter-spacing:-.01em;color:var(--c-text)}
 .app-utility-note{font-size:.72rem;line-height:1.3;color:var(--c-muted)}
@@ -93,6 +94,8 @@
 .app-settings-body{padding:0 20px 20px;display:flex;flex-direction:column;gap:18px}
 
 .app-workflow-stage{display:grid;grid-template-columns:minmax(240px,.7fr) minmax(420px,1.3fr);gap:22px;align-items:stretch}
+/* First-run: hide history rail → analysis rail goes full-width */
+.app-workflow-stage.first-run{grid-template-columns:1fr}
 .app-workflow-rail{padding:22px;border:1px solid var(--c-border);border-radius:18px;background:rgba(13,17,23,.62);box-shadow:var(--shadow);display:flex;flex-direction:column;gap:14px;position:relative;overflow:hidden;transition:transform .25s ease,opacity .25s ease,border-color .25s ease,box-shadow .25s ease;cursor:pointer;opacity:.78;transform:scale(.965)}
 .app-workflow-rail::after{content:"";position:absolute;inset:0;background:linear-gradient(180deg, rgba(255,255,255,.02), rgba(255,255,255,0));pointer-events:none}
 .app-workflow-stage[data-focus="history"] .app-rail-history,
@@ -213,6 +216,7 @@
 .app-workflow-rail input[type=file],.app-workflow-rail textarea,.app-card input[type=file],.app-card textarea{width:100%;padding:10px 12px;background:var(--c-bg);border:1px solid var(--c-border);border-radius:var(--radius);color:var(--c-text);font:inherit}
 .app-workflow-rail textarea,.app-card textarea{min-height:160px;resize:vertical}
 .app-analysis-actions{margin-top:4px}
+.app-analysis-queue-btn{width:100%;padding:14px;font-size:1rem;font-weight:700}
 .app-callout{padding:12px 14px;border-radius:var(--radius);font-size:.82rem;line-height:1.5}
 .app-callout[data-tone="info"]{background:rgba(94,236,196,.1);border:1px solid rgba(94,236,196,.25);color:var(--c-text)}
 .app-callout[data-tone="error"]{background:rgba(248,81,73,.12);border:1px solid rgba(248,81,73,.28);color:#ffb2ad}

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -406,8 +406,10 @@
     document.getElementById('app-history-copy').textContent = role.historyCopy;
     document.getElementById('app-run-copy').textContent = role.runCopy;
     document.getElementById('app-content-copy').textContent = role.contentCopy;
-    document.getElementById('app-analysis-lens-title').textContent = role.runLensTitle;
-    document.getElementById('app-analysis-lens-note').textContent = role.runLensNote + ' ' + preference.summary;
+    var lensTitle = document.getElementById('app-analysis-lens-title');
+    var lensNote = document.getElementById('app-analysis-lens-note');
+    if (lensTitle) lensTitle.textContent = role.runLensTitle;
+    if (lensNote) lensNote.textContent = role.runLensNote + ' ' + preference.summary;
 
     if (!latestAnalysisRun) {
       if (!analysisHistoryLoaded && currentAccount) {
@@ -830,11 +832,21 @@
   function applyFirstRunLayout() {
     var firstRun = document.getElementById('app-first-run-hero');
     var evidenceHero = document.getElementById('app-evidence-hero');
+    var historyRail = document.getElementById('app-history-card');
+    var workflowStage = document.getElementById('app-workflow-stage');
+    var modePill = document.getElementById('app-hero-mode');
+    var activeRunPill = document.getElementById('app-hero-active-run');
     if (!firstRun) return;
 
     var isEmpty = analysisHistoryLoaded && analysisHistoryRuns.length === 0 && !latestAnalysisRun;
     firstRun.hidden = !isEmpty;
     if (evidenceHero) evidenceHero.hidden = isEmpty;
+
+    // Collapse first-load noise: hide history rail + extra pills for new users
+    if (historyRail) historyRail.hidden = isEmpty;
+    if (workflowStage) workflowStage.classList.toggle('first-run', isEmpty);
+    if (modePill) modePill.closest('.app-stat-pill').hidden = isEmpty;
+    if (activeRunPill) activeRunPill.closest('.app-stat-pill').hidden = isEmpty;
   }
 
   /* ------------------------------------------------------------------ */
@@ -2289,6 +2301,13 @@
           updateAnalysisStory('complete', runtime, data);
           loadBillingStatus();
           loadAnalysisHistory({ preferInstanceId: instanceId });
+          loadRunEvidence(instanceId);
+          var evidenceHero = document.getElementById('app-evidence-hero');
+          if (evidenceHero) {
+            setTimeout(function() {
+              evidenceHero.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }, 400);
+          }
         } else if (runtime === 'Failed' || runtime === 'Canceled' || runtime === 'Terminated') {
           stopAnalysisPolling();
           setAnalysisStep(phase, 'failed');

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -751,6 +751,7 @@
     if (!replaced) analysisHistoryRuns.unshift(normalized);
     analysisHistoryRuns = sortAnalysisHistoryRuns(analysisHistoryRuns);
     renderAnalysisHistoryList();
+    applyFirstRunLayout();
   }
 
   function selectAnalysisRun(instanceId, options) {
@@ -2305,7 +2306,11 @@
           var evidenceHero = document.getElementById('app-evidence-hero');
           if (evidenceHero) {
             setTimeout(function() {
-              evidenceHero.scrollIntoView({ behavior: 'smooth', block: 'start' });
+              var scrollBehavior = 'smooth';
+              if (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+                scrollBehavior = 'auto';
+              }
+              evidenceHero.scrollIntoView({ behavior: scrollBehavior, block: 'start' });
             }, 400);
           }
         } else if (runtime === 'Failed' || runtime === 'Canceled' || runtime === 'Terminated') {


### PR DESCRIPTION
## Changes

Implements the three remaining UX slices from the UX review (#555):

### UX.3 — Collapse first-load noise (Slice 4)
- Hide history rail for users with no runs → analysis rail goes full-width
- Hide Mode and Active Run stat pills when history is empty
- Both re-appear once a run exists (via `applyFirstRunLayout`)

### UX.4 — Auto-scroll to results (Slice 2)
- On pipeline completion (pollAnalysisRun → Completed), scroll to `app-evidence-hero` with smooth scroll
- Load run evidence immediately without requiring manual history click

### UX.5 — Streamline submission form (Slice 5)
- Remove `app-mode-card` (lens description) from the form — lens info remains in Workspace Settings
- Make Queue Analysis button full-width and larger for clear call-to-action
- Add null-guards for removed lens elements

### Validation
- 1066 tests pass, 27 skipped, 0 failures
- All changes are frontend-only (HTML, CSS, JS)
- ruff clean

Fixes #555 (remaining slices)