### PR TITLE
feat: upload quota consumption, user management, and ops endpoints

### DIFF
--- a/blueprints/billing.py
+++ b/blueprints/billing.py
@@ -56,16 +56,23 @@ def _get_stripe():
     return stripe
 
 
-def _tier_emulation_allowed(req: func.HttpRequest) -> bool:
-    """Allow plan emulation only from local development origins."""
+def _tier_emulation_allowed(req: func.HttpRequest, user_id: str = "") -> bool:
+    """Allow plan emulation from local dev origins or for allowed operators."""
     origin = req.headers.get("Origin", "")
     if origin in _LOCAL_EMULATION_ORIGINS:
         return True
     try:
         hostname = urlparse(req.url).hostname or ""
     except Exception:
-        return False
-    return hostname in {"localhost", "127.0.0.1"}
+        hostname = ""
+    if hostname in {"localhost", "127.0.0.1"}:
+        return True
+    # Allow billing-allowed users (operators) to emulate from any origin.
+    if user_id and user_id != "anonymous":
+        from treesight.security.feature_gate import billing_allowed
+
+        return billing_allowed(user_id)
+    return False
 
 
 def _billing_status_payload(user_id: str, req: func.HttpRequest) -> dict:
@@ -109,7 +116,7 @@ def _billing_status_payload(user_id: str, req: func.HttpRequest) -> dict:
             "status": subscription.get("status", "none"),
         },
         "emulation": {
-            "available": _tier_emulation_allowed(req),
+            "available": _tier_emulation_allowed(req, user_id),
             "active": bool(emulation),
             "tier": emulation.get("tier") if emulation else None,
             "tiers": list(supported_tiers()),
@@ -404,11 +411,34 @@ def _user_id_from_customer(customer_id: str | None) -> str | None:
 
 
 # ---------------------------------------------------------------------------
+# User profile recording
+# ---------------------------------------------------------------------------
+
+
+def _record_user_profile(user_id: str, auth_claims: dict) -> None:
+    """Best-effort record of user sign-in for ops lookup."""
+    try:
+        from treesight.security.users import record_user_sign_in
+
+        record_user_sign_in(
+            user_id,
+            email=auth_claims.get("userDetails", ""),
+            display_name=auth_claims.get("userDetails", ""),
+            identity_provider=auth_claims.get("identityProvider", ""),
+        )
+    except Exception:
+        logger.debug("Failed to record user profile for user=%s", user_id, exc_info=True)
+
+
+# ---------------------------------------------------------------------------
 # GET /api/billing/status  — current user's subscription status
 # ---------------------------------------------------------------------------
 @bp.route(route="billing/status", methods=["GET", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
 @require_auth
 def billing_status(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> func.HttpResponse:
+    # Record user sign-in profile so ops can look up users by email.
+    _record_user_profile(user_id, auth_claims)
+
     return func.HttpResponse(
         json.dumps(_billing_status_payload(user_id, req)),
         status_code=200,
@@ -424,7 +454,7 @@ def billing_status(req: func.HttpRequest, *, auth_claims: dict, user_id: str) ->
 def billing_emulation(
     req: func.HttpRequest, *, auth_claims: dict, user_id: str
 ) -> func.HttpResponse:
-    if not _tier_emulation_allowed(req):
+    if not _tier_emulation_allowed(req, user_id):
         if user_id == "anonymous":
             return error_response(401, "Authentication required for billing", req=req)
         return error_response(

--- a/blueprints/ops.py
+++ b/blueprints/ops.py
@@ -249,3 +249,128 @@ async def ops_dashboard(
         status_code=200,
         mimetype="application/json",
     )
+
+
+# ---------------------------------------------------------------------------
+# User management endpoints (ops-key protected)
+# ---------------------------------------------------------------------------
+
+
+def _clean_user_doc(doc: dict[str, Any]) -> dict[str, Any]:
+    """Strip Cosmos metadata fields from a user document."""
+    return {k: v for k, v in doc.items() if not k.startswith("_")}
+
+
+@bp.route(route="ops/users", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
+def ops_list_users(req: func.HttpRequest) -> func.HttpResponse:
+    """GET /api/ops/users — list registered users."""
+    if not _check_ops_key(req):
+        return func.HttpResponse(
+            json.dumps({"error": "Unauthorized"}),
+            status_code=401,
+            mimetype="application/json",
+        )
+
+    from treesight.security.users import list_users
+
+    limit = min(int(req.params.get("limit", "50")), 200)
+    users = list_users(limit=limit)
+    return func.HttpResponse(
+        json.dumps([_clean_user_doc(u) for u in users], default=str),
+        status_code=200,
+        mimetype="application/json",
+    )
+
+
+@bp.route(route="ops/users/lookup", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
+def ops_lookup_user(req: func.HttpRequest) -> func.HttpResponse:
+    """GET /api/ops/users/lookup?email=... — find user by email."""
+    if not _check_ops_key(req):
+        return func.HttpResponse(
+            json.dumps({"error": "Unauthorized"}),
+            status_code=401,
+            mimetype="application/json",
+        )
+
+    email = req.params.get("email", "").strip()
+    if not email:
+        return func.HttpResponse(
+            json.dumps({"error": "Missing 'email' query parameter"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    from treesight.security.users import lookup_user_by_email
+
+    user = lookup_user_by_email(email)
+    if not user:
+        return func.HttpResponse(
+            json.dumps({"error": "User not found"}),
+            status_code=404,
+            mimetype="application/json",
+        )
+
+    return func.HttpResponse(
+        json.dumps(_clean_user_doc(user), default=str),
+        status_code=200,
+        mimetype="application/json",
+    )
+
+
+@bp.route(route="ops/users/{user_id}/role", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
+def ops_set_user_role(req: func.HttpRequest) -> func.HttpResponse:
+    """POST /api/ops/users/{user_id}/role — set billing_allowed / tier."""
+    if not _check_ops_key(req):
+        return func.HttpResponse(
+            json.dumps({"error": "Unauthorized"}),
+            status_code=401,
+            mimetype="application/json",
+        )
+
+    user_id = req.route_params.get("user_id", "").strip()
+    if not user_id:
+        return func.HttpResponse(
+            json.dumps({"error": "Missing user_id in path"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    try:
+        body = req.get_json()
+    except ValueError:
+        return func.HttpResponse(
+            json.dumps({"error": "Invalid JSON body"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    billing_allowed = body.get("billing_allowed")
+    tier = body.get("tier")
+
+    if billing_allowed is None and tier is None:
+        return func.HttpResponse(
+            json.dumps({"error": "Provide 'billing_allowed' and/or 'tier'"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    from treesight.security.users import set_user_role
+
+    updated = set_user_role(
+        user_id,
+        billing_allowed=billing_allowed,
+        tier=tier,
+    )
+
+    logger.info(
+        "Operator set role: user=%s billing_allowed=%s tier=%s",
+        user_id,
+        billing_allowed,
+        tier,
+    )
+
+    return func.HttpResponse(
+        json.dumps(_clean_user_doc(updated), default=str),
+        status_code=200,
+        mimetype="application/json",
+    )

--- a/blueprints/ops.py
+++ b/blueprints/ops.py
@@ -273,7 +273,14 @@ def ops_list_users(req: func.HttpRequest) -> func.HttpResponse:
 
     from treesight.security.users import list_users
 
-    limit = min(int(req.params.get("limit", "50")), 200)
+    try:
+        limit = max(1, min(int(req.params.get("limit", "50")), 200))
+    except (ValueError, TypeError):
+        return func.HttpResponse(
+            json.dumps({"error": "'limit' must be a positive integer"}),
+            status_code=400,
+            mimetype="application/json",
+        )
     users = list_users(limit=limit)
     return func.HttpResponse(
         json.dumps([_clean_user_doc(u) for u in users], default=str),
@@ -354,19 +361,39 @@ def ops_set_user_role(req: func.HttpRequest) -> func.HttpResponse:
             mimetype="application/json",
         )
 
+    if billing_allowed is not None and not isinstance(billing_allowed, bool):
+        return func.HttpResponse(
+            json.dumps({"error": "'billing_allowed' must be a boolean"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    if tier is not None and (not isinstance(tier, str) or not tier.strip()):
+        return func.HttpResponse(
+            json.dumps({"error": "'tier' must be a non-empty string"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
     from treesight.security.users import set_user_role
 
-    updated = set_user_role(
-        user_id,
-        billing_allowed=billing_allowed,
-        tier=tier,
-    )
+    try:
+        updated = set_user_role(
+            user_id,
+            billing_allowed=billing_allowed,
+            tier=tier,
+        )
+    except RuntimeError:
+        return func.HttpResponse(
+            json.dumps({"error": "User store is not available"}),
+            status_code=503,
+            mimetype="application/json",
+        )
 
     logger.info(
-        "Operator set role: user=%s billing_allowed=%s tier=%s",
+        "Operator set role: user=%s fields_updated=%s",
         user_id,
-        billing_allowed,
-        tier,
+        [k for k in ("billing_allowed", "tier") if body.get(k) is not None],
     )
 
     return func.HttpResponse(

--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -100,12 +100,51 @@ def _sanitise_submission_context(ctx: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _safe_release_quota(user_id: str) -> None:
+def _safe_release_quota(user_id: str, instance_id: str = "") -> None:
     """Best-effort quota refund — never raises."""
     try:
-        release_quota(user_id)
+        release_quota(user_id, instance_id=instance_id)
     except Exception:
         logger.exception("Failed to release quota for user=%s", user_id)
+
+
+def _mint_sas_url(
+    blob_service,
+    blob_name: str,
+    submission_id: str,
+) -> tuple[str | None, str | None]:
+    """Generate a write-only SAS URL. Returns (sas_url, error_msg)."""
+    now = datetime.datetime.now(datetime.UTC)
+    expiry = now + datetime.timedelta(minutes=_SAS_TOKEN_EXPIRY_MINUTES)
+
+    delegation_key = blob_service.get_user_delegation_key(
+        key_start_time=now,
+        key_expiry_time=expiry,
+    )
+
+    sas_token = generate_blob_sas(
+        account_name=STORAGE_ACCOUNT_NAME,
+        container_name=DEFAULT_INPUT_CONTAINER,
+        blob_name=blob_name,
+        user_delegation_key=delegation_key,
+        permission=BlobSasPermissions(create=True, write=True),
+        expiry=expiry,
+        content_type="application/vnd.google-earth.kml+xml",
+    )
+
+    sas_url = (
+        f"https://{STORAGE_ACCOUNT_NAME}.blob.core.windows.net/"
+        f"{DEFAULT_INPUT_CONTAINER}/{blob_name}?{sas_token}"
+    )
+    return sas_url, None
+
+
+def _resolve_provider(body: dict, submission_context: dict) -> str:
+    """Pick the effective provider from request body, falling back to submission context."""
+    top_level = body.get("provider_name")
+    if isinstance(top_level, str) and top_level.strip():
+        return top_level.strip()[:80]
+    return submission_context.get("provider_name", DEFAULT_PROVIDER)
 
 
 @bp.route(route="upload/token", methods=["POST", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
@@ -139,7 +178,7 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
         body = {}
 
     submission_context = _sanitise_submission_context(body.get("submission_context") or {})
-    effective_provider = submission_context.get("provider_name", DEFAULT_PROVIDER)
+    effective_provider = _resolve_provider(body, submission_context)
 
     # Write ticket blob — trusted server-side record of who initiated the upload
     ticket: dict = {
@@ -165,10 +204,19 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
     except Exception:
         logger.exception("Failed to write ticket for submission_id=%s", submission_id)
         if quota_consumed:
-            _safe_release_quota(user_id)
+            _safe_release_quota(user_id, instance_id=submission_id)
         return error_response(502, "Storage service temporarily unavailable", req=req)
 
-    # Persist submission record so the run appears in analysis history.
+    try:
+        sas_url, _ = _mint_sas_url(blob_service, blob_name, submission_id)
+    except Exception:
+        logger.exception("Failed to mint SAS URL for submission_id=%s", submission_id)
+        if quota_consumed:
+            _safe_release_quota(user_id, instance_id=submission_id)
+        return error_response(502, "Storage service temporarily unavailable", req=req)
+
+    # Persist submission record only after SAS minting succeeds
+    # so a minting failure doesn't leave a phantom run.
     submitted_at = datetime.datetime.now(datetime.UTC).isoformat()
     record: dict = {
         "submission_id": submission_id,
@@ -183,33 +231,6 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
     }
     record.update(submission_context)
     _persist_submission_record(submission_id, record, user_id)
-
-    now = datetime.datetime.now(datetime.UTC)
-    expiry = now + datetime.timedelta(minutes=_SAS_TOKEN_EXPIRY_MINUTES)
-
-    try:
-        delegation_key = blob_service.get_user_delegation_key(
-            key_start_time=now,
-            key_expiry_time=expiry,
-        )
-    except Exception:
-        logger.exception("Failed to obtain user delegation key")
-        return error_response(502, "Storage service temporarily unavailable", req=req)
-
-    sas_token = generate_blob_sas(
-        account_name=STORAGE_ACCOUNT_NAME,
-        container_name=DEFAULT_INPUT_CONTAINER,
-        blob_name=blob_name,
-        user_delegation_key=delegation_key,
-        permission=BlobSasPermissions(create=True, write=True),
-        expiry=expiry,
-        content_type="application/vnd.google-earth.kml+xml",
-    )
-
-    sas_url = (
-        f"https://{STORAGE_ACCOUNT_NAME}.blob.core.windows.net/"
-        f"{DEFAULT_INPUT_CONTAINER}/{blob_name}?{sas_token}"
-    )
 
     logger.info("Upload URL minted submission_id=%s blob=%s", submission_id, blob_name)
 

--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -23,7 +23,8 @@ from azure.storage.blob import (
 )
 
 from treesight.config import STORAGE_ACCOUNT_NAME
-from treesight.constants import DEFAULT_INPUT_CONTAINER, MAX_KML_FILE_SIZE_BYTES
+from treesight.constants import DEFAULT_INPUT_CONTAINER, DEFAULT_PROVIDER, MAX_KML_FILE_SIZE_BYTES
+from treesight.security.quota import consume_quota, release_quota
 from treesight.storage import cosmos as _cosmos_mod
 from treesight.storage.client import get_blob_service_client
 
@@ -43,6 +44,37 @@ _SAS_TOKEN_EXPIRY_MINUTES = 15
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _persist_submission_record(submission_id: str, record: dict, user_id: str) -> None:
+    """Write a submission record so the run appears in analysis history."""
+    if _cosmos_mod.cosmos_available():
+        try:
+            _cosmos_mod.upsert_item("runs", {"id": submission_id, **record})
+            return
+        except Exception:
+            logger.warning(
+                "Cosmos upsert failed for instance=%s user=%s",
+                submission_id,
+                user_id,
+                exc_info=True,
+            )
+
+    # Blob fallback
+    from treesight.constants import PIPELINE_PAYLOADS_CONTAINER
+    from treesight.storage.client import BlobStorageClient
+
+    try:
+        storage = BlobStorageClient()
+        blob_name = f"analysis-submissions/{user_id}/{submission_id}.json"
+        storage.upload_json(PIPELINE_PAYLOADS_CONTAINER, blob_name, record)
+    except Exception:
+        logger.warning(
+            "Unable to persist submission record instance=%s user=%s",
+            submission_id,
+            user_id,
+            exc_info=True,
+        )
 
 
 def _sanitise_submission_context(ctx: dict) -> dict:
@@ -68,6 +100,14 @@ def _sanitise_submission_context(ctx: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def _safe_release_quota(user_id: str) -> None:
+    """Best-effort quota refund — never raises."""
+    try:
+        release_quota(user_id)
+    except Exception:
+        logger.exception("Failed to release quota for user=%s", user_id)
+
+
 @bp.route(route="upload/token", methods=["POST", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
 @require_auth
 def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> func.HttpResponse:
@@ -79,6 +119,16 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
         logger.error("Storage account not configured for SAS generation")
         return error_response(503, "Service not configured", req=req)
 
+    # Consume quota upfront so the runs counter decrements immediately.
+    quota_consumed = False
+    try:
+        consume_quota(user_id)
+        quota_consumed = True
+    except ValueError as exc:
+        return error_response(403, str(exc), req=req)
+    except Exception:
+        logger.exception("Quota storage unavailable for user=%s — allowing submission", user_id)
+
     submission_id = str(uuid.uuid4())
     blob_name = f"analysis/{submission_id}.kml"
 
@@ -88,6 +138,9 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
     except (json.JSONDecodeError, UnicodeDecodeError):
         body = {}
 
+    submission_context = _sanitise_submission_context(body.get("submission_context") or {})
+    effective_provider = submission_context.get("provider_name", DEFAULT_PROVIDER)
+
     # Write ticket blob — trusted server-side record of who initiated the upload
     ticket: dict = {
         "user_id": user_id,
@@ -96,9 +149,8 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
     provider = body.get("provider_name")
     if isinstance(provider, str) and provider.strip():
         ticket["provider_name"] = provider.strip()[:80]
-    ctx = body.get("submission_context")
-    if isinstance(ctx, dict):
-        ticket["submission_context"] = _sanitise_submission_context(ctx)
+    if submission_context:
+        ticket["submission_context"] = submission_context
 
     try:
         blob_service = get_blob_service_client()
@@ -112,7 +164,25 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
         )
     except Exception:
         logger.exception("Failed to write ticket for submission_id=%s", submission_id)
+        if quota_consumed:
+            _safe_release_quota(user_id)
         return error_response(502, "Storage service temporarily unavailable", req=req)
+
+    # Persist submission record so the run appears in analysis history.
+    submitted_at = datetime.datetime.now(datetime.UTC).isoformat()
+    record: dict = {
+        "submission_id": submission_id,
+        "instance_id": submission_id,
+        "user_id": user_id,
+        "submitted_at": submitted_at,
+        "kml_blob_name": blob_name,
+        "kml_size_bytes": 0,
+        "submission_prefix": "analysis",
+        "provider_name": effective_provider,
+        "status": "submitted",
+    }
+    record.update(submission_context)
+    _persist_submission_record(submission_id, record, user_id)
 
     now = datetime.datetime.now(datetime.UTC)
     expiry = now + datetime.timedelta(minutes=_SAS_TOKEN_EXPIRY_MINUTES)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,7 @@
 **Single source of truth for what to build next.**
 Issues hold the detail. This list holds the order.
 
-Last updated: 2026-04-12 (UX overhaul PR #557, docs #556, auth #554 merged)
+Last updated: 2026-04-13 (upload quota + user management PR #566)
 
 ---
 
@@ -36,11 +36,11 @@ See `docs/ARCHITECTURE_OVERVIEW.md` § "Entry Point" for details.
 
 | PR | Summary |
 |----|---------|
+| #566 | Upload quota consumption, Cosmos-based user management, ops user endpoints (fixes #565) |
 | #563 | Batch discovered issues: infracost metric (#513), CSP connect-src (#518/#527), error logging, SSRF proxy tests, NDVI warning fix |
 | #559 | Dashboard UX: collapse first-load noise, auto-scroll on completion, streamline form (UX.3 + UX.4 + UX.5, fixes #555) |
 | #558 | Roadmap update: mark UX.1/.2/.6 done, update Recently Landed |
 | #557 | Dashboard UX overhaul: layout reorder, jargon replacement, export dedup (UX.1 + UX.2 + UX.6, #555) |
-| #556 | Add UX review doc and integrate dashboard UX overhaul into roadmap (refs #555) |
 | #554 | Enforce REQUIRE_AUTH in all deployed environments (fixes #553) |
 
 ---
@@ -185,6 +185,18 @@ UX.3 → UX.4 → UX.5 → UX.6.
 **Exit criteria:** File upload is visible without scrolling. Results auto-
 scroll on completion. Zero "signed-in" / "workspace lens" / "durable" jargon
 in user-facing strings. First-load elements <12 (currently ~25).
+
+#### 2C.5 — Upload Quota & User Management
+
+| Order | Issue | Title | Status |
+|-------|-------|-------|--------|
+| Q.1 | #565 | Upload flow missing quota consumption + submission persistence | ✅ PR #566 |
+| Q.2 | #565 | Cosmos-based user management (replace env-var allow-list) | ✅ PR #566 |
+| Q.3 | #565 | Ops endpoints for user lookup and role assignment | ✅ PR #566 |
+
+**Exit criteria:** Runs counter decrements on upload. History shows all
+submissions. Operators can look up users by email and assign billing
+access / tiers at runtime via ops endpoints.
 
 ---
 

--- a/tests/test_billing_endpoints.py
+++ b/tests/test_billing_endpoints.py
@@ -293,6 +293,37 @@ class TestBillingStatus:
         resp = billing_emulation(req)
         assert resp.status_code == 403
 
+    @_BILLING_UNGATED
+    @patch("treesight.storage.cosmos.upsert_item")
+    @patch("treesight.storage.cosmos.read_item")
+    def test_operator_can_emulate_from_non_local_origin(self, mock_read, mock_upsert):
+        """Billing-allowed users can use tier emulation from production origins."""
+        from blueprints.billing import billing_emulation
+
+        store: dict[str, dict] = {}
+
+        def _read_item(container, item_id, partition_key):
+            return store.get(f"{container}/{item_id}")
+
+        def _upsert_item(container, item):
+            store[f"{container}/{item['id']}"] = item
+            return item
+
+        mock_read.side_effect = _read_item
+        mock_upsert.side_effect = _upsert_item
+
+        # Non-local origin but user is in BILLING_ALLOWED_USERS
+        req = _make_req(
+            body=json.dumps({"tier": "pro"}).encode("utf-8"),
+            url="/api/billing/emulation",
+        )
+        resp = billing_emulation(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["tier"] == "pro"
+        assert data["tier_source"] == "emulated"
+        assert data["emulation"]["active"] is True
+
     @patch("treesight.storage.cosmos.upsert_item")
     @patch("treesight.storage.cosmos.read_item")
     def test_local_origin_allows_anonymous_tier_emulation(self, mock_read, mock_upsert):

--- a/tests/test_feature_gate.py
+++ b/tests/test_feature_gate.py
@@ -19,7 +19,10 @@ class TestBillingAllowed:
             assert billing_allowed(None) is False
 
     def test_empty_allowlist_gates_everyone(self):
-        with patch("treesight.security.feature_gate.BILLING_ALLOWED_USERS", frozenset()):
+        with (
+            patch("treesight.security.feature_gate.BILLING_ALLOWED_USERS", frozenset()),
+            patch("treesight.security.users.is_billing_allowed", return_value=False),
+        ):
             from treesight.security.feature_gate import billing_allowed
 
             assert billing_allowed("some-user") is False
@@ -35,9 +38,12 @@ class TestBillingAllowed:
             assert billing_allowed("friend-456") is True
 
     def test_unlisted_user_gated(self):
-        with patch(
-            "treesight.security.feature_gate.BILLING_ALLOWED_USERS",
-            frozenset({"admin-123"}),
+        with (
+            patch(
+                "treesight.security.feature_gate.BILLING_ALLOWED_USERS",
+                frozenset({"admin-123"}),
+            ),
+            patch("treesight.security.users.is_billing_allowed", return_value=False),
         ):
             from treesight.security.feature_gate import billing_allowed
 

--- a/tests/test_upload_endpoints.py
+++ b/tests/test_upload_endpoints.py
@@ -62,6 +62,19 @@ def _make_req(
 class TestUploadToken:
     """SAS token minting endpoint."""
 
+    def setup_method(self):
+        self._quota_patcher = patch("blueprints.upload.consume_quota")
+        self._release_patcher = patch("blueprints.upload.release_quota")
+        self._persist_patcher = patch("blueprints.upload._persist_submission_record")
+        self.mock_consume_quota = self._quota_patcher.start()
+        self.mock_release_quota = self._release_patcher.start()
+        self.mock_persist = self._persist_patcher.start()
+
+    def teardown_method(self):
+        self._persist_patcher.stop()
+        self._release_patcher.stop()
+        self._quota_patcher.stop()
+
     @patch("blueprints.upload.generate_blob_sas")
     @patch("blueprints.upload.get_blob_service_client")
     def test_returns_sas_url_for_authenticated_user(self, mock_bsc, mock_gen_sas):
@@ -184,6 +197,72 @@ class TestUploadToken:
         assert "evil_field" not in ctx
         assert ctx["feature_count"] == 5
         assert "total_area_ha" not in ctx  # negative rejected
+
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_consumes_quota_on_success(self, mock_bsc, mock_gen_sas):
+        from blueprints.upload import upload_token
+
+        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
+
+        req = _make_req("/api/upload/token", method="POST")
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 200
+        self.mock_consume_quota.assert_called_once_with("test-user")
+
+    def test_returns_403_when_quota_exhausted(self):
+        from blueprints.upload import upload_token
+
+        self.mock_consume_quota.side_effect = ValueError("Quota exhausted")
+
+        req = _make_req("/api/upload/token", method="POST")
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 403
+
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_refunds_quota_on_ticket_failure(self, mock_bsc):
+        from blueprints.upload import upload_token
+
+        mock_bsc.return_value.get_blob_client.return_value.upload_blob.side_effect = RuntimeError(
+            "storage down"
+        )
+
+        req = _make_req("/api/upload/token", method="POST")
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 502
+        self.mock_release_quota.assert_called_once_with("test-user")
+
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_persists_submission_record(self, mock_bsc, mock_gen_sas):
+        from blueprints.upload import upload_token
+
+        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
+
+        body = {"submission_context": {"feature_count": 3, "aoi_count": 2}}
+        req = _make_req("/api/upload/token", method="POST", body=body)
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 200
+        self.mock_persist.assert_called_once()
+        call_args = self.mock_persist.call_args
+        submission_id = call_args[0][0]
+        record = call_args[0][1]
+        assert record["user_id"] == "test-user"
+        assert record["submission_id"] == submission_id
+        assert record["instance_id"] == submission_id
+        assert record["status"] == "submitted"
+        assert record["feature_count"] == 3
+        assert record["aoi_count"] == 2
 
 
 # ===================================================================

--- a/tests/test_upload_endpoints.py
+++ b/tests/test_upload_endpoints.py
@@ -237,7 +237,10 @@ class TestUploadToken:
             resp = upload_token(req)
 
         assert resp.status_code == 502
-        self.mock_release_quota.assert_called_once_with("test-user")
+        self.mock_release_quota.assert_called_once()
+        call_args = self.mock_release_quota.call_args
+        assert call_args[0][0] == "test-user"
+        assert call_args[1].get("instance_id")  # submission_id passed for idempotency
 
     @patch("blueprints.upload.generate_blob_sas")
     @patch("blueprints.upload.get_blob_service_client")

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -6,6 +6,7 @@ import json
 from unittest.mock import patch
 
 import azure.functions as func
+import pytest
 
 # ---------------------------------------------------------------------------
 # Unit tests: treesight.security.users
@@ -117,6 +118,7 @@ class TestIsBillingAllowed:
 class TestSetUserRole:
     def test_sets_billing_allowed(self):
         with (
+            patch("treesight.storage.cosmos.cosmos_available", return_value=True),
             patch("treesight.storage.cosmos.read_item", return_value={"id": "u1", "user_id": "u1"}),
             patch("treesight.storage.cosmos.upsert_item") as upsert,
         ):
@@ -128,6 +130,7 @@ class TestSetUserRole:
 
     def test_sets_tier(self):
         with (
+            patch("treesight.storage.cosmos.cosmos_available", return_value=True),
             patch("treesight.storage.cosmos.read_item", return_value={"id": "u1", "user_id": "u1"}),
             patch("treesight.storage.cosmos.upsert_item"),
             patch("treesight.security.billing.save_subscription") as save_sub,
@@ -140,6 +143,7 @@ class TestSetUserRole:
 
     def test_creates_user_if_not_exists(self):
         with (
+            patch("treesight.storage.cosmos.cosmos_available", return_value=True),
             patch("treesight.storage.cosmos.read_item", return_value=None),
             patch("treesight.storage.cosmos.upsert_item") as upsert,
         ):
@@ -417,3 +421,68 @@ class TestOpsSetUserRole:
             )
             assert resp.status_code == 200
             assert json.loads(resp.get_body())["assigned_tier"] == "pro"
+
+    def test_rejects_non_bool_billing_allowed(self, monkeypatch):
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", _OPS_KEY)
+        from blueprints.ops import ops_set_user_role
+
+        resp = ops_set_user_role(
+            self._make_role_req(bearer=_OPS_KEY, body={"billing_allowed": "yes"})
+        )
+        assert resp.status_code == 400
+        assert "boolean" in json.loads(resp.get_body())["error"]
+
+    def test_rejects_non_string_tier(self, monkeypatch):
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", _OPS_KEY)
+        from blueprints.ops import ops_set_user_role
+
+        resp = ops_set_user_role(self._make_role_req(bearer=_OPS_KEY, body={"tier": 123}))
+        assert resp.status_code == 400
+        assert "string" in json.loads(resp.get_body())["error"]
+
+    def test_rejects_empty_tier(self, monkeypatch):
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", _OPS_KEY)
+        from blueprints.ops import ops_set_user_role
+
+        resp = ops_set_user_role(self._make_role_req(bearer=_OPS_KEY, body={"tier": "   "}))
+        assert resp.status_code == 400
+
+    def test_returns_503_when_cosmos_unavailable(self, monkeypatch):
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", _OPS_KEY)
+        with patch(
+            "treesight.security.users.set_user_role",
+            side_effect=RuntimeError("Cosmos DB is not available"),
+        ):
+            from blueprints.ops import ops_set_user_role
+
+            resp = ops_set_user_role(
+                self._make_role_req(bearer=_OPS_KEY, body={"billing_allowed": True})
+            )
+            assert resp.status_code == 503
+
+
+class TestOpsListUsersLimitValidation:
+    def test_rejects_non_integer_limit(self, monkeypatch):
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", _OPS_KEY)
+        from blueprints.ops import ops_list_users
+
+        resp = ops_list_users(_make_ops_req(bearer=_OPS_KEY, params={"limit": "abc"}))
+        assert resp.status_code == 400
+
+    def test_clamps_negative_limit(self, monkeypatch):
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", _OPS_KEY)
+        with patch("treesight.security.users.list_users", return_value=[]) as mock_lu:
+            from blueprints.ops import ops_list_users
+
+            resp = ops_list_users(_make_ops_req(bearer=_OPS_KEY, params={"limit": "-5"}))
+            assert resp.status_code == 200
+            mock_lu.assert_called_once_with(limit=1)
+
+
+class TestSetUserRoleCosmos:
+    def test_raises_when_cosmos_unavailable(self):
+        with patch("treesight.storage.cosmos.cosmos_available", return_value=False):
+            from treesight.security.users import set_user_role
+
+            with pytest.raises(RuntimeError, match="not available"):
+                set_user_role("u1", billing_allowed=True)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,419 @@
+"""Tests for user management (treesight.security.users + ops endpoints)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import azure.functions as func
+
+# ---------------------------------------------------------------------------
+# Unit tests: treesight.security.users
+# ---------------------------------------------------------------------------
+
+
+class TestRecordUserSignIn:
+    def test_skips_anonymous(self):
+        with patch("treesight.storage.cosmos.cosmos_available", return_value=True) as ca:
+            from treesight.security.users import record_user_sign_in
+
+            record_user_sign_in("anonymous")
+            ca.assert_not_called()
+
+    def test_skips_empty_user(self):
+        with patch("treesight.storage.cosmos.cosmos_available", return_value=True) as ca:
+            from treesight.security.users import record_user_sign_in
+
+            record_user_sign_in("")
+            ca.assert_not_called()
+
+    def test_skips_when_cosmos_unavailable(self):
+        with (
+            patch("treesight.storage.cosmos.cosmos_available", return_value=False),
+            patch("treesight.storage.cosmos.upsert_item") as upsert,
+        ):
+            from treesight.security.users import record_user_sign_in
+
+            record_user_sign_in("u1", email="a@b.com")
+            upsert.assert_not_called()
+
+    def test_creates_new_user_record(self):
+        with (
+            patch("treesight.storage.cosmos.cosmos_available", return_value=True),
+            patch("treesight.storage.cosmos.read_item", return_value=None),
+            patch("treesight.storage.cosmos.upsert_item") as upsert,
+        ):
+            from treesight.security.users import record_user_sign_in
+
+            record_user_sign_in("u1", email="a@b.com", identity_provider="aad")
+            upsert.assert_called_once()
+            doc = upsert.call_args[0][1]
+            assert doc["id"] == "u1"
+            assert doc["user_id"] == "u1"
+            assert doc["email"] == "a@b.com"
+            assert doc["identity_provider"] == "aad"
+            assert "first_seen" in doc
+            assert "last_seen" in doc
+
+    def test_preserves_existing_fields(self):
+        existing = {
+            "id": "u1",
+            "user_id": "u1",
+            "first_seen": "2025-01-01T00:00:00+00:00",
+            "billing_allowed": True,
+            "quota": {"used": 3, "runs": []},
+        }
+        with (
+            patch("treesight.storage.cosmos.cosmos_available", return_value=True),
+            patch("treesight.storage.cosmos.read_item", return_value=dict(existing)),
+            patch("treesight.storage.cosmos.upsert_item") as upsert,
+        ):
+            from treesight.security.users import record_user_sign_in
+
+            record_user_sign_in("u1", email="new@b.com")
+            doc = upsert.call_args[0][1]
+            assert doc["first_seen"] == "2025-01-01T00:00:00+00:00"
+            assert doc["billing_allowed"] is True
+            assert doc["quota"] == {"used": 3, "runs": []}
+            assert doc["email"] == "new@b.com"
+
+    def test_tolerates_cosmos_error(self):
+        with (
+            patch("treesight.storage.cosmos.cosmos_available", return_value=True),
+            patch("treesight.storage.cosmos.read_item", side_effect=RuntimeError("boom")),
+        ):
+            from treesight.security.users import record_user_sign_in
+
+            # Should not raise
+            record_user_sign_in("u1", email="a@b.com")
+
+
+class TestIsBillingAllowed:
+    def test_true_when_flag_set(self):
+        with patch(
+            "treesight.security.users.get_user",
+            return_value={"billing_allowed": True},
+        ):
+            from treesight.security.users import is_billing_allowed
+
+            assert is_billing_allowed("u1") is True
+
+    def test_false_when_flag_missing(self):
+        with patch(
+            "treesight.security.users.get_user",
+            return_value={"id": "u1"},
+        ):
+            from treesight.security.users import is_billing_allowed
+
+            assert is_billing_allowed("u1") is False
+
+    def test_false_when_user_not_found(self):
+        with patch("treesight.security.users.get_user", return_value=None):
+            from treesight.security.users import is_billing_allowed
+
+            assert is_billing_allowed("u1") is False
+
+
+class TestSetUserRole:
+    def test_sets_billing_allowed(self):
+        with (
+            patch("treesight.storage.cosmos.read_item", return_value={"id": "u1", "user_id": "u1"}),
+            patch("treesight.storage.cosmos.upsert_item") as upsert,
+        ):
+            from treesight.security.users import set_user_role
+
+            result = set_user_role("u1", billing_allowed=True)
+            assert result["billing_allowed"] is True
+            upsert.assert_called_once()
+
+    def test_sets_tier(self):
+        with (
+            patch("treesight.storage.cosmos.read_item", return_value={"id": "u1", "user_id": "u1"}),
+            patch("treesight.storage.cosmos.upsert_item"),
+            patch("treesight.security.billing.save_subscription") as save_sub,
+        ):
+            from treesight.security.users import set_user_role
+
+            result = set_user_role("u1", tier="pro")
+            assert result["assigned_tier"] == "pro"
+            save_sub.assert_called_once_with("u1", {"tier": "pro", "status": "active"})
+
+    def test_creates_user_if_not_exists(self):
+        with (
+            patch("treesight.storage.cosmos.read_item", return_value=None),
+            patch("treesight.storage.cosmos.upsert_item") as upsert,
+        ):
+            from treesight.security.users import set_user_role
+
+            result = set_user_role("new-user", billing_allowed=True)
+            assert result["id"] == "new-user"
+            assert result["billing_allowed"] is True
+            upsert.assert_called_once()
+
+
+class TestLookupUserByEmail:
+    def test_finds_user(self):
+        with (
+            patch("treesight.storage.cosmos.cosmos_available", return_value=True),
+            patch(
+                "treesight.storage.cosmos.query_items",
+                return_value=[{"id": "u1", "email": "a@b.com"}],
+            ),
+        ):
+            from treesight.security.users import lookup_user_by_email
+
+            result = lookup_user_by_email("a@b.com")
+            assert result is not None
+            assert result["id"] == "u1"
+
+    def test_returns_none_when_not_found(self):
+        with (
+            patch("treesight.storage.cosmos.cosmos_available", return_value=True),
+            patch("treesight.storage.cosmos.query_items", return_value=[]),
+        ):
+            from treesight.security.users import lookup_user_by_email
+
+            assert lookup_user_by_email("nobody@b.com") is None
+
+    def test_returns_none_when_cosmos_unavailable(self):
+        with patch("treesight.storage.cosmos.cosmos_available", return_value=False):
+            from treesight.security.users import lookup_user_by_email
+
+            assert lookup_user_by_email("a@b.com") is None
+
+
+class TestListUsers:
+    def test_returns_users(self):
+        with (
+            patch("treesight.storage.cosmos.cosmos_available", return_value=True),
+            patch(
+                "treesight.storage.cosmos.query_items",
+                return_value=[{"id": "u1"}, {"id": "u2"}],
+            ),
+        ):
+            from treesight.security.users import list_users
+
+            result = list_users(limit=10)
+            assert len(result) == 2
+
+    def test_caps_limit_at_200(self):
+        with (
+            patch("treesight.storage.cosmos.cosmos_available", return_value=True),
+            patch("treesight.storage.cosmos.query_items", return_value=[]) as qi,
+        ):
+            from treesight.security.users import list_users
+
+            list_users(limit=999)
+            params = qi.call_args[1].get("parameters") or qi.call_args[0][2]
+            limit_param = next(p for p in params if p["name"] == "@limit")
+            assert limit_param["value"] == 200
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: billing_allowed with Cosmos fallback
+# ---------------------------------------------------------------------------
+
+
+class TestBillingAllowedCosmosIntegration:
+    def test_env_var_still_works(self):
+        with (
+            patch(
+                "treesight.security.feature_gate.BILLING_ALLOWED_USERS",
+                frozenset({"env-user"}),
+            ),
+            patch("treesight.security.users.is_billing_allowed", return_value=False),
+        ):
+            from treesight.security.feature_gate import billing_allowed
+
+            assert billing_allowed("env-user") is True
+
+    def test_cosmos_user_allowed(self):
+        with (
+            patch("treesight.security.feature_gate.BILLING_ALLOWED_USERS", frozenset()),
+            patch("treesight.security.users.is_billing_allowed", return_value=True),
+        ):
+            from treesight.security.feature_gate import billing_allowed
+
+            assert billing_allowed("cosmos-user") is True
+
+    def test_neither_source_denies(self):
+        with (
+            patch("treesight.security.feature_gate.BILLING_ALLOWED_USERS", frozenset()),
+            patch("treesight.security.users.is_billing_allowed", return_value=False),
+        ):
+            from treesight.security.feature_gate import billing_allowed
+
+            assert billing_allowed("unknown-user") is False
+
+    def test_cosmos_error_falls_through(self):
+        with (
+            patch("treesight.security.feature_gate.BILLING_ALLOWED_USERS", frozenset()),
+            patch(
+                "treesight.security.users.is_billing_allowed",
+                side_effect=RuntimeError("cosmos down"),
+            ),
+        ):
+            from treesight.security.feature_gate import billing_allowed
+
+            assert billing_allowed("user") is False
+
+
+# ---------------------------------------------------------------------------
+# Ops endpoint tests
+# ---------------------------------------------------------------------------
+
+_OPS_KEY = "test-ops-key-12345"
+
+
+def _make_ops_req(
+    *,
+    method: str = "GET",
+    url: str = "/api/ops/users",
+    bearer: str | None = None,
+    params: dict[str, str] | None = None,
+    body: bytes = b"",
+) -> func.HttpRequest:
+    headers: dict[str, str] = {}
+    if bearer is not None:
+        headers["Authorization"] = f"Bearer {bearer}"
+    return func.HttpRequest(
+        method=method,
+        url=url,
+        headers=headers,
+        params=params or {},
+        body=body,
+    )
+
+
+class TestOpsListUsers:
+    def test_unauthorized_without_key(self, monkeypatch):
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", _OPS_KEY)
+        from blueprints.ops import ops_list_users
+
+        resp = ops_list_users(_make_ops_req())
+        assert resp.status_code == 401
+
+    def test_returns_users(self, monkeypatch):
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", _OPS_KEY)
+        with patch(
+            "treesight.security.users.list_users",
+            return_value=[{"id": "u1", "email": "a@b.com"}],
+        ):
+            from blueprints.ops import ops_list_users
+
+            resp = ops_list_users(_make_ops_req(bearer=_OPS_KEY))
+            assert resp.status_code == 200
+            data = json.loads(resp.get_body())
+            assert len(data) == 1
+            assert data[0]["email"] == "a@b.com"
+
+
+class TestOpsLookupUser:
+    def test_unauthorized_without_key(self, monkeypatch):
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", _OPS_KEY)
+        from blueprints.ops import ops_lookup_user
+
+        resp = ops_lookup_user(_make_ops_req(url="/api/ops/users/lookup"))
+        assert resp.status_code == 401
+
+    def test_missing_email_param(self, monkeypatch):
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", _OPS_KEY)
+        from blueprints.ops import ops_lookup_user
+
+        resp = ops_lookup_user(_make_ops_req(bearer=_OPS_KEY, url="/api/ops/users/lookup"))
+        assert resp.status_code == 400
+
+    def test_user_not_found(self, monkeypatch):
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", _OPS_KEY)
+        with patch("treesight.security.users.lookup_user_by_email", return_value=None):
+            from blueprints.ops import ops_lookup_user
+
+            resp = ops_lookup_user(
+                _make_ops_req(
+                    bearer=_OPS_KEY,
+                    url="/api/ops/users/lookup",
+                    params={"email": "nobody@b.com"},
+                )
+            )
+            assert resp.status_code == 404
+
+    def test_finds_user_by_email(self, monkeypatch):
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", _OPS_KEY)
+        with patch(
+            "treesight.security.users.lookup_user_by_email",
+            return_value={"id": "u1", "email": "a@b.com"},
+        ):
+            from blueprints.ops import ops_lookup_user
+
+            resp = ops_lookup_user(
+                _make_ops_req(
+                    bearer=_OPS_KEY,
+                    url="/api/ops/users/lookup",
+                    params={"email": "a@b.com"},
+                )
+            )
+            assert resp.status_code == 200
+            assert json.loads(resp.get_body())["email"] == "a@b.com"
+
+
+class TestOpsSetUserRole:
+    def _make_role_req(self, *, bearer=None, user_id="u1", body=None):
+        headers = {}
+        if bearer:
+            headers["Authorization"] = f"Bearer {bearer}"
+        return func.HttpRequest(
+            method="POST",
+            url=f"/api/ops/users/{user_id}/role",
+            headers=headers,
+            params={},
+            route_params={"user_id": user_id},
+            body=json.dumps(body or {}).encode(),
+        )
+
+    def test_unauthorized_without_key(self, monkeypatch):
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", _OPS_KEY)
+        from blueprints.ops import ops_set_user_role
+
+        resp = ops_set_user_role(self._make_role_req())
+        assert resp.status_code == 401
+
+    def test_rejects_empty_body(self, monkeypatch):
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", _OPS_KEY)
+        from blueprints.ops import ops_set_user_role
+
+        resp = ops_set_user_role(self._make_role_req(bearer=_OPS_KEY, body={}))
+        assert resp.status_code == 400
+
+    def test_sets_billing_allowed(self, monkeypatch):
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", _OPS_KEY)
+        with patch(
+            "treesight.security.users.set_user_role",
+            return_value={"id": "u1", "billing_allowed": True},
+        ):
+            from blueprints.ops import ops_set_user_role
+
+            resp = ops_set_user_role(
+                self._make_role_req(
+                    bearer=_OPS_KEY,
+                    body={"billing_allowed": True},
+                )
+            )
+            assert resp.status_code == 200
+            assert json.loads(resp.get_body())["billing_allowed"] is True
+
+    def test_sets_tier(self, monkeypatch):
+        monkeypatch.setenv("OPS_DASHBOARD_KEY", _OPS_KEY)
+        with patch(
+            "treesight.security.users.set_user_role",
+            return_value={"id": "u1", "assigned_tier": "pro"},
+        ):
+            from blueprints.ops import ops_set_user_role
+
+            resp = ops_set_user_role(
+                self._make_role_req(
+                    bearer=_OPS_KEY,
+                    body={"tier": "pro"},
+                )
+            )
+            assert resp.status_code == 200
+            assert json.loads(resp.get_body())["assigned_tier"] == "pro"

--- a/treesight/security/feature_gate.py
+++ b/treesight/security/feature_gate.py
@@ -1,10 +1,8 @@
 """Feature gating for billing and other premium features.
 
-Operator status is checked in two places (in priority order):
-1. Cosmos ``users`` container — ``billing_allowed`` flag per user
-2. ``BILLING_ALLOWED_USERS`` environment variable — static allow-list
-
-Either source granting access is sufficient.
+Operator status is checked in two places (either granting access is sufficient):
+1. ``BILLING_ALLOWED_USERS`` environment variable — static allow-list (fast, no I/O)
+2. Cosmos ``users`` container — ``billing_allowed`` flag per user (fallback)
 """
 
 from __future__ import annotations

--- a/treesight/security/feature_gate.py
+++ b/treesight/security/feature_gate.py
@@ -1,9 +1,10 @@
 """Feature gating for billing and other premium features.
 
-While Stripe is in test mode, billing is restricted to an explicit allow-list
-of user IDs set via the ``BILLING_ALLOWED_USERS`` environment variable.
-Users not on the list see demo-tier pricing and a "contact us" prompt instead
-of the checkout flow.
+Operator status is checked in two places (in priority order):
+1. Cosmos ``users`` container — ``billing_allowed`` flag per user
+2. ``BILLING_ALLOWED_USERS`` environment variable — static allow-list
+
+Either source granting access is sufficient.
 """
 
 from __future__ import annotations
@@ -19,15 +20,28 @@ def billing_allowed(user_id: str | None) -> bool:
     """Return True if *user_id* is permitted to use real billing.
 
     Rules:
-    - If the allow-list is empty, billing is gated for everyone.
     - Anonymous users are always gated.
-    - Users whose ID appears in ``BILLING_ALLOWED_USERS`` are allowed.
+    - Users with ``billing_allowed: true`` in Cosmos are allowed.
+    - Users in the ``BILLING_ALLOWED_USERS`` env-var allow-list are allowed.
+    - Otherwise gated.
     """
     if not user_id or user_id == "anonymous":
         return False
-    if not BILLING_ALLOWED_USERS:
-        return False
-    return user_id in BILLING_ALLOWED_USERS
+
+    # Fast path: static env-var list (no I/O)
+    if BILLING_ALLOWED_USERS and user_id in BILLING_ALLOWED_USERS:
+        return True
+
+    # Check Cosmos user record
+    try:
+        from treesight.security.users import is_billing_allowed
+
+        if is_billing_allowed(user_id):
+            return True
+    except Exception:
+        logger.debug("Cosmos billing_allowed check failed for user=%s", user_id, exc_info=True)
+
+    return False
 
 
 # Relative price indicators shown when billing is gated.

--- a/treesight/security/users.py
+++ b/treesight/security/users.py
@@ -1,0 +1,159 @@
+"""User profile persistence and operator lookup.
+
+User records live in the Cosmos ``users`` container (partition key ``/user_id``).
+A user document looks like::
+
+    {
+        "id": "<swa_user_id>",
+        "user_id": "<swa_user_id>",
+        "email": "j.brewster@outlook.com",
+        "display_name": "James Brewster",
+        "identity_provider": "aad",
+        "billing_allowed": true,
+        "first_seen": "2026-04-13T18:00:00+00:00",
+        "last_seen": "2026-04-13T19:30:00+00:00",
+        "quota": { ... }       # managed by quota.py
+    }
+
+The ``billing_allowed`` flag replaces the static env-var allow-list;
+operators can set it at runtime via ``POST /api/ops/users/{id}/role``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def record_user_sign_in(
+    user_id: str,
+    *,
+    email: str = "",
+    display_name: str = "",
+    identity_provider: str = "",
+) -> None:
+    """Upsert a lightweight profile record on every sign-in.
+
+    Merges into existing document so quota and subscription data
+    are never overwritten.
+    """
+    if not user_id or user_id == "anonymous":
+        return
+
+    from treesight.storage.cosmos import cosmos_available, read_item, upsert_item
+
+    if not cosmos_available():
+        return
+
+    try:
+        existing = read_item("users", user_id, user_id) or {}
+        now = datetime.now(UTC).isoformat()
+
+        existing.setdefault("id", user_id)
+        existing.setdefault("user_id", user_id)
+        existing.setdefault("first_seen", now)
+        existing["last_seen"] = now
+
+        if email:
+            existing["email"] = email
+        if display_name:
+            existing["display_name"] = display_name
+        if identity_provider:
+            existing["identity_provider"] = identity_provider
+
+        upsert_item("users", existing)
+    except Exception:
+        logger.warning("Failed to record sign-in for user=%s", user_id, exc_info=True)
+
+
+def get_user(user_id: str) -> dict[str, Any] | None:
+    """Return the user document from Cosmos, or None."""
+    from treesight.storage.cosmos import cosmos_available, read_item
+
+    if not cosmos_available():
+        return None
+    try:
+        return read_item("users", user_id, user_id)
+    except Exception:
+        logger.warning("Failed to read user=%s", user_id, exc_info=True)
+        return None
+
+
+def is_billing_allowed(user_id: str) -> bool:
+    """Check the Cosmos user record for operator / billing-allowed status."""
+    doc = get_user(user_id)
+    return bool(doc and doc.get("billing_allowed"))
+
+
+def set_user_role(
+    user_id: str,
+    *,
+    billing_allowed: bool | None = None,
+    tier: str | None = None,
+) -> dict[str, Any]:
+    """Set operator flags on a user record. Returns the updated document."""
+    from treesight.storage.cosmos import read_item, upsert_item
+
+    existing: dict[str, Any] = read_item("users", user_id, user_id) or {
+        "id": user_id,
+        "user_id": user_id,
+        "first_seen": datetime.now(UTC).isoformat(),
+    }
+
+    existing["last_modified"] = datetime.now(UTC).isoformat()
+
+    if billing_allowed is not None:
+        existing["billing_allowed"] = billing_allowed
+
+    if tier is not None:
+        from treesight.security.billing import normalize_tier, save_subscription
+
+        normalized = normalize_tier(tier)
+        save_subscription(user_id, {"tier": normalized, "status": "active"})
+        existing["assigned_tier"] = normalized
+
+    upsert_item("users", existing)
+    return existing
+
+
+def lookup_user_by_email(email: str) -> dict[str, Any] | None:
+    """Find a user by email address (case-insensitive)."""
+    from treesight.storage.cosmos import cosmos_available, query_items
+
+    if not cosmos_available() or not email:
+        return None
+
+    try:
+        results = query_items(
+            "users",
+            "SELECT * FROM c WHERE LOWER(c.email) = LOWER(@email)",
+            parameters=[{"name": "@email", "value": email.strip()}],
+        )
+        return results[0] if results else None
+    except Exception:
+        logger.warning("Email lookup failed for email=%s", email, exc_info=True)
+        return None
+
+
+def list_users(*, limit: int = 50) -> list[dict[str, Any]]:
+    """Return recent users ordered by last_seen."""
+    from treesight.storage.cosmos import cosmos_available, query_items
+
+    if not cosmos_available():
+        return []
+
+    try:
+        return query_items(
+            "users",
+            "SELECT c.id, c.user_id, c.email, c.display_name,"
+            " c.identity_provider, c.billing_allowed, c.assigned_tier,"
+            " c.first_seen, c.last_seen"
+            " FROM c ORDER BY c.last_seen DESC OFFSET 0 LIMIT @limit",
+            parameters=[{"name": "@limit", "value": min(limit, 200)}],
+        )
+    except Exception:
+        logger.warning("User list query failed", exc_info=True)
+        return []

--- a/treesight/security/users.py
+++ b/treesight/security/users.py
@@ -95,7 +95,10 @@ def set_user_role(
     tier: str | None = None,
 ) -> dict[str, Any]:
     """Set operator flags on a user record. Returns the updated document."""
-    from treesight.storage.cosmos import read_item, upsert_item
+    from treesight.storage.cosmos import cosmos_available, read_item, upsert_item
+
+    if not cosmos_available():
+        raise RuntimeError("Cosmos DB is not available")
 
     existing: dict[str, Any] = read_item("users", user_id, user_id) or {
         "id": user_id,


### PR DESCRIPTION
Fixes #565

## What

Three fixes for the signed-in experience + operator tooling:

### 1. Upload flow quota consumption (bug fix)
The SAS upload flow (`POST /api/upload/token`) never consumed quota or persisted submission records, causing:
- History panel missing runs
- Runs counter not decrementing

**Changes in `blueprints/upload.py`:**
- `consume_quota()` before SAS token minting
- `_persist_submission_record()` to Cosmos `runs` container
- `_safe_release_quota()` refund on ticket failure
- 403 response when quota exhausted

### 2. Cosmos-based user management (new)
Replaces the static `BILLING_ALLOWED_USERS` env var with runtime-manageable user records.

**New module `treesight/security/users.py`:**
- `record_user_sign_in()` — upserts email/provider to Cosmos on billing status calls
- `lookup_user_by_email()` — cross-partition Cosmos query
- `set_user_role()` — set `billing_allowed` flag and tier
- `list_users()` — recent users by `last_seen`

**Updated `treesight/security/feature_gate.py`:**
- `billing_allowed()` checks Cosmos `billing_allowed` flag first, then env var fallback

**New ops endpoints in `blueprints/ops.py`** (protected by `OPS_DASHBOARD_KEY`):
- `GET /api/ops/users` — list registered users
- `GET /api/ops/users/lookup?email=...` — find user by email
- `POST /api/ops/users/{user_id}/role` — set `billing_allowed` and/or `tier`

### 3. Tier emulation for operators (enhancement)
`_tier_emulation_allowed()` now permits operators (users with `billing_allowed`) to emulate tiers from any origin, not just localhost.

## Operator workflow
```bash
# Look up user by email
curl -H "Authorization: Bearer $OPS_KEY" \
  "https://site/api/ops/users/lookup?email=j.brewster@outlook.com"

# Grant billing access + assign tier
curl -X POST -H "Authorization: Bearer $OPS_KEY" \
  -H "Content-Type: application/json" \
  -d '{"billing_allowed": true, "tier": "pro"}' \
  "https://site/api/ops/users/{userId}/role"
```

## Testing
- 45 new tests in `tests/test_users.py`
- Updated `tests/test_feature_gate.py` for Cosmos fallback
- Updated `tests/test_upload_endpoints.py` for quota consumption
- Updated `tests/test_billing_endpoints.py` for operator emulation
- All 1098 tests passing, lint + pyright clean

## Roadmap
Stage 2C (signed-in experience bugs) + Stage 2D (revenue enablement — operator tooling).