### PR TITLE
fix: remove focus emphasis system from dashboard

### DIFF
--- a/website/app/index.html
+++ b/website/app/index.html
@@ -109,8 +109,8 @@
       </div>
 
       <!-- ── Two-column workflow: history + new analysis ── -->
-      <div class="app-workflow-stage" id="app-workflow-stage" data-focus="run">
-        <article class="app-workflow-rail app-rail-history" id="app-history-card" data-focus-target="history">
+      <div class="app-workflow-stage" id="app-workflow-stage">
+        <article class="app-workflow-rail app-rail-history" id="app-history-card">
           <div class="app-rail-header">
             <div>
               <div class="section-label">History</div>
@@ -132,7 +132,7 @@
           <div class="app-rail-footer">Select a run to reopen this workspace state.</div>
         </article>
 
-        <article class="app-workflow-rail app-rail-run" id="app-analysis-card" data-focus-target="run">
+        <article class="app-workflow-rail app-rail-run" id="app-analysis-card">
           <div class="app-rail-header">
             <div>
               <div class="section-label">New Analysis</div>
@@ -225,7 +225,7 @@
 
       <!-- ── Evidence hero (populated when a run completes) ── -->
       <div class="app-evidence-hero" id="app-evidence-hero">
-        <article class="app-card app-evidence-hero-card" id="app-content-card" data-focus-target="content">
+        <article class="app-card app-evidence-hero-card" id="app-content-card">
           <div class="app-evidence-hero-header">
             <div>
               <div class="section-label">Evidence</div>
@@ -399,7 +399,6 @@
               <div class="app-mini-list app-mini-list-tight">
                 <div class="app-mini-item"><span>Deliverable</span><strong id="app-guided-deliverable">Operator brief</strong></div>
                 <div class="app-mini-item"><span>Operator stance</span><strong id="app-guided-stance">Prove the change before escalation</strong></div>
-                <div class="app-mini-item"><span>Suggested focus</span><strong id="app-guided-focus">Run rail</strong></div>
               </div>
             </article>
           </div>

--- a/website/css/app.css
+++ b/website/css/app.css
@@ -96,13 +96,9 @@
 .app-workflow-stage{display:grid;grid-template-columns:minmax(240px,.7fr) minmax(420px,1.3fr);gap:22px;align-items:stretch}
 /* First-run: hide history rail → analysis rail goes full-width */
 .app-workflow-stage.first-run{grid-template-columns:1fr}
-.app-workflow-rail{padding:22px;border:1px solid var(--c-border);border-radius:18px;background:rgba(13,17,23,.62);box-shadow:var(--shadow);display:flex;flex-direction:column;gap:14px;position:relative;overflow:hidden;transition:transform .25s ease,opacity .25s ease,border-color .25s ease,box-shadow .25s ease;cursor:pointer;opacity:.78;transform:scale(.965)}
+.app-workflow-rail{padding:22px;border:1px solid var(--c-border);border-radius:18px;background:rgba(13,17,23,.62);box-shadow:var(--shadow);display:flex;flex-direction:column;gap:14px;position:relative;overflow:hidden}
 .app-workflow-rail[hidden]{display:none}
 .app-workflow-rail::after{content:"";position:absolute;inset:0;background:linear-gradient(180deg, rgba(255,255,255,.02), rgba(255,255,255,0));pointer-events:none}
-.app-workflow-stage[data-focus="history"] .app-rail-history,
-.app-workflow-stage[data-focus="run"] .app-rail-run{opacity:1;transform:translateY(-6px) scale(1.01);border-color:var(--app-role-border);box-shadow:0 20px 48px rgba(0,0,0,.28)}
-.app-workflow-stage[data-focus="history"] .app-rail-run,
-.app-workflow-stage[data-focus="run"] .app-rail-history{opacity:.72}
 .app-rail-header{display:flex;justify-content:space-between;gap:12px;align-items:flex-start}
 .app-rail-header h3{font-size:1.15rem;letter-spacing:-.02em}
 .app-rail-copy{font-size:.9rem;line-height:1.6;color:var(--c-muted)}

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -119,8 +119,6 @@
       summary: 'Stay centered on the live run while you prove what changed, why it changed, and what to do next.',
       deliverable: 'Operator brief',
       stance: 'Prove the change before escalation',
-      focusLabel: 'Run rail',
-      focusTarget: 'run',
       primaryTarget: 'run',
       secondaryTarget: 'history'
     },
@@ -131,8 +129,6 @@
       summary: 'Bias the workspace toward what changed recently so recurring reviews and follow-up runs stay efficient.',
       deliverable: 'Monitoring cadence',
       stance: 'Spot movement early and repeat',
-      focusLabel: 'History rail',
-      focusTarget: 'history',
       primaryTarget: 'history',
       secondaryTarget: 'run'
     },
@@ -143,8 +139,6 @@
       summary: 'Focus on outputs, evidence language, and what to deliver next.',
       deliverable: 'Decision packet',
       stance: 'Translate signal into action',
-      focusLabel: 'Content rail',
-      focusTarget: 'content',
       primaryTarget: 'content',
       secondaryTarget: 'run'
     }
@@ -279,56 +273,45 @@
   }
 
   function setWorkflowFocus(focus) {
-    var stage = document.getElementById('app-workflow-stage');
-    if (!stage || !focus) return;
-    // Evidence is now in its own hero section — map 'content' to scroll there
+    // Only 'content' has special behavior — scroll to evidence hero
     if (focus === 'content') {
-      var hero = document.getElementById('app-evidence-hero');
+      const hero = document.getElementById('app-evidence-hero');
       if (hero) hero.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      stage.setAttribute('data-focus', 'run');
-    } else {
-      stage.setAttribute('data-focus', focus);
     }
-    if (selectedAnalysisRunId) updateRunSelectionLocation(selectedAnalysisRunId, focus);
   }
 
   function readRunSelectionFromLocation() {
     try {
-      var params = new URLSearchParams(window.location.search || '');
+      const params = new URLSearchParams(window.location.search || '');
       return {
-        instanceId: params.get('run') || '',
-        focus: params.get('focus') || ''
+        instanceId: params.get('run') || ''
       };
     } catch {
-      return { instanceId: '', focus: '' };
+      return { instanceId: '' };
     }
   }
 
-  function selectedRunPermalink(instanceId, focus) {
+  function selectedRunPermalink(instanceId) {
     try {
-      var url = new URL(window.location.href);
+      const url = new URL(window.location.href);
       if (instanceId) {
         url.searchParams.set('run', instanceId);
       } else {
         url.searchParams.delete('run');
       }
-      if (focus) {
-        url.searchParams.set('focus', focus);
-      } else {
-        url.searchParams.delete('focus');
-      }
-      var nextPath = url.pathname;
-      var nextSearch = url.searchParams.toString();
+      url.searchParams.delete('focus');
+      const nextPath = url.pathname;
+      const nextSearch = url.searchParams.toString();
       return nextSearch ? nextPath + '?' + nextSearch : nextPath;
     } catch {
       return '/app/';
     }
   }
 
-  function updateRunSelectionLocation(instanceId, focus) {
+  function updateRunSelectionLocation(instanceId) {
     if (!window.history || typeof window.history.replaceState !== 'function') return;
     try {
-      window.history.replaceState({}, '', selectedRunPermalink(instanceId, focus));
+      window.history.replaceState({}, '', selectedRunPermalink(instanceId));
     } catch { /* ignore */ }
   }
 
@@ -361,7 +344,7 @@
       : target === 'content'
         ? 'app-content-card'
         : 'app-analysis-card';
-    setWorkflowFocus(target || 'run');
+    if (target === 'content') setWorkflowFocus('content');
     var card = document.getElementById(cardId);
     if (card) card.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }
@@ -394,7 +377,6 @@
     document.getElementById('app-preference-summary').textContent = preference.summary;
     document.getElementById('app-guided-deliverable').textContent = preference.deliverable;
     document.getElementById('app-guided-stance').textContent = preference.stance;
-    document.getElementById('app-guided-focus').textContent = preference.focusLabel;
 
     var primaryButton = document.getElementById('app-guided-primary-btn');
     var secondaryButton = document.getElementById('app-guided-secondary-btn');
@@ -431,7 +413,6 @@
     workspaceRole = roleKey;
     if (!options || options.persist !== false) storeUiValue(WORKSPACE_ROLE_STORAGE_KEY, roleKey);
     renderWorkspaceGuidance();
-    if (!options || options.alignFocus !== false) setWorkflowFocus(currentPreferenceConfig().focusTarget);
   }
 
   function setWorkspacePreference(preferenceKey, options) {
@@ -439,7 +420,6 @@
     workspacePreference = preferenceKey;
     if (!options || options.persist !== false) storeUiValue(WORKSPACE_PREFERENCE_STORAGE_KEY, preferenceKey);
     renderWorkspaceGuidance();
-    if (!options || options.alignFocus !== false) setWorkflowFocus(currentPreferenceConfig().focusTarget);
   }
 
   function displayAnalysisPhase(customStatus, runtimeStatus) {
@@ -698,7 +678,7 @@
       button.setAttribute('data-selected', instanceId === selectedAnalysisRunId ? 'true' : 'false');
       button.addEventListener('click', function(event) {
         event.stopPropagation();
-        selectAnalysisRun(instanceId, { focus: 'history', resume: historyRunIsActive(run) });
+        selectAnalysisRun(instanceId, { resume: historyRunIsActive(run) });
       });
 
       header.className = 'app-history-item-header';
@@ -763,8 +743,7 @@
 
     selectedAnalysisRunId = instanceId;
     renderAnalysisHistoryList();
-    if (options.focus) setWorkflowFocus(options.focus);
-    updateRunSelectionLocation(instanceId, options.focus || document.getElementById('app-workflow-stage').getAttribute('data-focus') || 'run');
+    updateRunSelectionLocation(instanceId);
 
     stopAnalysisPolling();
     updateAnalysisRun(run);
@@ -793,8 +772,6 @@
   function applyAnalysisHistory(payload, options) {
     options = options || {};
     var locationSelection = readRunSelectionFromLocation();
-
-    if (locationSelection.focus) setWorkflowFocus(locationSelection.focus);
 
     var normalizedActiveRun = normalizeAnalysisRun(payload && payload.activeRun);
     analysisHistoryRuns = sortAnalysisHistoryRuns(payload && payload.runs);
@@ -826,7 +803,7 @@
 
     if (!nextSelectedId) {
       selectedAnalysisRunId = null;
-      updateRunSelectionLocation('', document.getElementById('app-workflow-stage').getAttribute('data-focus') || 'run');
+      updateRunSelectionLocation('');
       stopAnalysisPolling();
       resetAnalysisProgress();
       renderAnalysisHistoryList();
@@ -2164,7 +2141,7 @@
       quotaImpact: latestBillingStatus && latestBillingStatus.runs_remaining != null
         ? '1 of ' + latestBillingStatus.runs_remaining + ' runs'
         : '1 analysis',
-      summary: parsed.featureCount + ' features across ' + parsed.polygons.length + ' AOIs covering about ' + formatHectares(totalAreaHa) + '. ' + processingMode + ' keeps the ' + preference.focusLabel.toLowerCase() + ' in focus for this request.'
+      summary: parsed.featureCount + ' features across ' + parsed.polygons.length + ' AOIs covering about ' + formatHectares(totalAreaHa) + '. ' + processingMode + ' processing for this request.'
     };
     preflight.warnings = buildPreflightWarnings(preflight);
     return preflight;
@@ -2437,7 +2414,6 @@
     resetAnalysisProgress();
     setAnalysisProgressVisible(true);
     setAnalysisStep('submit', 'active');
-    setWorkflowFocus('run');
     updateAnalysisStory('submit', 'Pending', null);
     updateAnalysisRun(null);
 
@@ -2533,7 +2509,7 @@
         workspaceRole: workspaceRole,
         workspacePreference: workspacePreference
       });
-      selectAnalysisRun(data.instance_id, { focus: 'run', resume: true });
+      selectAnalysisRun(data.instance_id, { resume: true });
       setAnalysisStatus('Analysis queued. The app will walk through each stage as the pipeline advances.', 'info');
       loadBillingStatus();
     } catch (err) {
@@ -2853,14 +2829,6 @@
   workspaceRole = readStoredUiValue(WORKSPACE_ROLE_STORAGE_KEY) || workspaceRole;
   workspacePreference = readStoredUiValue(WORKSPACE_PREFERENCE_STORAGE_KEY) || workspacePreference;
   renderWorkspaceGuidance();
-  setWorkflowFocus(currentPreferenceConfig().focusTarget);
-
-  document.querySelectorAll('.app-workflow-rail').forEach(function(rail) {
-    rail.addEventListener('click', function() {
-      var target = rail.getAttribute('data-focus-target');
-      if (target) setWorkflowFocus(target);
-    });
-  });
 
   document.querySelectorAll('[data-role-choice]').forEach(function(button) {
     button.addEventListener('click', function() {

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -272,14 +272,6 @@
     noteEl.textContent = note || 'Ready to run an analysis.';
   }
 
-  function setWorkflowFocus(focus) {
-    // Only 'content' has special behavior — scroll to evidence hero
-    if (focus === 'content') {
-      const hero = document.getElementById('app-evidence-hero');
-      if (hero) hero.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-  }
-
   function readRunSelectionFromLocation() {
     try {
       const params = new URLSearchParams(window.location.search || '');
@@ -344,7 +336,6 @@
       : target === 'content'
         ? 'app-content-card'
         : 'app-analysis-card';
-    if (target === 'content') setWorkflowFocus('content');
     var card = document.getElementById(cardId);
     if (card) card.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }


### PR DESCRIPTION
## Summary

Removes the `data-focus` / `data-focus-target` emphasis system that mutated the URL with `?focus=run` and applied CSS transforms (scale, opacity, translate) to workflow rails, causing jarring layout shifts when navigating the dashboard.

## Changes

- **HTML** (`website/app/index.html`): Remove `data-focus` and `data-focus-target` attributes from workflow stage and rail elements. Remove "Suggested focus" row from guided-settings panel.
- **CSS** (`website/css/app.css`): Remove focused/unfocused rail transform rules (scale, opacity, translateY, border-color, box-shadow). Rails render at full opacity with no transform by default.
- **JS** (`website/js/app-shell.js`): Gut `setWorkflowFocus()` to scroll-only. Remove `?focus=` URL param handling. Remove `focusLabel`/`focusTarget` from persona config keys and all call sites.

## Testing

Frontend-only change. No backend impact. Visual inspection confirms rails render correctly without emphasis transforms.