### PR TITLE
fix: security review batch — discovery files, headers, X-Robots-Tag

### DIFF
--- a/tests/test_frontend_config.py
+++ b/tests/test_frontend_config.py
@@ -221,3 +221,60 @@ class TestCorsConfig:
         finally:
             os.environ["CORS_ALLOWED_ORIGINS"] = original_cors or f"{TEST_ORIGIN}"
             importlib.reload(helpers_mod)
+
+
+# ---------------------------------------------------------------------------
+# Security headers — validate defensive header configuration
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityHeaders:
+    def test_xss_protection_disabled(self, swa_config):
+        """X-XSS-Protection must be '0' — deprecated header that can cause issues."""
+        headers = swa_config["globalHeaders"]
+        assert headers.get("X-XSS-Protection") == "0", (
+            "X-XSS-Protection must be explicitly set to '0' to disable the "
+            "deprecated XSS auditor — CSP provides real protection"
+        )
+
+    def test_x_robots_tag_on_app(self, swa_config):
+        """The /app/* route must set X-Robots-Tag to prevent indexing."""
+        routes = swa_config.get("routes", [])
+        app_routes = [r for r in routes if r.get("route") == "/app/*"]
+        assert app_routes, "/app/* route must exist"
+        headers = app_routes[0].get("headers", {})
+        assert "noindex" in headers.get("X-Robots-Tag", ""), (
+            "/app/* must have X-Robots-Tag: noindex to prevent search engine indexing"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Static discovery files — robots.txt, security.txt, sitemap.xml
+# ---------------------------------------------------------------------------
+
+
+class TestStaticDiscoveryFiles:
+    def test_robots_txt_exists(self):
+        assert (WEBSITE / "robots.txt").is_file(), "robots.txt must exist"
+
+    def test_robots_txt_disallows_app(self):
+        content = (WEBSITE / "robots.txt").read_text()
+        assert "Disallow: /app/" in content
+
+    def test_sitemap_xml_exists(self):
+        assert (WEBSITE / "sitemap.xml").is_file(), "sitemap.xml must exist"
+
+    def test_security_txt_exists(self):
+        assert (WEBSITE / ".well-known" / "security.txt").is_file(), (
+            ".well-known/security.txt must exist"
+        )
+
+    def test_security_txt_has_contact(self):
+        content = (WEBSITE / ".well-known" / "security.txt").read_text()
+        assert "Contact:" in content, "security.txt must include a Contact field"
+
+    def test_nav_fallback_excludes_static_files(self, swa_config):
+        """Navigation fallback must exclude static discovery files."""
+        excludes = swa_config["navigationFallback"]["exclude"]
+        for path in ["/robots.txt", "/sitemap.xml", "/.well-known/*"]:
+            assert path in excludes, f"{path} must be in navigationFallback.exclude"

--- a/website/.well-known/security.txt
+++ b/website/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: https://github.com/Hardcoreprawn/azure-workflow-for-kml-satellite/security/advisories/new
+Expires: 2027-04-13T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://canopex.hrdcrprwn.com/.well-known/security.txt
+Policy: https://github.com/Hardcoreprawn/azure-workflow-for-kml-satellite/blob/main/SECURITY.md

--- a/website/README.md
+++ b/website/README.md
@@ -153,7 +153,7 @@ The website expects:
 
 - **No secrets** in HTML/CSS/JS — all static content is public
 - **CORS**: Configured for local testing; adapt as needed in deployment
-- **Headers**: CSP, X-Frame-Options, X-XSS-Protection set in `staticwebapp.config.json`
+- **Headers**: CSP, X-Frame-Options, HSTS, Permissions-Policy set in `staticwebapp.config.json`
 - **User data**: Contact forms validated client-side before submission
 
 ---

--- a/website/robots.txt
+++ b/website/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+Disallow: /app/
+Disallow: /api/
+
+Sitemap: https://canopex.hrdcrprwn.com/sitemap.xml

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://canopex.hrdcrprwn.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://canopex.hrdcrprwn.com/docs/kml-guide.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://canopex.hrdcrprwn.com/docs/eudr-methodology.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://canopex.hrdcrprwn.com/terms.html</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://canopex.hrdcrprwn.com/privacy.html</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>

--- a/website/staticwebapp.config.json
+++ b/website/staticwebapp.config.json
@@ -1,7 +1,7 @@
 {
   "navigationFallback": {
     "rewrite": "/index.html",
-    "exclude": ["/api/*", "/api-config.json", "/css/*", "/js/*", "/images/*", "/docs/*", "/terms.html", "/privacy.html"]
+    "exclude": ["/api/*", "/api-config.json", "/css/*", "/js/*", "/images/*", "/docs/*", "/terms.html", "/privacy.html", "/robots.txt", "/sitemap.xml", "/.well-known/*"]
   },
   "routes": [
     {
@@ -17,6 +17,12 @@
     {
       "route": "/api-config.json",
       "allowedRoles": ["anonymous"]
+    },
+    {
+      "route": "/app/*",
+      "headers": {
+        "X-Robots-Tag": "noindex, nofollow"
+      }
     }
   ],
   "responseOverrides": {
@@ -31,6 +37,7 @@
   "globalHeaders": {
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
+    "X-XSS-Protection": "0",
     "Referrer-Policy": "strict-origin-when-cross-origin",
     "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
     "Permissions-Policy": "camera=(), microphone=(), geolocation=()",


### PR DESCRIPTION
## Summary

Batch fixes for quick-win items from the [2026-04-13 security review](docs/20260413-security-review.md).

## Changes

### New static discovery files
- **`robots.txt`** — disallows `/app/` and `/api/`, includes sitemap link
- **`.well-known/security.txt`** — contact via GitHub advisory, links to SECURITY.md
- **`sitemap.xml`** — public pages (landing, docs, terms, privacy)

### SWA config updates (`staticwebapp.config.json`)
- Navigation fallback now excludes `/robots.txt`, `/sitemap.xml`, `/.well-known/*` so SWA serves them as files instead of rewriting to the SPA
- **`X-XSS-Protection: 0`** — explicitly disables the deprecated XSS auditor (CSP provides real protection)
- **`X-Robots-Tag: noindex, nofollow`** on `/app/*` route — prevents indexing of authenticated app pages

### Tests
- 8 new regression tests in `test_frontend_config.py`:
  - `TestSecurityHeaders`: X-XSS-Protection disabled, X-Robots-Tag on /app/*
  - `TestStaticDiscoveryFiles`: robots.txt, sitemap.xml, security.txt exist with correct content; fallback excludes configured

### README
- Updated security header reference (replaced X-XSS-Protection mention with HSTS + Permissions-Policy)

## Items deferred to issues
- CSP wildcard pinning (`*.azurecontainerapps.io`, `*.blob.core.windows.net`)
- Unauthenticated endpoint audit
- Old domain takeover risk
- Public repo info disclosure policy
- Contact form anti-abuse