### PR TITLE
fix: frontend + backend hardening — auth, IDOR, data integrity, anti-abuse, reliability

### DIFF
--- a/blueprints/_helpers.py
+++ b/blueprints/_helpers.py
@@ -195,6 +195,15 @@ def submit_contact(
     if not isinstance(body, dict):
         return error_response(400, "Expected JSON object", req=req)
 
+    # Honeypot: if a hidden field is filled, silently accept (bot detected)
+    if body.get("website"):
+        return func.HttpResponse(
+            json.dumps({"status": "received", "submission_id": "ok"}),
+            status_code=200,
+            mimetype="application/json",
+            headers=cors_headers(req),
+        )
+
     email = sanitise(body.get("email", ""))
     if not email or not EMAIL_RE.match(email):
         return error_response(400, "Valid email is required", req=req)
@@ -260,7 +269,14 @@ async def fetch_enrichment_manifest(
     if not owner_id or owner_id != caller_user_id:
         return None, error_response(404, "Pipeline not found or not complete", req=req)
 
-    output = status.output if isinstance(status.output, dict) else {}
+    output = status.output
+    if isinstance(output, str):
+        try:
+            output = json.loads(output)
+        except (json.JSONDecodeError, TypeError):
+            output = {}
+    if not isinstance(output, dict):
+        output = {}
     if reshape_output is not None:
         output = reshape_output(status.output) if status.output else {}
     manifest_path = output.get("enrichment_manifest") or output.get("enrichmentManifest")

--- a/blueprints/_helpers.py
+++ b/blueprints/_helpers.py
@@ -278,7 +278,7 @@ async def fetch_enrichment_manifest(
     if not isinstance(output, dict):
         output = {}
     if reshape_output is not None:
-        output = reshape_output(status.output) if status.output else {}
+        output = reshape_output(output) if output else {}
     manifest_path = output.get("enrichment_manifest") or output.get("enrichmentManifest")
     if not manifest_path:
         return None, error_response(404, "No enrichment data for this pipeline run", req=req)

--- a/blueprints/_helpers.py
+++ b/blueprints/_helpers.py
@@ -242,7 +242,7 @@ async def fetch_enrichment_manifest(
     extracting the manifest path.
     """
     try:
-        check_auth(req)
+        _, caller_user_id = check_auth(req)
     except ValueError as exc:
         return None, error_response(401, str(exc), req=req)
 
@@ -252,6 +252,12 @@ async def fetch_enrichment_manifest(
 
     status = await client.get_status(instance_id)
     if not status or not status.output:
+        return None, error_response(404, "Pipeline not found or not complete", req=req)
+
+    # Verify the authenticated user owns this orchestration
+    inp = status.input_ if hasattr(status, "input_") else None
+    owner_id = inp.get("user_id", "") if isinstance(inp, dict) else ""
+    if not owner_id or owner_id != caller_user_id:
         return None, error_response(404, "Pipeline not found or not complete", req=req)
 
     output = status.output if isinstance(status.output, dict) else {}

--- a/blueprints/analysis.py
+++ b/blueprints/analysis.py
@@ -110,7 +110,7 @@ def _frame_logic(req: func.HttpRequest, context: dict) -> func.HttpResponse:
         date_val = _sanitise_for_prompt(context["date"])
         if date_val:
             context_lines.append(f"Date: {date_val}")
-    if context.get("latitude") and context.get("longitude"):
+    if context.get("latitude") is not None and context.get("longitude") is not None:
         context_lines.append(f"Location: {context['latitude']:.2f}, {context['longitude']:.2f}")
 
     context_lines.append("\n=== Vegetation Health ===")
@@ -118,9 +118,13 @@ def _frame_logic(req: func.HttpRequest, context: dict) -> func.HttpResponse:
         context_lines.append(f"NDVI (current): {context['ndvi_mean']:.3f}")
     if context.get("ndvi_previous") is not None:
         context_lines.append(f"NDVI (previous): {context['ndvi_previous']:.3f}")
-        ndvi_change = context["ndvi_mean"] - context["ndvi_previous"]
-        pct = ndvi_change / context["ndvi_previous"] * 100
-        context_lines.append(f"NDVI Change: {ndvi_change:+.3f} ({pct:+.1f}%)")
+        if context.get("ndvi_mean") is not None:
+            ndvi_change = context["ndvi_mean"] - context["ndvi_previous"]
+            if context["ndvi_previous"] != 0:
+                pct = ndvi_change / context["ndvi_previous"] * 100
+                context_lines.append(f"NDVI Change: {ndvi_change:+.3f} ({pct:+.1f}%)")
+            else:
+                context_lines.append(f"NDVI Change: {ndvi_change:+.3f}")
     if context.get("ndvi_min") is not None:
         context_lines.append(f"NDVI Range: {context['ndvi_min']:.3f} to {context['ndvi_max']:.3f}")
 
@@ -245,7 +249,7 @@ def _timelapse_logic(req: func.HttpRequest, context: dict) -> func.HttpResponse:
         end = _sanitise_for_prompt(context["date_range_end"])
         if start and end:
             context_lines.append(f"Analysis Period: {start} to {end}")
-    if context.get("latitude") and context.get("longitude"):
+    if context.get("latitude") is not None and context.get("longitude") is not None:
         context_lines.append(f"Location: {context['latitude']:.2f}, {context['longitude']:.2f}")
 
     n_frames = context.get("frame_count", len(ndvi_series))

--- a/blueprints/analysis.py
+++ b/blueprints/analysis.py
@@ -125,7 +125,7 @@ def _frame_logic(req: func.HttpRequest, context: dict) -> func.HttpResponse:
                 context_lines.append(f"NDVI Change: {ndvi_change:+.3f} ({pct:+.1f}%)")
             else:
                 context_lines.append(f"NDVI Change: {ndvi_change:+.3f}")
-    if context.get("ndvi_min") is not None:
+    if context.get("ndvi_min") is not None and context.get("ndvi_max") is not None:
         context_lines.append(f"NDVI Range: {context['ndvi_min']:.3f} to {context['ndvi_max']:.3f}")
 
     context_lines.append("\n=== Weather Context ===")

--- a/blueprints/demo.py
+++ b/blueprints/demo.py
@@ -111,6 +111,7 @@ def demo_artifacts(req: func.HttpRequest) -> func.HttpResponse:
         body=data,
         status_code=200,
         mimetype=content_type,
+        headers=cors_headers(req),
     )
 
 
@@ -179,7 +180,10 @@ def cors_proxy(req: func.HttpRequest) -> func.HttpResponse:
             allow_redirects=False,
             stream=True,
         )
-        body = resp.raw.read(_PROXY_MAX_RESPONSE_BYTES + 1)
+        try:
+            body = resp.raw.read(_PROXY_MAX_RESPONSE_BYTES + 1)
+        finally:
+            resp.close()
         if len(body) > _PROXY_MAX_RESPONSE_BYTES:
             return error_response(502, "Upstream response too large", req=req)
         hdrs = cors_headers(req)

--- a/blueprints/pipeline/orchestrator.py
+++ b/blueprints/pipeline/orchestrator.py
@@ -471,6 +471,18 @@ def _phase_enrichment(
     return enrichment
 
 
+def _safe_release_quota(context: df.DurableOrchestrationContext, user_id: str, instance_id: str):
+    """Release quota on failure, swallowing errors to preserve the original exception."""
+    try:
+        yield context.call_activity(
+            "release_quota", {"user_id": user_id, "instance_id": instance_id}
+        )
+    except Exception:
+        logger.exception(
+            "Failed to release quota during error handling for instance=%s", instance_id
+        )
+
+
 # ---------------------------------------------------------------------------
 # Coordinator
 # ---------------------------------------------------------------------------
@@ -511,7 +523,5 @@ def treesight_orchestrator(context: df.DurableOrchestrationContext):  # type: ig
         return summary
     except Exception:
         if user_id and tier != "demo":
-            yield context.call_activity(
-                "release_quota", {"user_id": user_id, "instance_id": instance_id}
-            )
+            yield from _safe_release_quota(context, user_id, instance_id)
         raise

--- a/blueprints/pipeline/orchestrator.py
+++ b/blueprints/pipeline/orchestrator.py
@@ -471,7 +471,9 @@ def _phase_enrichment(
     return enrichment
 
 
-def _safe_release_quota(context: df.DurableOrchestrationContext, user_id: str, instance_id: str):
+def _safe_release_quota(
+    context: df.DurableOrchestrationContext, user_id: str, instance_id: str
+) -> Generator[Any, Any, None]:
     """Release quota on failure, swallowing errors to preserve the original exception."""
     try:
         yield context.call_activity(

--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -288,6 +288,7 @@ def upload_status(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> 
                 {"name": "@sid", "value": submission_id},
                 {"name": "@uid", "value": user_id},
             ],
+            partition_key=user_id,
         )
     except Exception:
         logger.exception("Cosmos query failed for submission_id=%s", submission_id)

--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -277,13 +277,17 @@ def upload_status(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> 
     except ValueError:
         return error_response(400, "Invalid submission_id format", req=req)
 
-    # Read status from Cosmos runs container
+    # Read status from Cosmos runs container (scoped to authenticated user)
     try:
         records = _cosmos_mod.query_items(
             "runs",
             "SELECT c.submission_id, c.status, c.submitted_at, c.feature_count,"
-            " c.aoi_count FROM c WHERE c.submission_id = @sid",
-            parameters=[{"name": "@sid", "value": submission_id}],
+            " c.aoi_count FROM c WHERE c.submission_id = @sid"
+            " AND c.user_id = @uid",
+            parameters=[
+                {"name": "@sid", "value": submission_id},
+                {"name": "@uid", "value": user_id},
+            ],
         )
     except Exception:
         logger.exception("Cosmos query failed for submission_id=%s", submission_id)

--- a/treesight/parsers/fiona_parser.py
+++ b/treesight/parsers/fiona_parser.py
@@ -79,6 +79,7 @@ def _coords_to_feature(
     name, description = _extract_name_description(props, index)
     metadata = _extract_metadata(props)
     exterior = _ensure_closed(exterior)
+    interior = [_ensure_closed(ring) for ring in interior]
 
     return Feature(
         name=name,

--- a/treesight/parsers/lxml_parser.py
+++ b/treesight/parsers/lxml_parser.py
@@ -34,6 +34,7 @@ def parse_kml_lxml(kml_bytes: bytes, source_file: str = "") -> list[Feature]:
                 logger.warning("Skipping polygon with < 3 coords: %s", name)
                 continue
             exterior = _ensure_closed(exterior)
+            interior = [_ensure_closed(ring) for ring in interior]
             features.append(
                 Feature(
                     name=name,

--- a/treesight/pipeline/ingestion.py
+++ b/treesight/pipeline/ingestion.py
@@ -29,11 +29,14 @@ def parse_kml_from_blob(blob_event: BlobEvent, storage: BlobStorageClient) -> li
     if not blob_event.blob_name:
         raise ValueError("blob_event.blob_name must not be empty")
 
-    from treesight.parsers import maybe_unzip
+    from treesight.parsers import maybe_unzip, validate_kml_bytes
 
     raw_bytes = storage.download_bytes(blob_event.container_name, blob_event.blob_name)
     kml_bytes = maybe_unzip(raw_bytes)
     source_file = PurePosixPath(blob_event.blob_name).name
+
+    # Reject malformed or dangerous XML before parser dispatch
+    validate_kml_bytes(kml_bytes)
 
     # Try Fiona first, fall back to lxml
     try:

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -217,7 +217,7 @@
             <div class="app-detail-card">
               <span class="app-content-label">Run Link</span>
               <strong id="app-run-link-label">Dashboard state</strong>
-              <a class="app-inline-link" id="app-run-link" href="/app/">Open run details</a>
+              <a class="app-inline-link" id="app-run-link" href="/app/">Copy run link</a>
             </div>
           </div>
         </article>

--- a/website/index.html
+++ b/website/index.html
@@ -299,6 +299,11 @@
       <textarea id="ea-usecase" placeholder="Describe your geospatial imagery needs…" style="min-height:80px"></textarea>
       <label for="ea-email">Email</label>
       <input type="email" id="ea-email" placeholder="you@company.com">
+      <!-- Honeypot — hidden from real users, filled by bots -->
+      <div aria-hidden="true" style="position:absolute;left:-9999px">
+        <label for="ea-website">Website</label>
+        <input type="text" id="ea-website" tabindex="-1" autocomplete="off">
+      </div>
       <button class="btn btn-primary" id="ea-submit" style="width:100%">Submit</button>
       <div id="ea-status"></div>
     </div>

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -1783,7 +1783,7 @@
 
     linkLabelEl.textContent = 'Run details';
     linkEl.href = selectedRunPermalink(data.instanceId || data.instance_id, 'run');
-    linkEl.textContent = 'Open this run directly';
+    linkEl.textContent = 'Copy link to this run';
 
     document.querySelectorAll('[data-export-format]').forEach(function(button) {
       button.disabled = runtimeStatus !== 'Completed';
@@ -2846,6 +2846,21 @@
     revealWorkflowTarget(this.getAttribute('data-target') || currentPreferenceConfig().secondaryTarget);
   });
   document.getElementById('app-analysis-submit-btn').addEventListener('click', queueAnalysis);
+  document.getElementById('app-run-link').addEventListener('click', function(event) {
+    event.preventDefault();
+    const href = this.href;
+    if (!href) return;
+    const fullUrl = new URL(href, window.location.origin).href;
+    navigator.clipboard.writeText(fullUrl).then(function() {
+      const el = document.getElementById('app-run-link');
+      const prev = el.textContent;
+      el.textContent = 'Link copied!';
+      setTimeout(function() { el.textContent = prev; }, 1500);
+    }).catch(function() {
+      // Clipboard API blocked — open in same tab as fallback.
+      window.location.href = href;
+    });
+  });
   document.querySelectorAll('[data-export-format]').forEach(function(button) {
     button.addEventListener('click', function(event) {
       event.stopPropagation();

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -1805,7 +1805,7 @@
     }
 
     linkLabelEl.textContent = 'Run details';
-    linkEl.href = selectedRunPermalink(data.instanceId || data.instance_id, 'run');
+    linkEl.href = selectedRunPermalink(data.instanceId || data.instance_id);
     linkEl.textContent = 'Copy link to this run';
 
     document.querySelectorAll('[data-export-format]').forEach(function(button) {

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -2882,19 +2882,29 @@
   });
   document.getElementById('app-analysis-submit-btn').addEventListener('click', queueAnalysis);
   document.getElementById('app-run-link').addEventListener('click', function(event) {
-    event.preventDefault();
     const href = this.href;
     if (!href) return;
+    if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
+      return; // Let normal navigation proceed
+    }
     const fullUrl = new URL(href, window.location.origin).href;
-    navigator.clipboard.writeText(fullUrl).then(function() {
-      const el = document.getElementById('app-run-link');
-      const prev = el.textContent;
-      el.textContent = 'Link copied!';
-      setTimeout(function() { el.textContent = prev; }, 1500);
-    }).catch(function() {
-      // Clipboard API blocked — open in same tab as fallback.
+    event.preventDefault();
+    const el = document.getElementById('app-run-link');
+    try {
+      navigator.clipboard.writeText(fullUrl).then(function() {
+        if (el._copyTimer) clearTimeout(el._copyTimer);
+        const prev = el.textContent;
+        el.textContent = 'Link copied!';
+        el._copyTimer = setTimeout(function() {
+          if (el.textContent === 'Link copied!') el.textContent = prev;
+          el._copyTimer = null;
+        }, 1500);
+      }).catch(function() {
+        window.location.href = href;
+      });
+    } catch (_) {
       window.location.href = href;
-    });
+    }
   });
   document.querySelectorAll('[data-export-format]').forEach(function(button) {
     button.addEventListener('click', function(event) {

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -161,6 +161,7 @@
   let workspaceRole = 'conservation';
   let workspacePreference = 'investigate';
   let activeAnalysisPoll = null;
+  let analysisPollGeneration = 0; // incremented on each pollAnalysisRun call to detect stale callbacks
   const ANALYSIS_PHASES = ['submit', 'ingestion', 'acquisition', 'fulfilment', 'enrichment', 'complete'];
   const ANALYSIS_PHASE_DETAILS = {
     submit: 'Uploading your KML and reserving a pipeline worker for this run.',
@@ -241,6 +242,14 @@
     const resp = await fetch(url, opts);
     if (!resp.ok) {
       const body = await resp.json().catch(function () { return {}; });
+      if (resp.status === 401 && authEnabled()) {
+        // Session expired — clear local auth state and prompt re-login.
+        currentAccount = null;
+        _clientPrincipal = null;
+        updateAuthUI();
+        setAnalysisStatus('Your session has expired. Please sign in again.', 'error');
+        stopAnalysisPolling();
+      }
       const msg = body.error || ('API request failed: ' + resp.status + ' ' + resp.statusText);
       const err = new Error(msg);
       err.status = resp.status;
@@ -737,6 +746,8 @@
     updateRunSelectionLocation(instanceId);
 
     stopAnalysisPolling();
+    // Stop any running timelapse animation from a previous run.
+    if (evidencePlayInterval) { clearInterval(evidencePlayInterval); evidencePlayInterval = null; }
     updateAnalysisRun(run);
     resetAnalysisProgress();
     setAnalysisProgressVisible(true);
@@ -919,8 +930,12 @@
     try {
       await apiDiscoveryReady;
       var manifestRes = await apiFetch('/api/timelapse-data/' + encodeURIComponent(instanceId));
-      evidenceManifest = await manifestRes.json();
+      var manifest = await manifestRes.json();
+      // Guard: user may have switched runs while we were fetching.
+      if (evidenceInstanceId !== instanceId) return;
+      evidenceManifest = manifest;
     } catch (err) {
+      if (evidenceInstanceId !== instanceId) return;
       if (footerEl) footerEl.textContent = 'Could not load enrichment data: ' + ((err && err.message) || 'unknown error');
       return;
     }
@@ -1452,7 +1467,12 @@
         aiBlock.hidden = false;
         renderEvidenceAnalysis(evidenceAnalysis);
       }
-    } catch (e) { /* ignore — no saved analysis yet */ }
+    } catch (e) {
+      // 404 = no saved analysis yet (expected). Other errors indicate a real problem.
+      if (e && e.status && e.status !== 404) {
+        console.warn('Failed to load saved analysis:', e.message || e);
+      }
+    }
   }
 
   async function requestAiAnalysis() {
@@ -1514,12 +1534,15 @@
       evidenceAnalysis = await res.json();
       renderEvidenceAnalysis(evidenceAnalysis);
 
-      // Save the analysis
+      // Save the analysis (non-blocking but warn user on failure)
       apiFetch('/api/timelapse-analysis-save', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ instance_id: evidenceInstanceId, analysis: evidenceAnalysis })
-      }).catch(function() {});
+      }).catch(function() {
+        var saveWarn = document.getElementById('app-evidence-ai-content');
+        if (saveWarn) saveWarn.appendChild(createCallout('warning', 'Analysis displayed but could not be saved. It will be lost on reload.'));
+      });
     } catch (err) {
       content.textContent = '';
       content.appendChild(createCallout('error', (err && err.message) || 'Could not run AI analysis.'));
@@ -2320,10 +2343,19 @@
 
   async function pollAnalysisRun(instanceId) {
     stopAnalysisPolling();
+    const thisGeneration = ++analysisPollGeneration;
+    let consecutiveFailures = 0;
+    const MAX_CONSECUTIVE_FAILURES = 5;
+
     async function refreshRun() {
+      // Bail out if a newer poll has started while we were awaiting.
+      if (analysisPollGeneration !== thisGeneration) return null;
       try {
         var res = await apiFetch('/api/orchestrator/' + instanceId);
         var data = await res.json();
+        consecutiveFailures = 0;
+        // Re-check after await — another selectAnalysisRun may have fired.
+        if (analysisPollGeneration !== thisGeneration) return null;
         upsertAnalysisHistoryRun(data);
         updateAnalysisRun(data);
 
@@ -2358,11 +2390,17 @@
         }
         return data;
       } catch {
+        consecutiveFailures++;
+        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+          stopAnalysisPolling();
+          setAnalysisStatus('Connection lost — pipeline updates have stopped. Reload the page to resume.', 'error');
+        }
         return null;
       }
     }
 
     var initialData = await refreshRun();
+    if (analysisPollGeneration !== thisGeneration) return; // superseded during initial fetch
     if (initialData) {
       var initialRuntime = initialData.runtimeStatus || '';
       if (initialRuntime === 'Completed' || initialRuntime === 'Failed' || initialRuntime === 'Canceled' || initialRuntime === 'Terminated') {
@@ -2441,12 +2479,9 @@
           body: JSON.stringify(tokenBody)
         });
       } catch (tokenFetchErr) {
+        // 401 is handled centrally by apiFetch (clears session, shows re-login prompt).
         if (tokenFetchErr.status === 401) {
-          // Session expired — redirect to login.
           resetAnalysisProgress();
-          currentAccount = null;
-          updateAuthUI();
-          setAnalysisStatus('Your session has expired. Please sign in again to queue an analysis.', 'error');
           return;
         }
         setAnalysisStatus(tokenFetchErr.body && tokenFetchErr.body.error || 'Could not prepare upload. Please try again.', 'error');

--- a/website/js/landing.js
+++ b/website/js/landing.js
@@ -167,7 +167,8 @@
             organisation: org,
             use_case: useCase,
             email: email,
-            source: 'marketing_website'
+            source: 'marketing_website',
+            website: honeypot ? honeypot.value : ''
           })
         });
 

--- a/website/js/landing.js
+++ b/website/js/landing.js
@@ -131,7 +131,18 @@
       const org = document.getElementById('ea-org').value.trim();
       const useCase = document.getElementById('ea-usecase').value.trim();
       const email = document.getElementById('ea-email').value.trim();
+      const honeypot = document.getElementById('ea-website');
       const status = document.getElementById('ea-status');
+
+      // Honeypot filled → silently pretend success (bot detected)
+      if (honeypot && honeypot.value) {
+        if (status) {
+          status.textContent = 'Thanks! We\'ll be in touch.';
+          status.className = 'show';
+          status.style.color = 'var(--c-green)';
+        }
+        return;
+      }
 
       if (!org || !email) {
         if (status) {


### PR DESCRIPTION
## Summary

Four rounds of bug fixes covering the frontend dashboard and backend API/pipeline.

### Commit 1 — Run link reload/logout fix
- **Run permalink** now copies to clipboard instead of navigating (full-page reload was clearing SWA auth cookies and logging users out)

### Commit 2 — Frontend hardening (7 fixes)
- Centralised 401 handling in `apiFetch` (removed duplicate in upload-token)
- Polling race condition fix with generation counter
- Connection-lost feedback after 5 consecutive poll failures
- Stale evidence render guard after run switch
- Clear timelapse play interval on run switch
- AI analysis save failure warning
- Distinguish 404 vs server errors in `loadSavedAnalysis`

### Commit 3 — Backend security + data integrity (7 fixes)
**Security:**
- `upload_status` IDOR: scope Cosmos query to authenticated `user_id`
- `fetch_enrichment_manifest` IDOR: verify orchestrator `user_id` matches caller before returning data
- Ingestion XXE: call `validate_kml_bytes()` before parser dispatch

**Data integrity:**
- `analysis.py`: guard `ndvi_mean` existence before computing change, prevent div-by-zero when `ndvi_previous=0`, use `is not None` for lat/lon to preserve 0-valued coordinates
- `fiona_parser`: close interior polygon rings (was only closing exterior)

**Reliability:**
- Demo proxy: close streamed response to prevent socket leak
- Demo artifacts: add missing CORS headers

### Commit 4 — Additional hardening + anti-abuse (5 fixes)
**Data integrity:**
- `lxml_parser`: close interior polygon rings (matching fiona fix)
- `analysis.py`: guard `ndvi_max` existence before range formatting

**Reliability:**
- Orchestrator: wrap `release_quota` in try/except so failures don't mask the original pipeline error
- `fetch_enrichment_manifest`: handle JSON-string output from Durable Functions SDK (prevents spurious 404 on export)

**Anti-abuse (fixes #571):**
- Contact form honeypot: hidden field detected client-side and server-side — bots get a fake 200, no storage write

### Testing
- All 1128 tests pass after each commit
- `ruff check` + `ruff format` clean
- Pre-commit hooks pass (pyright, secrets, etc.)

### Files changed
- `website/js/app-shell.js`
- `website/app/index.html`
- `website/index.html`
- `website/js/landing.js`
- `blueprints/analysis.py`
- `blueprints/upload.py`
- `blueprints/_helpers.py`
- `blueprints/demo.py`
- `blueprints/pipeline/orchestrator.py`
- `treesight/pipeline/ingestion.py`
- `treesight/parsers/fiona_parser.py`
- `treesight/parsers/lxml_parser.py`