### PR TITLE
feat: stale-while-revalidate localStorage caching

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,12 +36,12 @@ See `docs/ARCHITECTURE_OVERVIEW.md` § "Entry Point" for details.
 
 | PR | Summary |
 |----|---------|
+| #594 | Roadmap update: recently landed PRs #576, #577, #591, #592 |
 | #592 | Frontend + backend hardening: auth, IDOR, data integrity, anti-abuse, reliability (fixes #571) |
 | #591 | Roadmap update + 56-polygon KML test fixture |
 | #577 | Dependabot: pytest bump |
 | #576 | Dependabot: pillow bump |
 | #568 | Security review batch: discovery files (robots.txt, sitemap.xml, security.txt), X-XSS-Protection, X-Robots-Tag |
-| #567 | Remove focus emphasis system from dashboard (competing scroll, dead code cleanup) |
 
 ---
 

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -172,6 +172,51 @@
     complete: 'Analysis complete — scroll down to review satellite imagery, vegetation health, and export options.'
   };
 
+  // ---------------------------------------------------------------------------
+  // localStorage stale-while-revalidate cache (#596)
+  // Render cached data instantly, then refresh in background.
+  // ---------------------------------------------------------------------------
+  const CACHE_PREFIX = 'canopex:';
+  const CACHE_TTL_HISTORY = 5 * 60 * 1000;   // 5 min
+  const CACHE_TTL_BILLING = 30 * 60 * 1000;  // 30 min
+
+  function readCache(key) {
+    try {
+      const raw = localStorage.getItem(CACHE_PREFIX + key);
+      if (!raw) return null;
+      const entry = JSON.parse(raw);
+      if (!entry || typeof entry.expires !== 'number' || Date.now() > entry.expires) {
+        localStorage.removeItem(CACHE_PREFIX + key);
+        return null;
+      }
+      return entry.data;
+    } catch { return null; }
+  }
+
+  function writeCache(key, data, ttlMs) {
+    try {
+      localStorage.setItem(CACHE_PREFIX + key, JSON.stringify({
+        data: data,
+        expires: Date.now() + ttlMs
+      }));
+    } catch { /* quota exceeded or private browsing — degrade gracefully */ }
+  }
+
+  function clearCacheKey(key) {
+    try { localStorage.removeItem(CACHE_PREFIX + key); } catch { /* ignore */ }
+  }
+
+  function clearAllCache() {
+    try {
+      const keys = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const k = localStorage.key(i);
+        if (k && k.startsWith(CACHE_PREFIX)) keys.push(k);
+      }
+      keys.forEach(function(k) { localStorage.removeItem(k); });
+    } catch { /* ignore */ }
+  }
+
   function authEnabled() { return true; /* SWA built-in auth — always available */ }
 
   function rememberPostLoginDestination() {
@@ -222,6 +267,7 @@
   }
 
   function logout() {
+    clearAllCache();
     try { sessionStorage.removeItem(POST_LOGIN_DESTINATION_KEY); } catch { /* ignore */ }
     window.location.href = '/.auth/logout';
   }
@@ -2366,6 +2412,8 @@
           stopAnalysisPolling();
           setAnalysisStep('complete', 'done');
           updateAnalysisStory('complete', runtime, data);
+          clearCacheKey('billing');
+          clearCacheKey('history');
           loadBillingStatus();
           loadAnalysisHistory({ preferInstanceId: instanceId });
           loadRunEvidence(instanceId);
@@ -2514,6 +2562,8 @@
       }
 
       // Step 3: Track the submission
+      clearCacheKey('history');
+      clearCacheKey('billing');
       var data = { instance_id: submissionId };
       analysisHistoryLoaded = true;
       applyFirstRunLayout();
@@ -2678,6 +2728,7 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ tier: select.value })
       });
+      clearCacheKey('billing');
       applyBillingStatus(await res.json());
     } catch (err) {
       alert((err && err.message) || 'Could not update plan emulation. Please try again.');
@@ -2691,17 +2742,26 @@
     await apiDiscoveryReady;
     if (!currentAccount) return;
 
+    // Render cached billing data instantly while fetching fresh data
+    const cached = readCache('billing');
+    if (cached) applyBillingStatus(cached);
+
     try {
-      var res = await apiFetch('/api/billing/status');
-      applyBillingStatus(await res.json());
+      const res = await apiFetch('/api/billing/status');
+      const data = await res.json();
+      writeCache('billing', data, CACHE_TTL_BILLING);
+      applyBillingStatus(data);
     } catch {
-      document.getElementById('app-tier').textContent = 'Unknown';
-      document.getElementById('app-subscription-status').textContent = 'Unavailable';
-      document.getElementById('app-runs-remaining').textContent = '—';
-      document.getElementById('app-billing-note').textContent = 'Could not load billing state';
-      document.getElementById('app-manage-billing-btn').style.display = 'none';
-      updateCapabilityFields({});
-      setHeroRunSummary('Ready to queue', 'Billing is unavailable, but analysis can still be launched locally.');
+      // Only show error state if we had no cached data to show
+      if (!cached) {
+        document.getElementById('app-tier').textContent = 'Unknown';
+        document.getElementById('app-subscription-status').textContent = 'Unavailable';
+        document.getElementById('app-runs-remaining').textContent = '—';
+        document.getElementById('app-billing-note').textContent = 'Could not load billing state';
+        document.getElementById('app-manage-billing-btn').style.display = 'none';
+        updateCapabilityFields({});
+        setHeroRunSummary('Ready to queue', 'Billing is unavailable, but analysis can still be launched locally.');
+      }
     }
   }
 
@@ -2709,14 +2769,24 @@
     await apiDiscoveryReady;
     if (!currentAccount && authEnabled()) return;
 
-    try {
-      var res = await apiFetch('/api/analysis/history?limit=6');
+    // Render cached history instantly while fetching fresh data
+    const cached = readCache('history');
+    if (cached && !analysisHistoryLoaded) {
       analysisHistoryLoaded = true;
-      applyAnalysisHistory(await res.json(), options || {});
+      applyAnalysisHistory(cached, options || {});
+      applyFirstRunLayout();
+    }
+
+    try {
+      const res = await apiFetch('/api/analysis/history?limit=6');
+      const data = await res.json();
+      writeCache('history', data, CACHE_TTL_HISTORY);
+      analysisHistoryLoaded = true;
+      applyAnalysisHistory(data, options || {});
       applyFirstRunLayout();
     } catch {
       analysisHistoryLoaded = true;
-      if (!analysisHistoryRuns.length && !latestAnalysisRun) {
+      if (!cached && !analysisHistoryRuns.length && !latestAnalysisRun) {
         analysisHistoryRuns = [];
         selectedAnalysisRunId = null;
         renderAnalysisHistoryList();

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -175,18 +175,26 @@
   // ---------------------------------------------------------------------------
   // localStorage stale-while-revalidate cache (#596)
   // Render cached data instantly, then refresh in background.
+  // Keys are scoped per-user to prevent cross-account data leakage.
   // ---------------------------------------------------------------------------
   const CACHE_PREFIX = 'canopex:';
   const CACHE_TTL_HISTORY = 5 * 60 * 1000;   // 5 min
   const CACHE_TTL_BILLING = 30 * 60 * 1000;  // 30 min
 
+  function cacheKey(key) {
+    const uid = currentAccount && currentAccount.userId;
+    return uid ? CACHE_PREFIX + uid + ':' + key : null;
+  }
+
   function readCache(key) {
     try {
-      const raw = localStorage.getItem(CACHE_PREFIX + key);
+      const full = cacheKey(key);
+      if (!full) return null;
+      const raw = localStorage.getItem(full);
       if (!raw) return null;
       const entry = JSON.parse(raw);
       if (!entry || typeof entry.expires !== 'number' || Date.now() > entry.expires) {
-        localStorage.removeItem(CACHE_PREFIX + key);
+        localStorage.removeItem(full);
         return null;
       }
       return entry.data;
@@ -194,8 +202,11 @@
   }
 
   function writeCache(key, data, ttlMs) {
+    if (!Number.isFinite(ttlMs)) return;
     try {
-      localStorage.setItem(CACHE_PREFIX + key, JSON.stringify({
+      const full = cacheKey(key);
+      if (!full) return;
+      localStorage.setItem(full, JSON.stringify({
         data: data,
         expires: Date.now() + ttlMs
       }));
@@ -203,7 +214,10 @@
   }
 
   function clearCacheKey(key) {
-    try { localStorage.removeItem(CACHE_PREFIX + key); } catch { /* ignore */ }
+    try {
+      const full = cacheKey(key);
+      if (full) localStorage.removeItem(full);
+    } catch { /* ignore */ }
   }
 
   function clearAllCache() {


### PR DESCRIPTION
## Summary

Renders cached billing and analysis history data instantly on page load, then refreshes in the background. Eliminates the jarring blank-then-populate flash on the dashboard.

Closes #596

## Changes

### Cache helpers
- `readCache(key)` — reads from `localStorage`, checks TTL expiry, auto-removes stale entries
- `writeCache(key, data, ttlMs)` — writes JSON envelope `{data, expires}`, catches quota errors
- `clearCacheKey(key)` — removes a single prefixed key
- `clearAllCache()` — removes all `canopex:*` keys

### Caching integration
| Data | TTL | Rationale |
|------|-----|-----------|
| Billing status | 30 min | Changes infrequently (plan changes, run completion) |
| Analysis history | 5 min | Changes on submission or completion |
| Run detail | **Not cached** | Poll-driven; caching would cause stale UI during active runs |

### Cache invalidation triggers
| Event | Keys invalidated |
|-------|-----------------|
| Logout | All (`clearAllCache`) |
| New submission | `history`, `billing` |
| Run completion | `billing`, `history` |
| Tier emulation change | `billing` |

### Error handling
- If fetch fails but cache exists → user sees cached data (no error flash)
- If fetch fails and no cache → original error UI shown
- `localStorage` quota exceeded or private browsing → degrades gracefully (no cache, no crash)

## Testing
- All 1113 tests pass, 28 skipped
- Ruff check + format clean
- No backend changes