### PR TITLE
fix: re-enable Cosmos DB public network access (#621)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,12 +32,12 @@ Stages 2D and 2E can proceed in parallel.
 
 | PR | Summary |
 |----|---------|
+| #623 | Use lxml instead of stdlib xml for KML generation — resolves Semgrep #2869 |
 | #622 | Re-enable Cosmos DB public network access — fixes 24h alert storm (fixes #621) |
 | #620 | aoi_limit enforcement, AOI count fix, EUDR date filter, data models, per-AOI enrichment, orgs, JS decomposition (#575, #580, #600, #583, #578, #614, #611) |
 | #597 | Stale-while-revalidate localStorage caching for billing + history (fixes #596) |
 | #594 | Roadmap update: recently landed PRs #576, #577, #591, #592 |
 | #592 | Frontend + backend hardening: auth, IDOR, data integrity, anti-abuse (fixes #571) |
-| #591 | Roadmap update + 56-polygon KML test fixture |
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,13 +32,12 @@ Stages 2D and 2E can proceed in parallel.
 
 | PR | Summary |
 |----|---------|
-| #620 | aoi_limit, AOI count, EUDR date filter, data models, per-AOI enrichment (#575, #580, #600, #583, #578) |
-| #620 | Enforce `aoi_limit` at submission time per plan tier (fixes #575) |
+| #622 | Re-enable Cosmos DB public network access — fixes 24h alert storm (fixes #621) |
+| #620 | aoi_limit enforcement, AOI count fix, EUDR date filter, data models, per-AOI enrichment, orgs, JS decomposition (#575, #580, #600, #583, #578, #614, #611) |
 | #597 | Stale-while-revalidate localStorage caching for billing + history (fixes #596) |
 | #594 | Roadmap update: recently landed PRs #576, #577, #591, #592 |
 | #592 | Frontend + backend hardening: auth, IDOR, data integrity, anti-abuse (fixes #571) |
 | #591 | Roadmap update + 56-polygon KML test fixture |
-| #577 | Dependabot: pytest bump |
 
 ---
 

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -429,8 +429,31 @@ resource "azurerm_cosmosdb_account" "main" {
   local_authentication_disabled         = true     # Disable key-based auth; RBAC only
   public_network_access_enabled         = true     # Required — Container Apps FA has no private endpoint
   minimal_tls_version                   = "Tls12"
-  network_acl_bypass_for_azure_services = true     # Allow Azure services (Functions, Portal diagnostics)
-  ip_range_filter                       = []       # TODO: restrict to FA outbound IPs once stable
+  network_acl_bypass_for_azure_services = true     # Portal/diagnostics only; does NOT cover Container Apps public-egress path
+  ip_range_filter                       = []       # Managed by azapi_update_resource.cosmos_ip_rules below
+
+  lifecycle {
+    ignore_changes = [ip_range_filter] # Managed by azapi_update_resource after FA creation
+  }
+}
+
+# Restrict Cosmos DB firewall to FA outbound IPs.  Applied as a separate
+# update resource to avoid a circular dependency: FA body → Cosmos endpoint,
+# Cosmos ip_range_filter → FA outbound IPs.
+resource "azapi_update_resource" "cosmos_ip_rules" {
+  count       = var.enable_cosmos_db ? 1 : 0
+  type        = "Microsoft.DocumentDB/databaseAccounts@2024-11-15"
+  resource_id = azurerm_cosmosdb_account.main[0].id
+
+  body = {
+    properties = {
+      ipRules = [
+        for ip in split(",", azapi_resource.function_app.output.properties.possibleOutboundIpAddresses) : {
+          ipAddressOrRange = ip
+        }
+      ]
+    }
+  }
 }
 
 resource "azurerm_cosmosdb_sql_database" "main" {
@@ -791,7 +814,7 @@ resource "azapi_resource" "function_app" {
     }
   }
 
-  response_export_values = ["id", "name", "properties.defaultHostName"]
+  response_export_values = ["id", "name", "properties.defaultHostName", "properties.possibleOutboundIpAddresses"]
 }
 
 resource "azurerm_static_web_app" "main" {

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -427,19 +427,22 @@ resource "azurerm_cosmosdb_account" "main" {
 
   # --- Security hardening ---
   local_authentication_disabled         = true     # Disable key-based auth; RBAC only
-  public_network_access_enabled         = true     # Required — Container Apps FA has no private endpoint
+  public_network_access_enabled         = false    # Safe default; enabled atomically with IP rules by azapi_update_resource below
   minimal_tls_version                   = "Tls12"
   network_acl_bypass_for_azure_services = true     # Portal/diagnostics only; does NOT cover Container Apps public-egress path
   ip_range_filter                       = []       # Managed by azapi_update_resource.cosmos_ip_rules below
 
   lifecycle {
-    ignore_changes = [ip_range_filter] # Managed by azapi_update_resource after FA creation
+    ignore_changes = [public_network_access_enabled, ip_range_filter]
   }
 }
 
-# Restrict Cosmos DB firewall to FA outbound IPs.  Applied as a separate
-# update resource to avoid a circular dependency: FA body → Cosmos endpoint,
-# Cosmos ip_range_filter → FA outbound IPs.
+# Enable Cosmos public access AND restrict firewall to FA outbound IPs
+# in a single atomic ARM call.  Applied as a separate update resource to
+# avoid a circular dependency: FA body → Cosmos endpoint, Cosmos
+# ip_range_filter → FA outbound IPs.  The base resource defaults to
+# publicNetworkAccess=Disabled so Cosmos is never publicly reachable
+# without an IP allowlist.
 resource "azapi_update_resource" "cosmos_ip_rules" {
   count       = var.enable_cosmos_db ? 1 : 0
   type        = "Microsoft.DocumentDB/databaseAccounts@2024-11-15"
@@ -447,6 +450,7 @@ resource "azapi_update_resource" "cosmos_ip_rules" {
 
   body = {
     properties = {
+      publicNetworkAccess = "Enabled"
       ipRules = [
         for ip in split(",", azapi_resource.function_app.output.properties.possibleOutboundIpAddresses) : {
           ipAddressOrRange = ip

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -397,7 +397,7 @@ resource "azurerm_cognitive_deployment" "gpt4o_mini" {
 
 # --- Cosmos DB for NoSQL — Serverless (M4 state persistence) ---
 # Security posture:
-#   - Public network access disabled (access via Azure backbone only)
+#   - Public network access enabled (Container Apps FA connects over public internet)
 #   - Local (key-based) authentication disabled — Entra ID RBAC only
 #   - TLS 1.2 enforced
 #   - Function App uses Managed Identity with Cosmos DB Built-in Data Contributor role
@@ -426,11 +426,11 @@ resource "azurerm_cosmosdb_account" "main" {
   }
 
   # --- Security hardening ---
-  local_authentication_disabled         = true  # Disable key-based auth; RBAC only
-  public_network_access_enabled         = false # No public internet access
+  local_authentication_disabled         = true     # Disable key-based auth; RBAC only
+  public_network_access_enabled         = true     # Required — Container Apps FA has no private endpoint
   minimal_tls_version                   = "Tls12"
-  network_acl_bypass_for_azure_services = true # Allow Azure services (Functions, Portal diagnostics)
-  ip_range_filter                       = []   # No IP allowlist needed — private access only
+  network_acl_bypass_for_azure_services = true     # Allow Azure services (Functions, Portal diagnostics)
+  ip_range_filter                       = []       # TODO: restrict to FA outbound IPs once stable
 }
 
 resource "azurerm_cosmosdb_sql_database" "main" {


### PR DESCRIPTION
## Fix: Cosmos DB firewall blocked Function App

### Problem

Cosmos DB account `cosmos-kmlsat-dev` had `publicNetworkAccess: Disabled`, blocking all requests from the Container Apps Function App (outbound IP `20.26.241.31`). Every Cosmos operation returned `403 Forbidden`.

**Impact:** 9 alert firings over 24h (5× `failed-requests` Sev2, 4× `eg-dropped-events` Sev1). User-facing failures: upload token, billing status, user reads, history queries, monitoring scheduler.

### Root cause

IaC set `public_network_access_enabled = false` during a security hardening pass. However, `network_acl_bypass_for_azure_services = true` does **not** cover Container Apps with public outbound IPs — it only works for services with VNet integration or private endpoints.

### Fix

- `public_network_access_enabled = true` (Container Apps FA has no private endpoint)
- Updated comments to reflect actual security posture
- Live fix already applied via `az cosmosdb update --public-network-access ENABLED`

### Follow-up (in #621)

- [ ] Add FA outbound IP(s) to `ip_range_filter` for defense-in-depth
- [ ] Evaluate private endpoint for Cosmos when justified by traffic/security
- [ ] Add Cosmos connectivity health check

### ⚠️ Approval-gated

This PR modifies OpenTofu infrastructure. Requires review before merge.

Fixes #621