### PR TITLE
feat: billing ledger, payment provider abstraction, run lifecycle (#589)

### DIFF
--- a/blueprints/pipeline/activities.py
+++ b/blueprints/pipeline/activities.py
@@ -434,3 +434,26 @@ def release_quota(payload: _Payload) -> dict[str, Any]:
         remaining,
     )
     return {"released": True, "remaining": remaining}
+
+
+@bp.activity_trigger(input_name="payload")
+def complete_billing(payload: _Payload) -> dict[str, Any]:
+    """Mark a run as charged in the billing ledger (#589)."""
+    from treesight.security.billing_ledger import complete_run_billing
+
+    user_id: str = payload["user_id"]
+    instance_id: str = payload["instance_id"]
+    complete_run_billing(user_id, instance_id)
+    return {"completed": True}
+
+
+@bp.activity_trigger(input_name="payload")
+def fail_billing(payload: _Payload) -> dict[str, Any]:
+    """Mark a run as refunded in the billing ledger (#589)."""
+    from treesight.security.billing_ledger import fail_run_billing
+
+    user_id: str = payload["user_id"]
+    instance_id: str = payload["instance_id"]
+    reason: str = payload.get("reason", "pipeline_failure")
+    fail_run_billing(user_id, instance_id, reason=reason)
+    return {"refunded": True}

--- a/blueprints/pipeline/orchestrator.py
+++ b/blueprints/pipeline/orchestrator.py
@@ -597,6 +597,42 @@ def _safe_release_quota(
         )
 
 
+def _safe_complete_billing(
+    context: df.DurableOrchestrationContext, user_id: str, instance_id: str
+) -> Generator[Any, Any, None]:
+    """Mark billing ledger as charged on success (#589)."""
+    billing_retry = df.RetryOptions(
+        first_retry_interval_in_milliseconds=ACTIVITY_RETRY_FIRST_INTERVAL_MS,
+        max_number_of_attempts=ACTIVITY_RETRY_MAX_ATTEMPTS,
+    )
+    try:
+        yield context.call_activity_with_retry(
+            "complete_billing",
+            billing_retry,
+            {"user_id": user_id, "instance_id": instance_id},
+        )
+    except Exception:
+        logger.exception("Failed to complete billing for instance=%s", instance_id)
+
+
+def _safe_fail_billing(
+    context: df.DurableOrchestrationContext, user_id: str, instance_id: str
+) -> Generator[Any, Any, None]:
+    """Mark billing ledger as refunded on failure (#589)."""
+    billing_retry = df.RetryOptions(
+        first_retry_interval_in_milliseconds=ACTIVITY_RETRY_FIRST_INTERVAL_MS,
+        max_number_of_attempts=ACTIVITY_RETRY_MAX_ATTEMPTS,
+    )
+    try:
+        yield context.call_activity_with_retry(
+            "fail_billing",
+            billing_retry,
+            {"user_id": user_id, "instance_id": instance_id, "reason": "pipeline_failure"},
+        )
+    except Exception:
+        logger.exception("Failed to record billing failure for instance=%s", instance_id)
+
+
 # ---------------------------------------------------------------------------
 # Progressive delivery — sub-orchestrator fan-out (#585)
 # ---------------------------------------------------------------------------
@@ -690,7 +726,6 @@ def treesight_orchestrator(context: df.DurableOrchestrationContext):  # type: ig
     instance_id, ctx = context.instance_id, derive_project_context(inp.get("blob_name", ""))
     user_id, tier = inp.get("user_id", ""), inp.get("tier", "")
     output_container = inp.get("output_container", DEFAULT_OUTPUT_CONTAINER)
-
     try:
         ing = yield from _phase_ingestion(context, inp, instance_id, ctx)
         acq_s, ful_s = yield from _dispatch_acq_ful(context, inp, ctx, ing, instance_id)
@@ -713,8 +748,11 @@ def treesight_orchestrator(context: df.DurableOrchestrationContext):  # type: ig
         if enrichment.get("manifest_path"):
             summary["enrichment_manifest"] = enrichment["manifest_path"]
             summary["enrichment_duration"] = enrichment.get("enrichment_duration_seconds")
+        if user_id and tier != "demo":
+            yield from _safe_complete_billing(context, user_id, instance_id)
         return summary
     except Exception:
         if user_id and tier != "demo":
             yield from _safe_release_quota(context, user_id, instance_id)
+            yield from _safe_fail_billing(context, user_id, instance_id)
         raise

--- a/blueprints/pipeline/submission.py
+++ b/blueprints/pipeline/submission.py
@@ -165,9 +165,17 @@ async def _submit_analysis_request(
     # transiently unavailable we log the error but still allow the
     # submission so a temporary outage doesn't block users.
     quota_consumed = False
+    billing_fields: dict[str, Any] = {}
     try:
         consume_quota(user_id)
         quota_consumed = True
+        # Classify the run for the billing ledger (#589).
+        try:
+            from treesight.security.billing_ledger import billing_fields_for_submission
+
+            billing_fields = billing_fields_for_submission(user_id)
+        except Exception:
+            logger.warning("Billing classification failed for user=%s", user_id, exc_info=True)
     except ValueError as exc:
         # Quota genuinely exhausted — hard block.
         return error_response(403, str(exc), req=req)
@@ -238,6 +246,7 @@ async def _submit_analysis_request(
             status="submitted",
             eudr_mode=eudr_mode is True,
             **ctx,
+            **billing_fields,
         )
         record = run.model_dump(exclude_none=True)
         _persist_submission_record(storage, record, user_id, submission_id)

--- a/blueprints/pipeline/submission.py
+++ b/blueprints/pipeline/submission.py
@@ -16,6 +16,7 @@ from blueprints._helpers import check_auth, cors_headers, cors_preflight, error_
 from treesight.constants import DEFAULT_INPUT_CONTAINER, DEFAULT_PROVIDER, MAX_KML_FILE_SIZE_BYTES
 from treesight.security.billing import get_effective_subscription, plan_capabilities
 from treesight.security.quota import consume_quota, release_quota
+from treesight.security.redact import redact_user_id as _redact
 
 from . import bp
 from .history import _extract_submission_context, _persist_submission_record
@@ -180,7 +181,10 @@ async def _submit_analysis_request(
         # Quota genuinely exhausted — hard block.
         return error_response(403, str(exc), req=req)
     except Exception:
-        logger.exception("Quota storage unavailable for user=%s — allowing submission", user_id)
+        logger.exception(
+            "Quota storage unavailable for user=%s — allowing submission",
+            _redact(user_id),
+        )
 
     try:
         body = req.get_json()

--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -184,9 +184,16 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
 
     # Consume quota upfront so the runs counter decrements immediately.
     quota_consumed = False
+    billing_fields: dict = {}
     try:
         consume_quota(user_id)
         quota_consumed = True
+        try:
+            from treesight.security.billing_ledger import billing_fields_for_submission
+
+            billing_fields = billing_fields_for_submission(user_id)
+        except Exception:
+            logger.warning("Billing classification failed for user=%s", user_id, exc_info=True)
     except ValueError as exc:
         return error_response(403, str(exc), req=req)
     except Exception:
@@ -249,6 +256,7 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
         status="submitted",
         eudr_mode=body.get("eudr_mode") is True,
         **ctx,
+        **billing_fields,
     )
     _persist_submission_record(submission_id, run.model_dump(exclude_none=True), user_id)
 

--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -25,6 +25,7 @@ from azure.storage.blob import (
 from treesight.config import STORAGE_ACCOUNT_NAME
 from treesight.constants import DEFAULT_INPUT_CONTAINER, DEFAULT_PROVIDER, MAX_KML_FILE_SIZE_BYTES
 from treesight.security.quota import consume_quota, release_quota
+from treesight.security.redact import redact_user_id as _redact
 from treesight.storage import cosmos as _cosmos_mod
 from treesight.storage.client import get_blob_service_client
 
@@ -197,7 +198,10 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
     except ValueError as exc:
         return error_response(403, str(exc), req=req)
     except Exception:
-        logger.exception("Quota storage unavailable for user=%s — allowing submission", user_id)
+        logger.exception(
+            "Quota storage unavailable for user=%s — allowing submission",
+            _redact(user_id),
+        )
 
     submission_id = str(uuid.uuid4())
     blob_name = f"analysis/{submission_id}.kml"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -126,10 +126,14 @@ Auth + billing security. Prerequisites for any paid product.
 |-------|-------|-------|--------|------------|
 | R.0 | #553 | Enforce REQUIRE_AUTH everywhere | ✅ PR #554 | — |
 | R.1 | #534 | Auth header verification (HMAC) | ✅ PR #620 | — |
-| R.2 | #535 | E2e Stripe billing flow on live site | Open | #520 |
-| R.3 | #406 | Reconcile docs with live routes | ✅ PR #615 | — |
-| R.4 | #589 | Billing ledger, metered overage, refunds | Open | R.2 |
+| R.2 | #589 | Billing ledger, metered overage, refunds | 🔄 Active | — |
+| R.3 | #535 | E2e Stripe billing flow on live site | Open | R.2 |
+| R.4 | #406 | Reconcile docs with live routes | ✅ PR #615 | — |
 | R.5 | #572 | Audit unauthenticated API endpoints | Open | — |
+
+Approach: billing ledger is provider-agnostic (PaymentProvider protocol).
+Stripe is one implementation behind the abstraction. Ledger + included/
+overage logic ships first; live Stripe verification (R.3) follows.
 
 **Exit:** Forged headers rejected. Free → paid upgrade → Stripe → quota
 increase works. Overage metered. Failed runs refunded. Docs match reality.

--- a/tests/test_billing_endpoints.py
+++ b/tests/test_billing_endpoints.py
@@ -173,8 +173,6 @@ class TestBillingCheckout:
     def test_anonymous_returns_401(self):
         from blueprints.billing import billing_checkout
 
-        req = _make_req(url="/api/billing/checkout")
-        # Override to remove the SWA principal header
         req = make_test_request(
             url="/api/billing/checkout",
             origin=_ALLOWED_ORIGIN,

--- a/tests/test_billing_ledger.py
+++ b/tests/test_billing_ledger.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from treesight.security.billing_ledger import (
     billing_fields_for_submission,
     classify_run,
@@ -183,8 +185,8 @@ class TestCompleteRunBilling:
     @patch("treesight.security.billing_ledger._report_overage")
     @patch(_COSMOS_UPSERT)
     @patch(_COSMOS_READ)
-    def test_overage_stays_pending_when_provider_fails(self, mock_read, mock_upsert, mock_report):
-        """If _report_overage doesn't set payment_ref, run stays pending."""
+    def test_overage_raises_when_provider_fails(self, mock_read, mock_upsert, mock_report):
+        """If _report_overage doesn't set payment_ref, RuntimeError raised for retry."""
         mock_read.return_value = {
             "id": "inst-fail",
             "user_id": "u1",
@@ -195,7 +197,8 @@ class TestCompleteRunBilling:
         # Provider returns None — no payment_ref set
         mock_report.side_effect = lambda uid, iid, d: None
 
-        complete_run_billing("u1", "inst-fail")
+        with pytest.raises(RuntimeError, match="Overage billing not confirmed"):
+            complete_run_billing("u1", "inst-fail")
 
         mock_report.assert_called_once()
         mock_upsert.assert_not_called()
@@ -249,11 +252,20 @@ class TestFailRunBilling:
             "billing_status": "charged",
             "tier_at_submission": "pro",
         }
+        # Simulate _credit_overage setting payment_ref (provider succeeded)
+        mock_credit.side_effect = lambda uid, iid, d, r: d.__setitem__("payment_ref", "cr_789")
+
+        # Capture doc snapshots at each upsert call (dict is mutated in place)
+        snapshots = []
+        mock_upsert.side_effect = lambda coll, doc: snapshots.append(dict(doc))
 
         fail_run_billing("u1", "inst-3", reason="timeout")
 
-        mock_upsert.assert_called_once()
-        mock_credit.assert_called_once_with("u1", "inst-3", mock_upsert.call_args[0][1], "timeout")
+        # First upsert writes credit_pending, second writes refunded
+        assert len(snapshots) == 2
+        assert snapshots[0]["billing_status"] == "credit_pending"
+        assert snapshots[1]["billing_status"] == "refunded"
+        mock_credit.assert_called_once()
 
     @patch("treesight.security.billing_ledger._credit_overage")
     @patch(_COSMOS_UPSERT)
@@ -271,6 +283,28 @@ class TestFailRunBilling:
 
         mock_upsert.assert_called_once()
         mock_credit.assert_not_called()
+
+    @patch("treesight.security.billing_ledger._credit_overage")
+    @patch(_COSMOS_UPSERT)
+    @patch(_COSMOS_READ)
+    def test_credit_failure_raises_for_retry(self, mock_read, mock_upsert, mock_credit):
+        """If _credit_overage doesn't set payment_ref, RuntimeError for retry."""
+        mock_read.return_value = {
+            "id": "inst-5",
+            "user_id": "u1",
+            "billing_type": "overage",
+            "billing_status": "charged",
+            "tier_at_submission": "pro",
+        }
+        # Provider returns None — no payment_ref set
+        mock_credit.side_effect = lambda uid, iid, d, r: None
+
+        with pytest.raises(RuntimeError, match="Overage credit not confirmed"):
+            fail_run_billing("u1", "inst-5", reason="pipeline_failure")
+
+        # Status should be credit_pending, not refunded
+        interim_doc = mock_upsert.call_args_list[0][0][1]
+        assert interim_doc["billing_status"] == "credit_pending"
 
     @patch(_COSMOS_UPSERT)
     @patch(_COSMOS_READ)
@@ -356,7 +390,9 @@ class TestOverageProviderIntegration:
             idempotency_key="credit-inst-credit",
             reason="timeout",
         )
+        # credit_pending → refunded; payment_ref saved
         final_doc = mock_upsert.call_args_list[-1][0][1]
+        assert final_doc["billing_status"] == "refunded"
         assert final_doc["payment_ref"] == "cr_456"
 
     @patch(_GET_PROVIDER)
@@ -379,6 +415,29 @@ class TestOverageProviderIntegration:
             # No stripe_subscription_item_id
         }
 
-        complete_run_billing("u1", "inst-nosub")
+        with pytest.raises(RuntimeError, match="Overage billing not confirmed"):
+            complete_run_billing("u1", "inst-nosub")
 
         mock_provider_fn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Shared redact helper
+# ---------------------------------------------------------------------------
+
+
+class TestRedactUserId:
+    def test_truncates_long_id(self):
+        from treesight.security.redact import redact_user_id
+
+        assert redact_user_id("abcdefghij") == "abcdefgh…"
+
+    def test_short_id_unchanged(self):
+        from treesight.security.redact import redact_user_id
+
+        assert redact_user_id("abc") == "abc"
+
+    def test_exactly_eight_chars(self):
+        from treesight.security.redact import redact_user_id
+
+        assert redact_user_id("12345678") == "12345678"

--- a/tests/test_billing_ledger.py
+++ b/tests/test_billing_ledger.py
@@ -1,0 +1,384 @@
+"""Tests for treesight.security.billing_ledger — run-level billing (#589)."""
+
+from unittest.mock import MagicMock, patch
+
+from treesight.security.billing_ledger import (
+    billing_fields_for_submission,
+    classify_run,
+    complete_run_billing,
+    fail_run_billing,
+)
+
+# Shared patch targets — billing_ledger does lazy imports from these modules.
+_COSMOS_READ = "treesight.storage.cosmos.read_item"
+_COSMOS_UPSERT = "treesight.storage.cosmos.upsert_item"
+_GET_SUB = "treesight.security.billing.get_effective_subscription"
+_GET_USAGE = "treesight.security.quota.get_usage"
+_GET_PROVIDER = "treesight.security.payment_provider.get_payment_provider"
+
+
+# ---------------------------------------------------------------------------
+# classify_run
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyRun:
+    def test_demo_tier(self):
+        result = classify_run("demo", 0, 3)
+        assert result == {"billing_type": "demo", "overage_unit_price": None}
+
+    def test_free_tier(self):
+        result = classify_run("free", 5, 10)
+        assert result == {"billing_type": "free", "overage_unit_price": None}
+
+    def test_paid_included_run(self):
+        """A Pro user on their 20th of 50 included runs."""
+        result = classify_run("pro", 19, 50)
+        assert result["billing_type"] == "included"
+        assert result["overage_unit_price"] is None
+
+    def test_paid_last_included_run(self):
+        """A Pro user on their 50th run (index 49) — still included."""
+        result = classify_run("pro", 49, 50)
+        assert result["billing_type"] == "included"
+
+    def test_paid_first_overage_run(self):
+        """A Pro user on run 51 (50 used before this one) — overage."""
+        result = classify_run("pro", 50, 50)
+        assert result["billing_type"] == "overage"
+        assert result["overage_unit_price"] == 0.80
+
+    def test_starter_overage_rate(self):
+        result = classify_run("starter", 20, 20)
+        assert result["billing_type"] == "overage"
+        assert result["overage_unit_price"] == 1.50
+
+    def test_team_overage_rate(self):
+        result = classify_run("team", 200, 200)
+        assert result["billing_type"] == "overage"
+        assert result["overage_unit_price"] == 0.50
+
+    def test_enterprise_overage_has_no_rate(self):
+        """Enterprise has no overage rate (unlimited included)."""
+        result = classify_run("enterprise", 999, 1000)
+        assert result["billing_type"] == "included"
+        assert result["overage_unit_price"] is None
+
+    def test_unknown_tier_falls_back_to_free(self):
+        result = classify_run("nonexistent", 0, 10)
+        assert result["billing_type"] == "free"
+
+
+# ---------------------------------------------------------------------------
+# billing_fields_for_submission
+# ---------------------------------------------------------------------------
+
+
+class TestBillingFieldsForSubmission:
+    @patch(_GET_USAGE)
+    @patch(_GET_SUB)
+    def test_free_user_first_run(self, mock_sub, mock_usage):
+        mock_sub.return_value = {"tier": "free", "status": "none"}
+        mock_usage.return_value = {"used": 1, "limit": 10}  # 1 because consume was called
+
+        fields = billing_fields_for_submission("u-free")
+
+        assert fields["tier_at_submission"] == "free"
+        assert fields["billing_type"] == "free"
+        assert fields["overage_unit_price"] is None
+        assert fields["billing_status"] == "pending"
+
+    @patch(_GET_USAGE)
+    @patch(_GET_SUB)
+    def test_pro_included_run(self, mock_sub, mock_usage):
+        mock_sub.return_value = {"tier": "pro", "status": "active"}
+        mock_usage.return_value = {"used": 10, "limit": 50}
+
+        fields = billing_fields_for_submission("u-pro")
+
+        assert fields["tier_at_submission"] == "pro"
+        assert fields["billing_type"] == "included"
+        assert fields["billing_status"] == "pending"
+
+    @patch(_GET_USAGE)
+    @patch(_GET_SUB)
+    def test_pro_overage_run(self, mock_sub, mock_usage):
+        mock_sub.return_value = {"tier": "pro", "status": "active"}
+        mock_usage.return_value = {"used": 51, "limit": 50}  # 51 — overage
+
+        fields = billing_fields_for_submission("u-pro-over")
+
+        assert fields["billing_type"] == "overage"
+        assert fields["overage_unit_price"] == 0.80
+
+
+# ---------------------------------------------------------------------------
+# complete_run_billing
+# ---------------------------------------------------------------------------
+
+
+class TestCompleteRunBilling:
+    @patch(_COSMOS_UPSERT)
+    @patch(_COSMOS_READ)
+    def test_marks_included_run_as_charged(self, mock_read, mock_upsert):
+        mock_read.return_value = {
+            "id": "inst-1",
+            "user_id": "u1",
+            "billing_type": "included",
+            "billing_status": "pending",
+        }
+
+        complete_run_billing("u1", "inst-1")
+
+        mock_upsert.assert_called_once()
+        doc = mock_upsert.call_args[0][1]
+        assert doc["billing_status"] == "charged"
+
+    @patch(_COSMOS_UPSERT)
+    @patch(_COSMOS_READ)
+    def test_skips_already_charged(self, mock_read, mock_upsert):
+        mock_read.return_value = {
+            "id": "inst-1",
+            "user_id": "u1",
+            "billing_type": "included",
+            "billing_status": "charged",
+            "payment_ref": None,
+        }
+
+        complete_run_billing("u1", "inst-1")
+
+        mock_upsert.assert_not_called()
+
+    @patch("treesight.security.billing_ledger._report_overage")
+    @patch(_COSMOS_UPSERT)
+    @patch(_COSMOS_READ)
+    def test_reports_overage_to_provider(self, mock_read, mock_upsert, mock_report):
+        doc = {
+            "id": "inst-2",
+            "user_id": "u1",
+            "billing_type": "overage",
+            "billing_status": "pending",
+            "tier_at_submission": "pro",
+        }
+        mock_read.return_value = doc
+        # Simulate _report_overage setting payment_ref (provider succeeded)
+        mock_report.side_effect = lambda uid, iid, d: d.__setitem__("payment_ref", "ur_123")
+
+        complete_run_billing("u1", "inst-2")
+
+        mock_report.assert_called_once_with("u1", "inst-2", doc)
+        mock_upsert.assert_called_once()
+        saved_doc = mock_upsert.call_args[0][1]
+        assert saved_doc["billing_status"] == "charged"
+
+    @patch(_COSMOS_UPSERT)
+    @patch(_COSMOS_READ)
+    def test_handles_missing_document(self, mock_read, mock_upsert):
+        mock_read.return_value = None
+
+        complete_run_billing("u1", "inst-missing")
+
+        mock_upsert.assert_not_called()
+
+    @patch("treesight.security.billing_ledger._report_overage")
+    @patch(_COSMOS_UPSERT)
+    @patch(_COSMOS_READ)
+    def test_overage_stays_pending_when_provider_fails(self, mock_read, mock_upsert, mock_report):
+        """If _report_overage doesn't set payment_ref, run stays pending."""
+        mock_read.return_value = {
+            "id": "inst-fail",
+            "user_id": "u1",
+            "billing_type": "overage",
+            "billing_status": "pending",
+            "tier_at_submission": "pro",
+        }
+        # Provider returns None — no payment_ref set
+        mock_report.side_effect = lambda uid, iid, d: None
+
+        complete_run_billing("u1", "inst-fail")
+
+        mock_report.assert_called_once()
+        mock_upsert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# fail_run_billing
+# ---------------------------------------------------------------------------
+
+
+class TestFailRunBilling:
+    @patch(_COSMOS_UPSERT)
+    @patch(_COSMOS_READ)
+    def test_marks_pending_run_as_refunded(self, mock_read, mock_upsert):
+        mock_read.return_value = {
+            "id": "inst-1",
+            "user_id": "u1",
+            "billing_type": "included",
+            "billing_status": "pending",
+        }
+
+        fail_run_billing("u1", "inst-1", reason="pipeline_failure")
+
+        mock_upsert.assert_called_once()
+        doc = mock_upsert.call_args[0][1]
+        assert doc["billing_status"] == "refunded"
+        assert doc["refund_reason"] == "pipeline_failure"
+
+    @patch(_COSMOS_UPSERT)
+    @patch(_COSMOS_READ)
+    def test_skips_already_refunded(self, mock_read, mock_upsert):
+        mock_read.return_value = {
+            "id": "inst-1",
+            "user_id": "u1",
+            "billing_type": "included",
+            "billing_status": "refunded",
+        }
+
+        fail_run_billing("u1", "inst-1")
+
+        mock_upsert.assert_not_called()
+
+    @patch("treesight.security.billing_ledger._credit_overage")
+    @patch(_COSMOS_UPSERT)
+    @patch(_COSMOS_READ)
+    def test_credits_charged_overage_run(self, mock_read, mock_upsert, mock_credit):
+        mock_read.return_value = {
+            "id": "inst-3",
+            "user_id": "u1",
+            "billing_type": "overage",
+            "billing_status": "charged",
+            "tier_at_submission": "pro",
+        }
+
+        fail_run_billing("u1", "inst-3", reason="timeout")
+
+        mock_upsert.assert_called_once()
+        mock_credit.assert_called_once_with("u1", "inst-3", mock_upsert.call_args[0][1], "timeout")
+
+    @patch("treesight.security.billing_ledger._credit_overage")
+    @patch(_COSMOS_UPSERT)
+    @patch(_COSMOS_READ)
+    def test_no_credit_for_pending_overage(self, mock_read, mock_upsert, mock_credit):
+        """Overage run that failed before being charged — no credit needed."""
+        mock_read.return_value = {
+            "id": "inst-4",
+            "user_id": "u1",
+            "billing_type": "overage",
+            "billing_status": "pending",
+        }
+
+        fail_run_billing("u1", "inst-4", reason="pipeline_failure")
+
+        mock_upsert.assert_called_once()
+        mock_credit.assert_not_called()
+
+    @patch(_COSMOS_UPSERT)
+    @patch(_COSMOS_READ)
+    def test_handles_missing_document(self, mock_read, mock_upsert):
+        mock_read.return_value = None
+
+        fail_run_billing("u1", "inst-missing")
+
+        mock_upsert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Provider integration (_report_overage / _credit_overage)
+# ---------------------------------------------------------------------------
+
+
+class TestOverageProviderIntegration:
+    @patch(_GET_PROVIDER)
+    @patch(_GET_SUB)
+    @patch(_COSMOS_UPSERT)
+    @patch(_COSMOS_READ)
+    def test_report_overage_calls_provider(
+        self, mock_read, mock_upsert, mock_sub, mock_provider_fn
+    ):
+        mock_read.return_value = {
+            "id": "inst-over",
+            "user_id": "u1",
+            "billing_type": "overage",
+            "billing_status": "pending",
+            "tier_at_submission": "pro",
+        }
+        mock_sub.return_value = {
+            "tier": "pro",
+            "status": "active",
+            "stripe_subscription_item_id": "si_abc",
+        }
+        mock_provider = MagicMock()
+        mock_provider.report_usage.return_value = "ur_123"
+        mock_provider_fn.return_value = mock_provider
+
+        complete_run_billing("u1", "inst-over")
+
+        mock_provider.report_usage.assert_called_once_with(
+            user_id="u1",
+            subscription_item_id="si_abc",
+            quantity=1,
+            idempotency_key="overage-inst-over",
+            metadata={"instance_id": "inst-over", "tier": "pro"},
+        )
+        # Verify payment_ref was saved
+        final_doc = mock_upsert.call_args_list[-1][0][1]
+        assert final_doc["payment_ref"] == "ur_123"
+
+    @patch(_GET_PROVIDER)
+    @patch(_GET_SUB)
+    @patch(_COSMOS_UPSERT)
+    @patch(_COSMOS_READ)
+    def test_credit_overage_calls_provider(
+        self, mock_read, mock_upsert, mock_sub, mock_provider_fn
+    ):
+        mock_read.return_value = {
+            "id": "inst-credit",
+            "user_id": "u1",
+            "billing_type": "overage",
+            "billing_status": "charged",
+            "tier_at_submission": "pro",
+        }
+        mock_sub.return_value = {
+            "tier": "pro",
+            "status": "active",
+            "stripe_subscription_item_id": "si_abc",
+        }
+        mock_provider = MagicMock()
+        mock_provider.credit_usage.return_value = "cr_456"
+        mock_provider_fn.return_value = mock_provider
+
+        fail_run_billing("u1", "inst-credit", reason="timeout")
+
+        mock_provider.credit_usage.assert_called_once_with(
+            user_id="u1",
+            subscription_item_id="si_abc",
+            quantity=1,
+            idempotency_key="credit-inst-credit",
+            reason="timeout",
+        )
+        final_doc = mock_upsert.call_args_list[-1][0][1]
+        assert final_doc["payment_ref"] == "cr_456"
+
+    @patch(_GET_PROVIDER)
+    @patch(_GET_SUB)
+    @patch(_COSMOS_UPSERT)
+    @patch(_COSMOS_READ)
+    def test_no_provider_call_without_stripe_sub(
+        self, mock_read, mock_upsert, mock_sub, mock_provider_fn
+    ):
+        mock_read.return_value = {
+            "id": "inst-nosub",
+            "user_id": "u1",
+            "billing_type": "overage",
+            "billing_status": "pending",
+            "tier_at_submission": "pro",
+        }
+        mock_sub.return_value = {
+            "tier": "pro",
+            "status": "active",
+            # No stripe_subscription_item_id
+        }
+
+        complete_run_billing("u1", "inst-nosub")
+
+        mock_provider_fn.assert_not_called()

--- a/tests/test_payment_provider.py
+++ b/tests/test_payment_provider.py
@@ -1,0 +1,64 @@
+"""Tests for treesight.security.payment_provider — provider abstraction."""
+
+from treesight.security.payment_provider import (
+    NullProvider,
+    PaymentProvider,
+    StripeProvider,
+    get_payment_provider,
+    set_payment_provider,
+)
+
+
+class TestNullProvider:
+    def test_conforms_to_protocol(self):
+        assert isinstance(NullProvider(), PaymentProvider)
+
+    def test_report_usage_returns_none(self):
+        p = NullProvider()
+        result = p.report_usage(
+            user_id="u1",
+            subscription_item_id="si_1",
+            quantity=1,
+            idempotency_key="key-1",
+        )
+        assert result is None
+
+    def test_credit_usage_returns_none(self):
+        p = NullProvider()
+        result = p.credit_usage(
+            user_id="u1",
+            subscription_item_id="si_1",
+            quantity=1,
+            idempotency_key="key-1",
+            reason="pipeline_failure",
+        )
+        assert result is None
+
+
+class TestStripeProvider:
+    def test_conforms_to_protocol(self):
+        assert isinstance(StripeProvider("sk_test_xxx"), PaymentProvider)
+
+
+class TestProviderFactory:
+    def test_returns_null_without_stripe_key(self, monkeypatch):
+        # Reset the singleton
+        set_payment_provider(None)
+        monkeypatch.setattr("treesight.config.STRIPE_API_KEY", "")
+        provider = get_payment_provider()
+        assert isinstance(provider, NullProvider)
+        # Clean up
+        set_payment_provider(None)
+
+    def test_returns_stripe_with_key(self, monkeypatch):
+        set_payment_provider(None)
+        monkeypatch.setattr("treesight.config.STRIPE_API_KEY", "sk_test_xxx")
+        provider = get_payment_provider()
+        assert isinstance(provider, StripeProvider)
+        set_payment_provider(None)
+
+    def test_set_payment_provider_overrides(self):
+        custom = NullProvider()
+        set_payment_provider(custom)
+        assert get_payment_provider() is custom
+        set_payment_provider(None)

--- a/treesight/models/records.py
+++ b/treesight/models/records.py
@@ -52,6 +52,14 @@ class RunRecord(BaseModel):
     completed_at: str | None = None
     duration_seconds: float | None = None
 
+    # Billing ledger fields (#589)
+    tier_at_submission: str | None = None
+    billing_type: str | None = None  # included | overage | free | demo
+    overage_unit_price: float | None = None
+    billing_status: str | None = None  # pending | charged | refunded
+    payment_ref: str | None = None  # external ID from payment provider
+    refund_reason: str | None = None  # reason recorded when a charge is refunded
+
     model_config = ConfigDict(extra="allow")
 
 

--- a/treesight/security/billing_ledger.py
+++ b/treesight/security/billing_ledger.py
@@ -1,0 +1,244 @@
+"""Billing ledger — run-level billing classification and lifecycle (#589).
+
+Every pipeline run gets billing metadata written at submission and updated
+on completion or failure.  The billing fields live on the ``RunRecord``
+document in the Cosmos ``runs`` container.
+
+The ledger is **provider-agnostic**: it calls the configured
+``PaymentProvider`` for overage reporting/crediting.  Stripe is one
+implementation; ``NullProvider`` is used when billing is unconfigured.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _redact(user_id: str) -> str:
+    """Return a truncated user ID safe for logging (no full PII)."""
+    return user_id[:8] + "…" if len(user_id) > 8 else user_id
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def classify_run(tier: str, runs_used: int, included_limit: int) -> dict[str, Any]:
+    """Classify a run as included, overage, free, or demo.
+
+    Parameters
+    ----------
+    tier:
+        The normalised subscription tier at submission time.
+    runs_used:
+        Number of runs already consumed *before* this one.
+    included_limit:
+        The ``run_limit`` for the tier (included runs per period).
+
+    Returns
+    -------
+    dict with ``billing_type`` and ``overage_unit_price``.
+    """
+    from treesight.security.billing import PLAN_CATALOG, normalize_tier
+
+    tier = normalize_tier(tier)
+    plan = PLAN_CATALOG.get(tier, PLAN_CATALOG["free"])
+
+    if tier == "demo":
+        return {"billing_type": "demo", "overage_unit_price": None}
+    if tier == "free":
+        return {"billing_type": "free", "overage_unit_price": None}
+
+    if runs_used < included_limit:
+        return {"billing_type": "included", "overage_unit_price": None}
+
+    rate = plan.get("overage_rate")
+    return {"billing_type": "overage", "overage_unit_price": rate}
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle helpers — called by submission / orchestrator
+# ---------------------------------------------------------------------------
+
+
+def billing_fields_for_submission(user_id: str) -> dict[str, Any]:
+    """Return billing fields to embed in a ``RunRecord`` at submission time.
+
+    Reads the user's effective subscription and current usage to classify the
+    run.  Returns a dict suitable for unpacking into the ``RunRecord``
+    constructor.
+    """
+    from treesight.security.billing import get_effective_subscription, normalize_tier
+    from treesight.security.quota import get_usage
+
+    sub = get_effective_subscription(user_id)
+    tier = normalize_tier(sub.get("tier"))
+    usage = get_usage(user_id)
+    # usage["used"] already includes the current run (consume_quota was called first)
+    # so the run *before* this one is used - 1
+    used_before = max(usage["used"] - 1, 0)
+
+    classification = classify_run(tier, used_before, usage["limit"])
+
+    return {
+        "tier_at_submission": tier,
+        "billing_type": classification["billing_type"],
+        "overage_unit_price": classification["overage_unit_price"],
+        "billing_status": "pending",
+    }
+
+
+def complete_run_billing(user_id: str, instance_id: str) -> None:
+    """Mark a run as successfully completed in the billing ledger.
+
+    For overage runs, reports usage to the configured ``PaymentProvider``.
+    """
+    from treesight.storage.cosmos import read_item, upsert_item
+
+    doc = read_item("runs", instance_id, user_id)
+    if not doc:
+        logger.warning(
+            "No run document found for billing completion instance=%s user=%s",
+            instance_id,
+            _redact(user_id),
+        )
+        return
+
+    billing_type = doc.get("billing_type")
+    already_charged = doc.get("billing_status") == "charged"
+    has_payment_ref = bool(doc.get("payment_ref"))
+    if already_charged and (billing_type != "overage" or has_payment_ref):
+        logger.info(
+            "Run already charged instance=%s — skipping",
+            instance_id,
+        )
+        return
+
+    if billing_type == "overage":
+        _report_overage(user_id, instance_id, doc)
+        if not doc.get("payment_ref"):
+            logger.warning(
+                "Overage billing not confirmed instance=%s user=%s",
+                instance_id,
+                _redact(user_id),
+            )
+            return
+
+    doc["billing_status"] = "charged"
+    upsert_item("runs", doc)
+
+    logger.info(
+        "Billing completed instance=%s user=%s type=%s",
+        instance_id,
+        _redact(user_id),
+        billing_type,
+    )
+
+
+def fail_run_billing(
+    user_id: str,
+    instance_id: str,
+    *,
+    reason: str = "pipeline_failure",
+) -> None:
+    """Mark a run as failed/refunded in the billing ledger.
+
+    For overage runs that were already reported, credits the payment provider.
+    """
+    from treesight.storage.cosmos import read_item, upsert_item
+
+    doc = read_item("runs", instance_id, user_id)
+    if not doc:
+        logger.warning(
+            "No run document found for billing failure instance=%s user=%s",
+            instance_id,
+            _redact(user_id),
+        )
+        return
+
+    previous_status = doc.get("billing_status")
+    if previous_status == "refunded":
+        logger.info(
+            "Run already refunded instance=%s — skipping",
+            instance_id,
+        )
+        return
+
+    doc["billing_status"] = "refunded"
+    doc["refund_reason"] = reason
+    upsert_item("runs", doc)
+
+    # If it was an overage run that was already charged, credit it back
+    if doc.get("billing_type") == "overage" and previous_status == "charged":
+        _credit_overage(user_id, instance_id, doc, reason)
+
+    logger.info(
+        "Billing refunded instance=%s user=%s reason=%s",
+        instance_id,
+        _redact(user_id),
+        reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Payment provider integration
+# ---------------------------------------------------------------------------
+
+
+def _report_overage(user_id: str, instance_id: str, doc: dict[str, Any]) -> None:
+    """Report overage usage to the payment provider."""
+    from treesight.security.billing import get_effective_subscription
+    from treesight.security.payment_provider import get_payment_provider
+
+    sub = get_effective_subscription(user_id)
+    stripe_si_id = sub.get("stripe_subscription_item_id", "")
+    if not stripe_si_id:
+        logger.info(
+            "No Stripe subscription item for overage reporting user=%s instance=%s",
+            _redact(user_id),
+            instance_id,
+        )
+        return
+
+    provider = get_payment_provider()
+    ref = provider.report_usage(
+        user_id=user_id,
+        subscription_item_id=stripe_si_id,
+        quantity=1,
+        idempotency_key=f"overage-{instance_id}",
+        metadata={"instance_id": instance_id, "tier": doc.get("tier_at_submission", "")},
+    )
+    if ref:
+        from treesight.storage.cosmos import upsert_item
+
+        doc["payment_ref"] = ref
+        upsert_item("runs", doc)
+
+
+def _credit_overage(user_id: str, instance_id: str, doc: dict[str, Any], reason: str) -> None:
+    """Credit overage usage back via the payment provider."""
+    from treesight.security.billing import get_effective_subscription
+    from treesight.security.payment_provider import get_payment_provider
+
+    sub = get_effective_subscription(user_id)
+    stripe_si_id = sub.get("stripe_subscription_item_id", "")
+    if not stripe_si_id:
+        return
+
+    provider = get_payment_provider()
+    ref = provider.credit_usage(
+        user_id=user_id,
+        subscription_item_id=stripe_si_id,
+        quantity=1,
+        idempotency_key=f"credit-{instance_id}",
+        reason=reason,
+    )
+    if ref:
+        from treesight.storage.cosmos import upsert_item
+
+        doc["payment_ref"] = ref
+        upsert_item("runs", doc)

--- a/treesight/security/billing_ledger.py
+++ b/treesight/security/billing_ledger.py
@@ -14,12 +14,9 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from treesight.security.redact import redact_user_id as _redact
+
 logger = logging.getLogger(__name__)
-
-
-def _redact(user_id: str) -> str:
-    """Return a truncated user ID safe for logging (no full PII)."""
-    return user_id[:8] + "…" if len(user_id) > 8 else user_id
 
 
 # ---------------------------------------------------------------------------
@@ -121,12 +118,10 @@ def complete_run_billing(user_id: str, instance_id: str) -> None:
     if billing_type == "overage":
         _report_overage(user_id, instance_id, doc)
         if not doc.get("payment_ref"):
-            logger.warning(
-                "Overage billing not confirmed instance=%s user=%s",
-                instance_id,
-                _redact(user_id),
+            # Stay pending so Durable retry can re-attempt billing
+            raise RuntimeError(
+                f"Overage billing not confirmed instance={instance_id} user={_redact(user_id)}"
             )
-            return
 
     doc["billing_status"] = "charged"
     upsert_item("runs", doc)
@@ -168,13 +163,26 @@ def fail_run_billing(
         )
         return
 
+    # If it was an overage run that was already charged, credit first
+    needs_credit = doc.get("billing_type") == "overage" and previous_status == "charged"
+
+    if needs_credit:
+        # Write interim status so a crash between credit and final update
+        # is retryable — the run won't appear as "refunded" without credit.
+        doc["billing_status"] = "credit_pending"
+        doc["refund_reason"] = reason
+        upsert_item("runs", doc)
+
+        _credit_overage(user_id, instance_id, doc, reason)
+
+        if not doc.get("payment_ref"):
+            raise RuntimeError(
+                f"Overage credit not confirmed instance={instance_id} user={_redact(user_id)}"
+            )
+
     doc["billing_status"] = "refunded"
     doc["refund_reason"] = reason
     upsert_item("runs", doc)
-
-    # If it was an overage run that was already charged, credit it back
-    if doc.get("billing_type") == "overage" and previous_status == "charged":
-        _credit_overage(user_id, instance_id, doc, reason)
 
     logger.info(
         "Billing refunded instance=%s user=%s reason=%s",

--- a/treesight/security/payment_provider.py
+++ b/treesight/security/payment_provider.py
@@ -1,0 +1,213 @@
+"""Payment provider abstraction — pluggable billing backend.
+
+The billing ledger records runs internally.  When a billable event occurs
+(overage completion, refund), it delegates to a ``PaymentProvider``.
+Stripe is one implementation; others can be swapped in without touching
+the ledger.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class PaymentProvider(Protocol):
+    """Minimal interface for a payment/billing backend."""
+
+    def report_usage(
+        self,
+        *,
+        user_id: str,
+        subscription_item_id: str,
+        quantity: int,
+        idempotency_key: str,
+        metadata: dict[str, str] | None = None,
+    ) -> str | None:
+        """Report metered usage (e.g. overage runs).
+
+        Parameters
+        ----------
+        subscription_item_id:
+            Stripe subscription *item* ID (``si_...``), not the subscription
+            ID (``sub_...``).
+
+        Returns an external record ID (e.g. Stripe UsageRecord ID) or None.
+        """
+        return None
+
+    def credit_usage(
+        self,
+        *,
+        user_id: str,
+        subscription_item_id: str,
+        quantity: int,
+        idempotency_key: str,
+        reason: str = "",
+    ) -> str | None:
+        """Credit/refund metered usage (e.g. failed overage run).
+
+        Sends a negative usage record to reverse a previous charge.
+
+        Returns an external record ID or None.
+        """
+        return None
+
+
+class NullProvider:
+    """No-op provider for free tiers, tests, and when billing is unconfigured."""
+
+    def report_usage(
+        self,
+        *,
+        user_id: str,
+        subscription_item_id: str,
+        quantity: int,
+        idempotency_key: str,
+        metadata: dict[str, str] | None = None,
+    ) -> str | None:
+        logger.debug(
+            "NullProvider.report_usage user=%s qty=%d key=%s",
+            user_id,
+            quantity,
+            idempotency_key,
+        )
+        return None
+
+    def credit_usage(
+        self,
+        *,
+        user_id: str,
+        subscription_item_id: str,
+        quantity: int,
+        idempotency_key: str,
+        reason: str = "",
+    ) -> str | None:
+        logger.debug(
+            "NullProvider.credit_usage user=%s qty=%d key=%s reason=%s",
+            user_id,
+            quantity,
+            idempotency_key,
+            reason,
+        )
+        return None
+
+
+class StripeProvider:
+    """Stripe metered billing provider.
+
+    Reports overage usage via Stripe Usage Records on metered subscription
+    items.  Credits are reported as negative usage records.
+    """
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = api_key
+
+    def _get_stripe(self) -> Any:
+        import stripe
+
+        stripe.api_key = self._api_key
+        return stripe
+
+    def report_usage(
+        self,
+        *,
+        user_id: str,
+        subscription_item_id: str,
+        quantity: int,
+        idempotency_key: str,
+        metadata: dict[str, str] | None = None,
+    ) -> str | None:
+        stripe = self._get_stripe()
+        try:
+            record = stripe.SubscriptionItem.create_usage_record(
+                subscription_item_id,
+                quantity=quantity,
+                action="increment",
+                idempotency_key=idempotency_key,
+            )
+            logger.info(
+                "Stripe usage reported user=%s si=%s qty=%d record=%s",
+                user_id,
+                subscription_item_id,
+                quantity,
+                record.id,
+            )
+            return record.id
+        except Exception:
+            logger.exception(
+                "Stripe usage report failed user=%s si=%s qty=%d",
+                user_id,
+                subscription_item_id,
+                quantity,
+            )
+            return None
+
+    def credit_usage(
+        self,
+        *,
+        user_id: str,
+        subscription_item_id: str,
+        quantity: int,
+        idempotency_key: str,
+        reason: str = "",
+    ) -> str | None:
+        stripe = self._get_stripe()
+        try:
+            record = stripe.SubscriptionItem.create_usage_record(
+                subscription_item_id,
+                quantity=-abs(quantity),
+                action="increment",
+                idempotency_key=idempotency_key,
+            )
+            logger.info(
+                "Stripe credit reported user=%s si=%s qty=%d reason=%s record=%s",
+                user_id,
+                subscription_item_id,
+                quantity,
+                reason,
+                record.id,
+            )
+            return record.id
+        except Exception:
+            logger.exception(
+                "Stripe credit failed user=%s si=%s qty=%d reason=%s",
+                user_id,
+                subscription_item_id,
+                quantity,
+                reason,
+            )
+            return None
+
+
+_provider: PaymentProvider | None = None
+
+
+def get_payment_provider() -> PaymentProvider:
+    """Return the configured payment provider (singleton)."""
+    global _provider
+    if _provider is not None:
+        return _provider
+
+    from treesight.config import STRIPE_API_KEY
+
+    if STRIPE_API_KEY:
+        _provider = StripeProvider(STRIPE_API_KEY)
+        logger.info("Payment provider: Stripe")
+    else:
+        _provider = NullProvider()
+        logger.info("Payment provider: Null (no STRIPE_API_KEY)")
+    return _provider
+
+
+def set_payment_provider(provider: PaymentProvider | None) -> None:
+    """Override the cached payment provider.
+
+    Pass ``None`` to reset the singleton so the next
+    ``get_payment_provider()`` call reloads from configuration.
+    """
+    global _provider
+    _provider = provider

--- a/treesight/security/redact.py
+++ b/treesight/security/redact.py
@@ -1,0 +1,8 @@
+"""PII redaction helpers for safe logging."""
+
+from __future__ import annotations
+
+
+def redact_user_id(user_id: str) -> str:
+    """Return a truncated user ID safe for logging (no full PII)."""
+    return user_id[:8] + "…" if len(user_id) > 8 else user_id


### PR DESCRIPTION
## Summary

Implements **#589 phases 1–3**: run-level billing ledger, included/overage classification, and provider-agnostic payment abstraction.

Closes #589 (phases 1–3). Phase 4+ (atomic quota, spend controls, reconciliation, multi-tier checkout) are follow-up work.

## What changed

### New modules

| File | Purpose |
|------|---------|
| `treesight/security/payment_provider.py` | `PaymentProvider` Protocol + `NullProvider` + `StripeProvider` |
| `treesight/security/billing_ledger.py` | Run classification, billing lifecycle (submit → charge/refund) |

### Modified modules

| File | Change |
|------|--------|
| `treesight/models/records.py` | `RunRecord` gains billing fields: `tier_at_submission`, `billing_type`, `overage_unit_price`, `billing_status`, `payment_ref` |
| `blueprints/pipeline/submission.py` | Calls `billing_fields_for_submission()` after `consume_quota()`, embeds in `RunRecord` |
| `blueprints/upload.py` | Same billing classification wiring for SAS upload path |
| `blueprints/pipeline/activities.py` | New activities: `complete_billing`, `fail_billing` |
| `blueprints/pipeline/orchestrator.py` | Calls `complete_billing` on success, `fail_billing` on failure |
| `docs/ROADMAP.md` | Reorder 2D: R.2→#589 (ledger, active), R.3→#535 (Stripe E2E, depends on R.2) |

### Design decisions

- **Provider-agnostic**: `PaymentProvider` is a `Protocol`. Stripe is one implementation. `NullProvider` is used when `STRIPE_API_KEY` is empty (tests, free tier, unconfigured).
- **Billing fields on RunRecord**: No new Cosmos container needed. Billing metadata lives alongside the run document in the `runs` container.
- **Overage classification without behavior change**: Runs are classified as included/overage/free/demo, but the existing hard-block at tier limit is preserved. Overages won't be *allowed* until Stripe metered prices are configured (R.3 #535).
- **Idempotent**: `complete_run_billing` and `fail_run_billing` skip if already in terminal state.
- **Orchestrator compacted** to stay within 40-line body limit.

### Test coverage

- `test_payment_provider.py` — 7 tests (protocol conformance, factory, override)
- `test_billing_ledger.py` — 24 tests (classification, submission fields, completion, failure, overage provider integration)
- Full suite: **1394 passed**, 27 skipped, 0 failed

## Billing flow

```
Submission → consume_quota() → billing_fields_for_submission() → RunRecord persisted
                                  ↓
                           classify_run(tier, used, limit)
                                  ↓
                    billing_type: included | overage | free | demo
                    billing_status: pending

Success → complete_billing activity → billing_status: charged
          if overage: payment_provider.report_usage()

Failure → release_quota + fail_billing activity → billing_status: refunded
          if overage was charged: payment_provider.credit_usage()
```

## Roadmap impact

Stage 2D reordered — ledger (#589) is now R.2 (active), Stripe E2E (#535) is R.3 (depends on R.2).