### PR TITLE
fix: AOI limit error suggests tier (#635), enrichment 404 on completed runs (#637)

### DIFF
--- a/blueprints/_helpers.py
+++ b/blueprints/_helpers.py
@@ -325,7 +325,7 @@ async def fetch_enrichment_manifest(
     if not instance_id:
         return None, error_response(400, "instance_id required", req=req)
 
-    status = await client.get_status(instance_id)
+    status = await client.get_status(instance_id, show_input=True)
     if not status or not status.output:
         return None, error_response(404, "Pipeline not found or not complete", req=req)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -323,3 +323,78 @@ class TestSafeBlobPath:
         from treesight.storage.client import _safe_blob_path
 
         assert _safe_blob_path("demo-submissions/abc123.json") == "demo-submissions/abc123.json"
+
+
+# ---------------------------------------------------------------------------
+# fetch_enrichment_manifest — ownership check (#636)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchEnrichmentManifest:
+    """Regression tests for ``fetch_enrichment_manifest``."""
+
+    @pytest.mark.asyncio
+    async def test_get_status_called_with_show_input(self) -> None:
+        """get_status must pass show_input=True so the ownership check works."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from blueprints._helpers import fetch_enrichment_manifest
+
+        # Build a fake DurableOrchestrationStatus with input and output
+        fake_status = MagicMock()
+        fake_status.output = {"enrichmentManifest": "enrichment/abc/payload.json"}
+        fake_status.input_ = {"user_id": "user-123"}
+
+        client = AsyncMock()
+        client.get_status = AsyncMock(return_value=fake_status)
+
+        req = func.HttpRequest(
+            method="GET",
+            url="https://example.com/api/timelapse-data/abc",
+            route_params={"instance_id": "abc"},
+            headers={"Origin": TEST_ORIGIN},
+            body=b"",
+        )
+
+        with (
+            patch("blueprints._helpers.check_auth", return_value=({}, "user-123")),
+            patch(
+                "treesight.storage.client.BlobStorageClient.download_json",
+                return_value={"frames": []},
+            ),
+        ):
+            manifest, err = await fetch_enrichment_manifest(req, client)
+
+        # The critical assertion: show_input MUST be True
+        client.get_status.assert_called_once_with("abc", show_input=True)
+        assert err is None
+        assert manifest == {"frames": []}
+
+    @pytest.mark.asyncio
+    async def test_ownership_mismatch_returns_404(self) -> None:
+        """Different user_id in input vs caller returns 404."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from blueprints._helpers import fetch_enrichment_manifest
+
+        fake_status = MagicMock()
+        fake_status.output = {"enrichmentManifest": "enrichment/abc/payload.json"}
+        fake_status.input_ = {"user_id": "other-user"}
+
+        client = AsyncMock()
+        client.get_status = AsyncMock(return_value=fake_status)
+
+        req = func.HttpRequest(
+            method="GET",
+            url="https://example.com/api/timelapse-data/abc",
+            route_params={"instance_id": "abc"},
+            headers={"Origin": TEST_ORIGIN},
+            body=b"",
+        )
+
+        with patch("blueprints._helpers.check_auth", return_value=({}, "user-123")):
+            manifest, err = await fetch_enrichment_manifest(req, client)
+
+        assert manifest is None
+        assert err is not None
+        assert err.status_code == 404

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -393,12 +393,12 @@ class TestEnforceAoiLimit:
             enforce_aoi_limit(feature_count=6, tier="unknown_tier")
 
     def test_error_message_includes_upgrade_hint(self) -> None:
-        """Error message should tell the user to upgrade."""
+        """Error message should suggest a suitable tier."""
         import pytest
 
         from treesight.pipeline.ingestion import enforce_aoi_limit
 
-        with pytest.raises(ValueError, match=r"[Uu]pgrade"):
+        with pytest.raises(ValueError, match=r"Starter plan supports up to 15"):
             enforce_aoi_limit(feature_count=6, tier="free")
 
     def test_none_tier_defaults_to_free(self) -> None:
@@ -410,3 +410,35 @@ class TestEnforceAoiLimit:
         enforce_aoi_limit(feature_count=5, tier=None)
         with pytest.raises(ValueError, match=r"6 AOIs.*Free.*allows 5"):
             enforce_aoi_limit(feature_count=6, tier=None)
+
+    def test_error_message_suggests_suitable_tier(self) -> None:
+        """Error should name the cheapest tier that fits the AOI count."""
+        import pytest
+
+        from treesight.pipeline.ingestion import enforce_aoi_limit
+
+        # 6 AOIs on free (limit 5) → suggest Starter (limit 15)
+        with pytest.raises(ValueError, match=r"Starter plan supports up to 15"):
+            enforce_aoi_limit(feature_count=6, tier="free")
+
+        # 16 AOIs on free → suggest Pro (limit 50)
+        with pytest.raises(ValueError, match=r"Pro plan supports up to 50"):
+            enforce_aoi_limit(feature_count=16, tier="free")
+
+        # 56 AOIs on free → suggest Team (limit 200)
+        with pytest.raises(ValueError, match=r"Team plan supports up to 200"):
+            enforce_aoi_limit(feature_count=56, tier="free")
+
+        # 201 AOIs on free → suggest Enterprise (unlimited)
+        with pytest.raises(ValueError, match=r"Enterprise plan supports unlimited"):
+            enforce_aoi_limit(feature_count=201, tier="free")
+
+    def test_error_message_suggests_next_tier_from_current(self) -> None:
+        """When over the Pro limit, suggestion should be Team, not Starter."""
+        import pytest
+
+        from treesight.pipeline.ingestion import enforce_aoi_limit
+
+        # 51 AOIs on pro (limit 50) → suggest Team (limit 200)
+        with pytest.raises(ValueError, match=r"Team plan supports up to 200"):
+            enforce_aoi_limit(feature_count=51, tier="pro")

--- a/treesight/pipeline/ingestion.py
+++ b/treesight/pipeline/ingestion.py
@@ -71,11 +71,23 @@ def enforce_aoi_limit(feature_count: int, tier: str | None) -> None:
         return
 
     if feature_count > aoi_limit:
+        suggestion = _suggest_tier(feature_count, PLAN_CATALOG)
         raise ValueError(
             f"This file contains {feature_count} AOIs but your "
             f"{label} plan allows {aoi_limit} per submission. "
-            f"Upgrade your plan for higher limits."
+            f"{suggestion}"
         )
+
+
+def _suggest_tier(feature_count: int, catalog: dict[str, dict]) -> str:
+    """Return a human-readable suggestion for the cheapest tier that fits."""
+    for plan in catalog.values():
+        limit = plan.get("aoi_limit")
+        if limit is None:
+            return f"The {plan['label']} plan supports unlimited AOIs per submission."
+        if feature_count <= limit:
+            return f"The {plan['label']} plan supports up to {limit} AOIs per submission."
+    return "Upgrade your plan for higher limits."
 
 
 def prepare_aois(features: list[Feature], buffer_m: float | None = None) -> list[AOI]:


### PR DESCRIPTION
## Summary

Fixes #635 — AOI limit rejection errors now suggest the cheapest plan that fits the file.
Fixes #637 — Enrichment data loading was broken for all completed runs.

### AOI limit error improvement (#635)

**Before:**
> This file contains 56 AOIs but your Free plan allows 5 per submission. Upgrade your plan for higher limits.

**After:**
> This file contains 56 AOIs but your Free plan allows 5 per submission. The Team plan supports up to 200 AOIs per submission.

The suggestion dynamically walks the plan catalog to find the cheapest tier whose `aoi_limit` accommodates the file's AOI count. For files exceeding all numeric limits, it suggests Enterprise (unlimited).

### Enrichment 404 fix (#637)

`fetch_enrichment_manifest` called `client.get_status(instance_id)` without `show_input=True`. The Azure Durable Functions SDK defaults `show_input` to `False`, so `status.input_` was always `None` — the ownership check always failed with a 404 for every authenticated user.

Fix: pass `show_input=True`.

### Changes

- `treesight/pipeline/ingestion.py` — `enforce_aoi_limit` calls `_suggest_tier()` for actionable suggestions
- `blueprints/_helpers.py` — `fetch_enrichment_manifest` passes `show_input=True` to `get_status`
- `tests/test_ingestion.py` — 2 new tests for tier suggestion, 1 updated assertion
- `tests/test_helpers.py` — 2 regression tests for enrichment manifest fetch

### #634 note

Issue #634 (tier emulation for operators) requires no code change — the `POST /api/ops/users/{user_id}/role` endpoint already exists. It's an ops/config task.