### PR TITLE
docs: update roadmap — PR #636 landed

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,12 +39,12 @@ Stages 2D and 2E can proceed in parallel.
 
 | PR | Summary |
 |----|---------|
+| #636 | AOI limit tier suggestion (#635), enrichment 404 on completed runs (#637) |
 | #629 | Billing ledger, payment provider, run lifecycle, PII redaction (fixes #589) |
 | #631 | EUDR UI polish: landing page, phase copy, app-shell branching (fixes #630, #632) |
 | #615 | EUDR landing page, per-parcel export, audit PDF (fixes #533, #605) |
 | #626 | Progressive delivery: per-AOI sub-orchestrators (fixes #585) |
 | #624 | DF retry on acquisition activities, remove dead Cosmos IP rules, infracost fix |
-| #620 | aoi_limit enforcement, AOI count fix, EUDR date filter, data models, per-AOI enrichment, orgs, JS decomposition (#575, #580, #600, #583, #578, #614, #611) |
 
 ---
 


### PR DESCRIPTION
Housekeeping — adds PR #636 to Recently Landed, drops oldest entry to keep table at 6.