### PR TITLE
fix: resolve code scanning security alerts

### DIFF
--- a/tests/test_billing_ledger.py
+++ b/tests/test_billing_ledger.py
@@ -427,17 +427,28 @@ class TestOverageProviderIntegration:
 
 
 class TestRedactUserId:
-    def test_truncates_long_id(self):
+    def test_returns_hash_prefix(self):
         from treesight.security.redact import redact_user_id
 
-        assert redact_user_id("abcdefghij") == "abcdefgh…"
+        result = redact_user_id("abcdefghij")
+        assert result.startswith("u#")
+        assert len(result) == 14  # "u#" + 12 hex chars
+        # No raw PII leaks
+        assert "abcdefgh" not in result
 
-    def test_short_id_unchanged(self):
+    def test_deterministic(self):
         from treesight.security.redact import redact_user_id
 
-        assert redact_user_id("abc") == "abc"
+        assert redact_user_id("abc") == redact_user_id("abc")
 
-    def test_exactly_eight_chars(self):
+    def test_different_ids_produce_different_hashes(self):
         from treesight.security.redact import redact_user_id
 
-        assert redact_user_id("12345678") == "12345678"
+        assert redact_user_id("user-a") != redact_user_id("user-b")
+
+    def test_empty_string(self):
+        from treesight.security.redact import redact_user_id
+
+        result = redact_user_id("")
+        assert result.startswith("u#")
+        assert len(result) == 14

--- a/treesight/security/redact.py
+++ b/treesight/security/redact.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
+import hashlib
+
 
 def redact_user_id(user_id: str) -> str:
-    """Return a truncated user ID safe for logging (no full PII)."""
-    return user_id[:8] + "…" if len(user_id) > 8 else user_id
+    """Return a hashed prefix of *user_id* safe for logging.
+
+    Uses a SHA-256 digest so no raw PII leaks into logs while
+    remaining deterministic (same input → same output) for
+    log correlation.
+    """
+    digest = hashlib.sha256(user_id.encode()).hexdigest()
+    return f"u#{digest[:12]}"


### PR DESCRIPTION
## Summary

Resolves all 6 open code scanning alerts (2 CodeQL, 4 Trivy).

### Code fix — Alert #2873 (HIGH)
**`py/clear-text-logging-sensitive-data`** in `billing_ledger.py:133`

`redact_user_id()` was doing substring truncation (`user_id[:8] + "…"`), which:
- Leaked the first 8 characters of raw user ID into logs
- Returned the **full** value for IDs ≤ 8 chars
- Maintained CodeQL taint tracking through the substring

**Fix:** Replaced with SHA-256 hash prefix (`u#<12-hex-chars>`). This:
- Breaks the taint chain entirely (new value, no raw PII)
- Remains deterministic for log correlation
- Works for all input lengths including empty strings

### Dismissed — Alert #78 (note)
**`py/ineffectual-statement`** in `replay.py:26` — dismissed as **false positive**.
`...` (Ellipsis) is the standard Python idiom for `Protocol` method stubs. Pyright/mypy treat it as a type-safe stub marker; replacing with `pass` triggers `reportReturnType`.

### Dismissed — Alerts #2872, #2871, #2870 (low)
Base image / Azure Functions host transitive dependencies (CVE-2026-32178, GHSA-g4vj-cjjj-v7hg). Not our code — requires Microsoft to update the base image.

### Dismissed — Alert #101 (low)
AZU-0058 geo-redundant storage — intentionally disabled for dev (LRS saves cost). Will revisit for production tier.

## Testing
- All 1404 tests pass, 27 skipped
- `TestRedactUserId` updated with 4 new tests covering hash format, determinism, uniqueness, and empty input
- `ruff check` + `ruff format --check` + `pyright` all pass