### PR TITLE
fix: parse Durable Functions input_ from JSON string for ownership check

### DIFF
--- a/blueprints/_helpers.py
+++ b/blueprints/_helpers.py
@@ -304,6 +304,16 @@ def submit_contact(
     )
 
 
+def _parse_json_field(value: Any) -> Any:
+    """Parse a Durable Functions status field that may be a JSON string."""
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+    return value
+
+
 async def fetch_enrichment_manifest(
     req: func.HttpRequest,
     client: Any,
@@ -330,17 +340,13 @@ async def fetch_enrichment_manifest(
         return None, error_response(404, "Pipeline not found or not complete", req=req)
 
     # Verify the authenticated user owns this orchestration
-    inp = status.input_ if hasattr(status, "input_") else None
+    inp = getattr(status, "input_", None)
+    inp = _parse_json_field(inp)
     owner_id = inp.get("user_id", "") if isinstance(inp, dict) else ""
     if not owner_id or owner_id != caller_user_id:
         return None, error_response(404, "Pipeline not found or not complete", req=req)
 
-    output = status.output
-    if isinstance(output, str):
-        try:
-            output = json.loads(output)
-        except (json.JSONDecodeError, TypeError):
-            output = {}
+    output = _parse_json_field(status.output)
     if not isinstance(output, dict):
         output = {}
     if reshape_output is not None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -398,3 +398,38 @@ class TestFetchEnrichmentManifest:
         assert manifest is None
         assert err is not None
         assert err.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_input_as_json_string(self) -> None:
+        """input_ from the Durable Functions SDK is a JSON string, not a dict."""
+        import json
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from blueprints._helpers import fetch_enrichment_manifest
+
+        fake_status = MagicMock()
+        fake_status.output = json.dumps({"enrichmentManifest": "enrichment/abc/payload.json"})
+        fake_status.input_ = json.dumps({"user_id": "user-123"})
+
+        client = AsyncMock()
+        client.get_status = AsyncMock(return_value=fake_status)
+
+        req = func.HttpRequest(
+            method="GET",
+            url="https://example.com/api/timelapse-data/abc",
+            route_params={"instance_id": "abc"},
+            headers={"Origin": TEST_ORIGIN},
+            body=b"",
+        )
+
+        with (
+            patch("blueprints._helpers.check_auth", return_value=({}, "user-123")),
+            patch(
+                "treesight.storage.client.BlobStorageClient.download_json",
+                return_value={"frames": []},
+            ),
+        ):
+            manifest, err = await fetch_enrichment_manifest(req, client)
+
+        assert err is None
+        assert manifest == {"frames": []}

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -978,6 +978,13 @@
       if (evidenceInstanceId !== instanceId) return;
       evidenceManifest = manifest;
     } catch (err) {
+      // Retry once after a short delay — the orchestrator may have just
+      // completed and storage propagation can lag a few seconds.
+      if (err && err.status === 404 && !arguments[1]) {
+        await new Promise(function (r) { setTimeout(r, 3000); });
+        if (evidenceInstanceId !== instanceId) return;
+        return loadRunEvidence(instanceId, true);
+      }
       if (evidenceInstanceId !== instanceId) return;
       if (footerEl) footerEl.textContent = 'Could not load enrichment data: ' + ((err && err.message) || 'unknown error');
       return;


### PR DESCRIPTION
## Root Cause

The Durable Functions Python SDK returns `status.input_` as a **JSON string**, not a parsed dict. The ownership check in `fetch_enrichment_manifest` used `isinstance(inp, dict)` which was always `False`, causing every authenticated `timelapse-data` request to return **404 "Pipeline not found or not complete"** — even when the orchestration was fully completed with valid enrichment output.

This was the primary cause of the "Analysis is still not loading" bug on the EUDR results page.

## Timeline (from App Insights)

| Time | Endpoint | Status | Notes |
|------|----------|--------|-------|
| 20:08:49 | orchestrator/{id} | 200 | Poller sees `Completed` |
| 20:08:52 | timelapse-data/{id} | 404 | Race: orchestrator still committing (billing retries via `_safe_complete_billing`) |
| 20:08:55 | timelapse-data/{id} | 404 | **Bug**: `input_` is string → ownership check always fails |
| 20:09:49 | timelapse-data/{id} | 401 | Auth state cleared by earlier error cascade |

## Fix

### Backend (`blueprints/_helpers.py`)
- Extract `_parse_json_field()` helper to safely parse JSON strings from Durable Functions status fields
- Apply it to both `input_` (ownership check) and `output` (manifest extraction) — DRY, reduces function complexity

### Frontend (`website/js/app-shell.js`)
- Add single retry with 3s delay in `loadRunEvidence` for 404 responses — handles the race condition where the orchestrator has just completed but billing retries kept it in `Running` state slightly longer

### Tests (`tests/test_helpers.py`)
- Add `test_input_as_json_string` covering the actual SDK behavior (string `input_`)

## Separate Issue: Cosmos DB Firewall

`cosmos-kmlsat-dev` has `publicNetworkAccess: Disabled` with no IP rules, blocking the Container App's outbound IP (`20.26.241.31`). This causes `complete_billing` activity to fail with `CosmosHttpResponseError: (Forbidden)`. The failure is swallowed by `_safe_complete_billing`, but the 3 retry attempts add ~20s to orchestration completion time, widening the race window. Tracked separately.