### PR TITLE
feat(website): show enrichment sub-steps as nested progress indicators

### DIFF
--- a/website/app/index.html
+++ b/website/app/index.html
@@ -198,7 +198,14 @@
             <div class="pipeline-step" data-phase="ingestion"><span class="step-icon">○</span> Parsing AOIs and validating geometry</div>
             <div class="pipeline-step" data-phase="acquisition"><span class="step-icon">○</span> Searching NAIP and Sentinel-2 imagery</div>
             <div class="pipeline-step" data-phase="fulfilment"><span class="step-icon">○</span> Downloading scenes, clipping, and reprojection</div>
-            <div class="pipeline-step" data-phase="enrichment"><span class="step-icon">○</span> Building NDVI, weather, and cache layers</div>
+            <div class="pipeline-step" data-phase="enrichment"><span class="step-icon">○</span> Building evidence layers
+              <div class="pipeline-sub-steps" hidden>
+                <div class="pipeline-sub-step" data-sub="data_sources_and_imagery"><span class="sub-icon">○</span> Weather, fire/flood context, and land-cover overlays</div>
+                <div class="pipeline-sub-step" data-sub="imagery"><span class="sub-icon">○</span> Mosaic registration and NDVI computation</div>
+                <div class="pipeline-sub-step" data-sub="per_aoi"><span class="sub-icon">○</span> Per-AOI enrichment and change detection</div>
+                <div class="pipeline-sub-step" data-sub="finalizing"><span class="sub-icon">○</span> Merging results and storing the manifest</div>
+              </div>
+            </div>
             <div class="pipeline-step" data-phase="complete"><span class="step-icon">○</span> Complete</div>
           </div>
           <dl class="app-stats compact" id="app-analysis-run" hidden>

--- a/website/css/app.css
+++ b/website/css/app.css
@@ -241,6 +241,12 @@
 .app-pipeline-progress .pipeline-step.active{color:var(--c-text);font-weight:600;transform:translateX(2px)}
 .app-pipeline-progress .pipeline-step.done{color:var(--c-green)}
 .app-pipeline-progress .pipeline-step.failed{color:#ffb2ad}
+.app-pipeline-progress .pipeline-sub-steps{display:grid;gap:4px;margin:4px 0 2px 30px}
+.app-pipeline-progress .pipeline-sub-step{display:flex;align-items:center;gap:8px;font-size:.78rem;font-weight:400;color:var(--c-muted);transition:color .2s ease}
+.app-pipeline-progress .pipeline-sub-step.active{color:var(--c-text);font-weight:600}
+.app-pipeline-progress .pipeline-sub-step.done{color:var(--c-green)}
+.app-pipeline-progress .sub-icon{width:14px;text-align:center;font-size:.75rem;flex:0 0 14px}
+.app-pipeline-progress .pipeline-sub-step .spinner{width:10px;height:10px;border-width:1.5px}
 .app-pipeline-progress .step-icon{width:20px;text-align:center;font-size:.9rem;flex:0 0 20px}
 .app-pipeline-progress .spinner{display:inline-block;width:14px;height:14px;border:2px solid var(--c-border);border-top-color:var(--c-accent);border-radius:50%;animation:spin .8s linear infinite}
 .app-run-detail-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -204,7 +204,14 @@
             <div class="pipeline-step" data-phase="ingestion"><span class="step-icon">○</span> Parsing parcels and validating geometry</div>
             <div class="pipeline-step" data-phase="acquisition"><span class="step-icon">○</span> Searching post-2020 Sentinel-2 imagery and polling scene availability</div>
             <div class="pipeline-step" data-phase="fulfilment"><span class="step-icon">○</span> Downloading scenes, clipping to parcel boundaries</div>
-            <div class="pipeline-step" data-phase="enrichment"><span class="step-icon">○</span> Building NDVI time series, deforestation risk, weather, fire, and WorldCover/IO LULC/ALOS land-cover evidence</div>
+            <div class="pipeline-step" data-phase="enrichment"><span class="step-icon">○</span> Building evidence layers
+              <div class="pipeline-sub-steps" hidden>
+                <div class="pipeline-sub-step" data-sub="data_sources_and_imagery"><span class="sub-icon">○</span> Weather, fire/flood, WorldCover, IO LULC, ALOS land-cover</div>
+                <div class="pipeline-sub-step" data-sub="imagery"><span class="sub-icon">○</span> Sentinel-2 mosaic registration and NDVI time series</div>
+                <div class="pipeline-sub-step" data-sub="per_aoi"><span class="sub-icon">○</span> Per-parcel deforestation risk and change detection</div>
+                <div class="pipeline-sub-step" data-sub="finalizing"><span class="sub-icon">○</span> Merging results and storing the evidence manifest</div>
+              </div>
+            </div>
             <div class="pipeline-step" data-phase="complete"><span class="step-icon">○</span> Evidence pack complete — ready for review</div>
           </div>
           <dl class="app-stats compact" id="app-analysis-run" hidden>

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -1710,6 +1710,7 @@
       var icon = el.querySelector('.step-icon');
       if (icon) icon.textContent = '○';
     });
+    resetEnrichmentSubSteps();
   }
 
   function setAnalysisProgressVisible(visible) {
@@ -1769,6 +1770,69 @@
     finalizing: 'Merging results and storing the analysis manifest.'
   };
 
+  // Sub-step order for the enrichment phase progress UI.
+  // 'data_sources_and_imagery' maps to both data_sources_and_imagery + imagery
+  // sub-bullets since the orchestrator runs them in parallel under one status.
+  const ENRICHMENT_SUB_ORDER = ['data_sources_and_imagery', 'imagery', 'per_aoi', 'finalizing'];
+
+  function updateEnrichmentSubSteps(enrichmentStep) {
+    const container = document.querySelector('#app-analysis-progress .pipeline-step[data-phase="enrichment"] .pipeline-sub-steps');
+    if (!container) return;
+    container.hidden = false;
+    const currentIdx = ENRICHMENT_SUB_ORDER.indexOf(enrichmentStep);
+    const subs = container.querySelectorAll('.pipeline-sub-step');
+    subs.forEach(function(el) {
+      const sub = el.getAttribute('data-sub');
+      const icon = el.querySelector('.sub-icon');
+      el.className = 'pipeline-sub-step';
+      if (!icon) return;
+      const subIdx = ENRICHMENT_SUB_ORDER.indexOf(sub);
+      if (subIdx < 0) return;
+
+      // data_sources_and_imagery and imagery run in parallel — treat
+      // them as the same phase for status purposes.
+      const isParallelPair = (sub === 'imagery' && enrichmentStep === 'data_sources_and_imagery')
+        || (sub === 'data_sources_and_imagery' && enrichmentStep === 'imagery');
+
+      if (sub === enrichmentStep || isParallelPair) {
+        el.classList.add('active');
+        icon.replaceChildren();
+        const spinner = document.createElement('span');
+        spinner.className = 'spinner';
+        icon.appendChild(spinner);
+      } else if (subIdx < currentIdx) {
+        el.classList.add('done');
+        icon.textContent = '✓';
+      } else {
+        icon.textContent = '○';
+      }
+    });
+  }
+
+  function resetEnrichmentSubSteps() {
+    const container = document.querySelector('#app-analysis-progress .pipeline-step[data-phase="enrichment"] .pipeline-sub-steps');
+    if (!container) return;
+    container.hidden = true;
+    const subs = container.querySelectorAll('.pipeline-sub-step');
+    subs.forEach(function(el) {
+      el.className = 'pipeline-sub-step';
+      const icon = el.querySelector('.sub-icon');
+      if (icon) icon.textContent = '○';
+    });
+  }
+
+  function completeEnrichmentSubSteps() {
+    const container = document.querySelector('#app-analysis-progress .pipeline-step[data-phase="enrichment"] .pipeline-sub-steps');
+    if (!container) return;
+    container.hidden = false;
+    const subs = container.querySelectorAll('.pipeline-sub-step');
+    subs.forEach(function(el) {
+      el.className = 'pipeline-sub-step done';
+      const icon = el.querySelector('.sub-icon');
+      if (icon) icon.textContent = '✓';
+    });
+  }
+
   function updateAnalysisStory(phase, runtimeStatus, data) {
     var runtime = runtimeStatus || 'Pending';
     var phaseDetails = EUDR_LOCKED ? EUDR_ANALYSIS_PHASE_DETAILS : ANALYSIS_PHASE_DETAILS;
@@ -1790,8 +1854,24 @@
       if (timing.sinceUpdate) {
         detail += ' Last backend update ' + timing.sinceUpdate + ' ago.';
       }
-    } else if (runtime !== 'Completed' && timing.elapsed) {
-      detail += ' Elapsed ' + timing.elapsed + '.';
+      // Drive the nested sub-step progress indicators.
+      if (step) updateEnrichmentSubSteps(step);
+    } else if (phase !== 'enrichment') {
+      // Past enrichment (complete) — mark all sub-steps done.
+      // Before enrichment — keep sub-steps hidden.
+      const enrichIdx = ANALYSIS_PHASES.indexOf('enrichment');
+      const phaseIdx = ANALYSIS_PHASES.indexOf(phase);
+      if (phaseIdx > enrichIdx) {
+        completeEnrichmentSubSteps();
+      } else {
+        resetEnrichmentSubSteps();
+      }
+      if (runtime !== 'Completed' && timing.elapsed) {
+        detail += ' Elapsed ' + timing.elapsed + '.';
+      }
+    } else {
+      // Completed while on enrichment phase — mark all sub-steps done.
+      completeEnrichmentSubSteps();
     }
 
     if (runtime === 'Completed') {


### PR DESCRIPTION
## Summary

Replace the single flat enrichment pipeline step with nested sub-step progress bullets that reveal progressively as the orchestrator moves through each enrichment phase.

### What it looks like

When the pipeline enters the enrichment phase, four nested sub-steps appear under the main "Building evidence layers" step:

1. **Weather, fire/flood, land-cover data sources** — active in parallel with imagery
2. **Sentinel-2 mosaic registration and NDVI** — active in parallel with data sources
3. **Per-parcel enrichment and change detection** — fan-out across AOIs
4. **Merging results and storing the manifest** — finalize step

Sub-steps are hidden until enrichment begins, show spinners when active, checkmarks when done, and all complete when the pipeline finishes.

### Changes

| File | Change |
|------|--------|
| `website/eudr/index.html` | Nested sub-step divs under enrichment (EUDR-specific labels) |
| `website/app/index.html` | Same pattern with conservation-scoped labels |
| `website/css/app.css` | `.pipeline-sub-steps`, `.pipeline-sub-step` styles (indented, smaller, state-driven) |
| `website/js/app-shell.js` | `updateEnrichmentSubSteps()`, `resetEnrichmentSubSteps()`, `completeEnrichmentSubSteps()` + wiring into `updateAnalysisStory` and `resetAnalysisProgress` |

### How it works

- `updateAnalysisStory()` already reads `customStatus.step` from the orchestrator — now also calls `updateEnrichmentSubSteps(step)` to drive the visual indicators
- `data_sources_and_imagery` and `imagery` sub-bullets both activate simultaneously (orchestrator runs them in parallel under one status)
- When pipeline completes (`phase === 'complete'`), all sub-steps show as done
- `resetAnalysisProgress()` now also resets sub-steps

### Testing

- All 1390 tests pass
- No backend changes — purely frontend
- Structural test in `test_launch_readiness.py` still passes (checks `resetAnalysisProgress` is called in error paths)