### PR TITLE
feat(website): show run ID in evidence section header for traceability

### DIFF
--- a/website/app/index.html
+++ b/website/app/index.html
@@ -238,6 +238,7 @@
             <div>
               <div class="section-label">Evidence</div>
               <h3 id="app-content-title">Satellite Imagery &amp; Analysis</h3>
+              <span class="app-evidence-run-ref" id="app-evidence-run-ref" hidden></span>
             </div>
             <p class="app-evidence-hero-note" id="app-content-copy">Select a completed run to review satellite imagery, vegetation health, weather context, and AI-powered findings.</p>
           </div>

--- a/website/css/app.css
+++ b/website/css/app.css
@@ -49,6 +49,7 @@
 .app-evidence-hero-card{padding:24px;min-height:auto}
 .app-evidence-hero-header{display:flex;justify-content:space-between;gap:16px;align-items:flex-start;flex-wrap:wrap}
 .app-evidence-hero-note{font-size:.88rem;color:var(--c-muted);max-width:48ch;margin:0}
+.app-evidence-run-ref{display:inline-block;font-size:.72rem;font-family:monospace;color:var(--c-muted);background:rgba(230,237,243,.06);border:1px solid var(--c-border);border-radius:4px;padding:1px 7px;margin-top:4px;cursor:default;user-select:all}
 .app-evidence-status-row{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:14px}
 .app-evidence-two-col{display:grid;grid-template-columns:1.6fr 1fr;gap:16px;align-items:start}
 .app-evidence-primary .app-evidence-map-wrap{height:420px}

--- a/website/css/app.css
+++ b/website/css/app.css
@@ -50,6 +50,7 @@
 .app-evidence-hero-header{display:flex;justify-content:space-between;gap:16px;align-items:flex-start;flex-wrap:wrap}
 .app-evidence-hero-note{font-size:.88rem;color:var(--c-muted);max-width:48ch;margin:0}
 .app-evidence-run-ref{display:inline-block;font-size:.72rem;font-family:monospace;color:var(--c-muted);background:rgba(230,237,243,.06);border:1px solid var(--c-border);border-radius:4px;padding:1px 7px;margin-top:4px;cursor:default;user-select:all}
+.app-evidence-run-ref[hidden]{display:none}
 .app-evidence-status-row{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:14px}
 .app-evidence-two-col{display:grid;grid-template-columns:1.6fr 1fr;gap:16px;align-items:start}
 .app-evidence-primary .app-evidence-map-wrap{height:420px}

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -244,6 +244,7 @@
             <div>
               <div class="section-label">Evidence</div>
               <h3 id="app-content-title">Satellite Evidence &amp; EUDR Assessment</h3>
+              <span class="app-evidence-run-ref" id="app-evidence-run-ref" hidden></span>
             </div>
             <p class="app-evidence-hero-note" id="app-content-copy">Select a completed run to review multi-source satellite evidence, vegetation health trends, and per-parcel deforestation-free determination for EUDR compliance.</p>
           </div>

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -967,8 +967,9 @@
     showEvidenceSurface(true);
     clearEvidencePanels();
 
+    var shortId = instanceId.slice(0, 8);
     var footerEl = document.getElementById('app-content-footer');
-    if (footerEl) footerEl.textContent = 'Loading evidence for run ' + instanceId.slice(0, 8) + '…';
+    if (footerEl) footerEl.textContent = 'Loading evidence for run ' + shortId + '…';
 
     try {
       await apiDiscoveryReady;
@@ -998,7 +999,7 @@
     // Show persistent run reference in the evidence header.
     var runRefEl = document.getElementById('app-evidence-run-ref');
     if (runRefEl) {
-      runRefEl.textContent = 'Run ' + instanceId.slice(0, 8);
+      runRefEl.textContent = 'Run ' + shortId;
       runRefEl.title = instanceId;
       runRefEl.hidden = false;
     }
@@ -1031,7 +1032,7 @@
     var noteEl = document.getElementById('app-evidence-ndvi-note');
     if (noteEl) noteEl.textContent = '';
     var runRefEl = document.getElementById('app-evidence-run-ref');
-    if (runRefEl) { runRefEl.textContent = ''; runRefEl.hidden = true; }
+    if (runRefEl) { runRefEl.textContent = ''; runRefEl.title = ''; runRefEl.hidden = true; }
     var canvases = ['app-evidence-ndvi-canvas', 'app-evidence-weather-canvas'];
     canvases.forEach(function(id) {
       var c = document.getElementById(id);

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -995,6 +995,14 @@
     renderEvidenceChangeDetection(evidenceManifest);
     initEvidenceMap(evidenceManifest);
 
+    // Show persistent run reference in the evidence header.
+    var runRefEl = document.getElementById('app-evidence-run-ref');
+    if (runRefEl) {
+      runRefEl.textContent = 'Run ' + instanceId.slice(0, 8);
+      runRefEl.title = instanceId;
+      runRefEl.hidden = false;
+    }
+
     // Per-AOI selector (multi-polygon runs)
     evidenceSelectedAoi = -1;
     populateAoiSelector(evidenceManifest.per_aoi_enrichment);
@@ -1022,6 +1030,8 @@
     ids.forEach(function(id) { var el = document.getElementById(id); if (el) el.textContent = ''; });
     var noteEl = document.getElementById('app-evidence-ndvi-note');
     if (noteEl) noteEl.textContent = '';
+    var runRefEl = document.getElementById('app-evidence-run-ref');
+    if (runRefEl) { runRefEl.textContent = ''; runRefEl.hidden = true; }
     var canvases = ['app-evidence-ndvi-canvas', 'app-evidence-weather-canvas'];
     canvases.forEach(function(id) {
       var c = document.getElementById(id);


### PR DESCRIPTION
## Summary

Add a persistent run ID badge to the evidence section header so the generating pipeline run is always visible and traceable.

### What it does

When evidence loads for a run, a small monospace pill badge appears below the evidence title showing `Run ab12cd34` (first 8 chars of the instance ID). Hovering shows the full ID. The badge clears when evidence is reset.

### Changes

| File | Change |
|------|--------|
| `website/eudr/index.html` | Add `app-evidence-run-ref` span in evidence hero header |
| `website/app/index.html` | Same |
| `website/css/app.css` | `.app-evidence-run-ref` — monospace, muted pill badge, `user-select: all` for easy copy |
| `website/js/app-shell.js` | Populate in `loadRunEvidence()`, clear in `clearEvidencePanels()` |

### Context

- First step toward full evidence provenance (#649)
- All 1390 tests pass
- No backend changes