### PR TITLE
docs: archive completed stages, fix stale statuses, add verification instructions

### DIFF
--- a/.github/instructions/verification-validation.instructions.md
+++ b/.github/instructions/verification-validation.instructions.md
@@ -1,0 +1,65 @@
+---
+description: "Standing orders for verification, validation, and regression prevention across all PRs. Enforces that main stays working and nothing merges without proof."
+name: "Verification & Validation Discipline"
+applyTo: "**"
+---
+# Verification & Validation Discipline
+
+`main` is the deployable branch. It must always work. Every merge is a
+potential deployment. These rules prevent regressions.
+
+## Before opening a PR
+
+1. **Run the full test suite locally.** `make test` must pass with zero
+   failures. No exceptions, no "it's just a docs change" shortcuts — docs
+   changes can break test assertions on route tables or config.
+2. **Run lint and format checks.** `ruff check` and `ruff format --check`
+   must be clean before committing. Fix issues proactively; do not rely
+   on CI to catch them.
+3. **Verify affected behavior manually** when the change touches API
+   endpoints, UI flows, or pipeline logic. If it's testable locally
+   (Azurite, `func start`), test it locally.
+4. **Check for regressions in adjacent areas.** If you changed billing
+   logic, run billing tests. If you changed parsers, run parser tests.
+   If you're unsure what's adjacent, run the full suite.
+
+## CI must pass before merge
+
+- All GitHub Actions checks (lint, test, security scanners) must pass.
+- If a scanner flags a finding, fix it — do not dismiss without
+  justification and user approval.
+- If CI fails on something unrelated to your change, log a `[discovered]`
+  issue and get the PR green before merging.
+
+## Review gate
+
+- Every PR must be reviewed before merge.
+- Address all review comments. Do not merge with unresolved threads.
+- After addressing comments, re-run the test suite to confirm fixes
+  didn't introduce new issues.
+
+## After merge
+
+- Verify the merge commit is clean (`git log --oneline -1`).
+- If the change affects deployed behavior, check the deployment
+  (health endpoint, smoke test, or manual verification as appropriate).
+- Update `docs/ROADMAP.md` as part of the feature branch before merge —
+  mark stage items, update "Recently Landed", close the loop.
+
+## Regression prevention principles
+
+- **Tests are the contract.** If behavior isn't tested, it isn't
+  guaranteed. When you rely on a behavior, write a test for it.
+- **Never weaken a test to make a change pass.** If a test fails, either
+  your change has a bug or the test needs updating because the contract
+  genuinely changed. Both cases require deliberate thought.
+- **Security, auth, billing, and quota gates are load-bearing.** Changes
+  to these areas need extra scrutiny. Run the specific test suites
+  (`test_auth.py`, `test_billing.py`, `test_hmac_auth.py`) and confirm
+  no gate was weakened.
+- **Snapshot the working state.** When the app reaches a known-good
+  milestone (e.g. "pipeline works end-to-end"), note it in the roadmap.
+  Future changes that break that milestone are regressions.
+- **Prefer additive changes.** Add new behavior; deprecate old behavior
+  with a migration path. Avoid big-bang rewrites that invalidate the
+  existing test suite.

--- a/.github/instructions/verification-validation.instructions.md
+++ b/.github/instructions/verification-validation.instructions.md
@@ -43,8 +43,10 @@ potential deployment. These rules prevent regressions.
 - Verify the merge commit is clean (`git log --oneline -1`).
 - If the change affects deployed behavior, check the deployment
   (health endpoint, smoke test, or manual verification as appropriate).
-- Update `docs/ROADMAP.md` as part of the feature branch before merge —
-  mark stage items, update "Recently Landed", close the loop.
+- Finalize `docs/ROADMAP.md` at merge-time / immediately after merge:
+  update "Recently Landed", mark the shipped stage items, and close the
+  loop. If the PR included roadmap edits, treat them as candidate updates
+  to be confirmed or adjusted once the merge is complete.
 
 ## Regression prevention principles
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -53,8 +53,9 @@ Stages 2D and 2E can proceed in parallel.
 ## Completed Stages
 
 M1–M4, Stage 1, Stage 2A/2B, P0–P3, Stage 2C, Stage 2F, and most of
-Stage 2G are complete. Full detail in
-[docs/archive/COMPLETED_STAGES.md](archive/COMPLETED_STAGES.md).
+Stage 2G are complete. Completed-stage detail lives in
+[docs/archive/COMPLETED_STAGES.md](archive/COMPLETED_STAGES.md); any
+still-open Stage 2G items remain tracked below.
 
 ---
 
@@ -101,10 +102,11 @@ Build once, promote dev → prod.
 Dedicated EUDR vertical on the multi-app platform. Master tracker: #606.
 `/eudr/` is the entry point; shared platform concerns live at `/account/`.
 
-**Status:** 21/22 issues closed. Pipeline, data sources, frontend, org
-management, and evidence export are complete. Only #613 (EUDR metered
-Stripe billing) remains — tracked in 2D (R.3) and 2G.5. #589 (billing
-ledger) merged as PR #629. Batch ops (#588) moved to Stage 4.1.
+**Status:** 21/22 issues closed. Pipeline, core data sources, frontend,
+org management, and evidence export are complete. Remaining: #613 (EUDR
+metered Stripe billing — also in 2D/R.3), #612 (Landsat deep
+integration, D.5), #617 (EUDR content cluster, FE.5). Billing ledger
+(#589) merged as PR #629. Batch ops (#588) moved to Stage 4.1.
 
 ### 2G.1 — Data Sources
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,7 @@
 **Single source of truth for what to build next.**
 Issues hold the detail. This list holds the order.
 
-Last updated: 2026-04-17
+Last updated: 2026-04-18
 
 ---
 
@@ -52,72 +52,9 @@ Stages 2D and 2E can proceed in parallel.
 
 ## Completed Stages
 
-<details>
-<summary>M1–M4, Stage 1, Stage 2A/2B (expand)</summary>
-
-| Milestone | Summary |
-|-----------|---------|
-| **M1 — Deployable Product** | CI/CD, Azure deploy, App Insights, AI Foundry, KMZ |
-| **M2 — Free Tier Launch** | SWA auth, onboarding, KML guide, terms/privacy |
-| **M3 — Core Analysis Value** | NDVI, weather, AI summaries, change detection, multi-polygon |
-| **M4 — Revenue** | Stripe billing, quota, pricing page, export, EUDR mode, WorldCover, WDPA |
-| **Stage 1 — Launch Readiness** | Cosmos migration, billing gate, dashboard, SSO, branding |
-| **Stage 2A/2B — Scaling + Pipeline** | Fan-out/fan-in, bulk AOI, Rust accel, Batch fallback, BYOF consolidation |
-
-### P0 — Live Site Fixes ✅
-
-| Issue | Title | Status |
-|-------|-------|--------|
-| #438 | CSP violations + deploy health check regression | ✅ PR #442 |
-| #446 | SWA strips Authorization header → built-in auth | ✅ PR #472 |
-
-### P1 — Event-Driven Pipeline + BFF ✅
-
-| Issue | Title | Status |
-|-------|-------|--------|
-| #421 | KML/KMZ input sanitisation | ✅ PR #425 |
-| #422 | SAS token minting + status polling | ✅ PR #427 |
-| #423 | Unify on event-driven path | ✅ Merged |
-| #424 | Migrate read-only endpoints | ✅ PR #444, #481, #483, #484 |
-| #446 | Switch to SWA built-in auth | ✅ PR #472 |
-| #464 | App Insights instrumentation | ✅ PR #478 |
-
-### P2 — Code Quality ✅
-
-| Issue | Title | Status |
-|-------|-------|--------|
-| #452, #457, #458, #459 | Orchestrator decomp, code quality | ✅ PR #487 |
-| #437 | E2E validation (200+ AOI) | Partial (#488) |
-| #439, #381, #440 | Scanning alerts, CVEs | ✅ Closed |
-
-### P3 — BYOF Consolidation ✅
-
-All 12 items completed. SWA managed API deleted. All `/api/*` on
-Container Apps FA via `api-config.json`.
-
-</details>
-
----
-
-## Stage 2C — Pipeline Verification & User Journey
-
-Prove the pipeline works, fix bugs, establish `/eudr/` as the entry point.
-
-| Order | Issue | Title | Status |
-|-------|-------|-------|--------|
-| 2C.1 | #531 | E2e pipeline verification in Azure | ✅ Verified 2026-04-12 |
-| 2C.1 | #520 | Fix billing/status 500 | ✅ PR #536 |
-| 2C.2 | #532 | Remove demo mode — Free Tier entry point | ✅ PR #546 |
-| 2C.3 | #533 | EUDR pricing on pricing page | ✅ PR #615 |
-| 2C.4 | #555 | Dashboard UX overhaul (6 slices) | ✅ PR #557, #559 |
-| 2C.5 | #565 | Upload quota & Cosmos user management | ✅ PR #566 |
-| 2C.6 | #575 | `aoi_limit` never enforced at submission | ✅ PR #620 |
-| 2C.6 | #580 | Feature/AOI count mismatch (56→57) | ✅ PR #620 |
-| 2C.7 | #590 | Pipeline retry model + quota refund | ✅ |
-| 2C.8 | #610 | Create `/eudr/` app entry point | ✅ PR #615 |
-
-**Exit:** Visitor → `/` landing page → `/eudr/` → free trial → submit
-parcels → evidence → pricing. AOI limits enforced. Retries work.
+M1–M4, Stage 1, Stage 2A/2B, P0–P3, Stage 2C, Stage 2F, and most of
+Stage 2G are complete. Full detail in
+[docs/archive/COMPLETED_STAGES.md](archive/COMPLETED_STAGES.md).
 
 ---
 
@@ -150,33 +87,12 @@ Build once, promote dev → prod.
 
 | Order | Issue | Title | Status |
 |-------|-------|-------|--------|
-| 2E.1 | #401 | Separate dev and prod deployment flows | 🔄 In PR |
-| 2E.2 | #405 | Reduce config drift (OpenTofu vs az CLI) | Open (needs #401) |
-| 2E.3 | #402 | Security-gated production deploys | Open (needs #401) |
-| 2E.4 | #403 | Smoke gates, promotion/demotion | Open (needs #401) |
+| 2E.1 | #401 | Separate dev and prod deployment flows | ✅ Closed |
+| 2E.2 | #405 | Reduce config drift (OpenTofu vs az CLI) | Open |
+| 2E.3 | #402 | Security-gated production deploys | Open |
+| 2E.4 | #403 | Smoke gates, promotion/demotion | Open |
 
 **Exit:** Immutable artifact promotion. Security-gated. Smoke before traffic.
-
----
-
-## Stage 2F — Per-Parcel Evidence & EUDR Export
-
-Per-AOI enrichment so multi-polygon submissions produce audit-grade EUDR evidence.
-**Do not start until 2C.6 bugs are fixed.**
-
-| Order | Issue | Title | Status | Depends On |
-|-------|-------|-------|--------|------------|
-| F.0 | #583 | Data model cleanup: typed models, manifest, run timing | ✅ PR #620 | — |
-| F.1 | #578 | Per-AOI enrichment: weather, NDVI, change detection | ✅ PR #620 | #583 |
-| F.2 | #574 | Enrichment sub-step progress in UI | ✅ | #578 |
-| F.3 | #579 | Frontend per-AOI evidence + polygon interaction | ✅ PR #620 | #578 |
-| F.4 | #581 | Spatial clustering for wide-spread submissions | ✅ d01f642 | #578 |
-| F.5 | #582 | EUDR per-parcel deforestation evidence export | ✅ aee1756 | #578, #579 |
-| F.6 | #585 | Progressive delivery: stream per-AOI results | ✅ PR #626 | #578 |
-| F.7 | #587 | Audit-grade EUDR PDF report | ✅ f586892 | #578, #582 |
-
-**Exit:** 50-polygon submission → per-AOI NDVI/weather/change. Click polygon
-→ see that AOI's results. EUDR PDF with per-parcel evidence.
 
 ---
 
@@ -185,9 +101,10 @@ Per-AOI enrichment so multi-polygon submissions produce audit-grade EUDR evidenc
 Dedicated EUDR vertical on the multi-app platform. Master tracker: #606.
 `/eudr/` is the entry point; shared platform concerns live at `/account/`.
 
-**Status:** 20/22 issues closed. Pipeline, data sources, frontend, org
-management, and evidence export are complete. Revenue items (#589, #613)
-tracked in 2D/2G.5. Batch ops (#588) moved to Stage 4.1.
+**Status:** 21/22 issues closed. Pipeline, data sources, frontend, org
+management, and evidence export are complete. Only #613 (EUDR metered
+Stripe billing) remains — tracked in 2D (R.3) and 2G.5. #589 (billing
+ledger) merged as PR #629. Batch ops (#588) moved to Stage 4.1.
 
 ### 2G.1 — Data Sources
 

--- a/docs/archive/COMPLETED_STAGES.md
+++ b/docs/archive/COMPLETED_STAGES.md
@@ -1,0 +1,134 @@
+# Canopex — Completed Stages Archive
+
+Archived from `docs/ROADMAP.md`. These stages are done and closed.
+The roadmap retains a summary line; full detail lives here.
+
+---
+
+## M1 — Deployable Product
+
+CI/CD, Azure deploy, App Insights, AI Foundry, KMZ support.
+
+## M2 — Free Tier Launch
+
+SWA auth, onboarding, KML guide, terms/privacy.
+
+## M3 — Core Analysis Value
+
+NDVI, weather, AI summaries, change detection, multi-polygon.
+
+## M4 — Revenue
+
+Stripe billing, quota, pricing page, export, EUDR mode,
+WorldCover, WDPA.
+
+## Stage 1 — Launch Readiness
+
+Cosmos migration, billing gate, dashboard, SSO, branding.
+
+## Stage 2A/2B — Scaling + Pipeline
+
+Fan-out/fan-in, bulk AOI, Rust acceleration, Batch fallback,
+BYOF consolidation.
+
+---
+
+## P0 — Live Site Fixes ✅
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| #438 | CSP violations + deploy health check regression | ✅ PR #442 |
+| #446 | SWA strips Authorization header → built-in auth | ✅ PR #472 |
+
+## P1 — Event-Driven Pipeline + BFF ✅
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| #421 | KML/KMZ input sanitisation | ✅ PR #425 |
+| #422 | SAS token minting + status polling | ✅ PR #427 |
+| #423 | Unify on event-driven path | ✅ Merged |
+| #424 | Migrate read-only endpoints | ✅ PR #444, #481, #483, #484 |
+| #446 | Switch to SWA built-in auth | ✅ PR #472 |
+| #464 | App Insights instrumentation | ✅ PR #478 |
+
+## P2 — Code Quality ✅
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| #452, #457, #458, #459 | Orchestrator decomp, code quality | ✅ PR #487 |
+| #437 | E2E validation (200+ AOI) | Partial (#488) |
+| #439, #381, #440 | Scanning alerts, CVEs | ✅ Closed |
+
+## P3 — BYOF Consolidation ✅
+
+All 12 items completed. SWA managed API deleted. All `/api/*` on
+Container Apps FA via `api-config.json`.
+
+---
+
+## Stage 2C — Pipeline Verification & User Journey ✅
+
+Prove the pipeline works, fix bugs, establish `/eudr/` as the entry point.
+
+| Order | Issue | Title | Status |
+|-------|-------|-------|--------|
+| 2C.1 | #531 | E2e pipeline verification in Azure | ✅ Verified 2026-04-12 |
+| 2C.1 | #520 | Fix billing/status 500 | ✅ PR #536 |
+| 2C.2 | #532 | Remove demo mode — Free Tier entry point | ✅ PR #546 |
+| 2C.3 | #533 | EUDR pricing on pricing page | ✅ PR #615 |
+| 2C.4 | #555 | Dashboard UX overhaul (6 slices) | ✅ PR #557, #559 |
+| 2C.5 | #565 | Upload quota & Cosmos user management | ✅ PR #566 |
+| 2C.6 | #575 | `aoi_limit` never enforced at submission | ✅ PR #620 |
+| 2C.6 | #580 | Feature/AOI count mismatch (56→57) | ✅ PR #620 |
+| 2C.7 | #590 | Pipeline retry model + quota refund | ✅ |
+| 2C.8 | #610 | Create `/eudr/` app entry point | ✅ PR #615 |
+
+## Stage 2F — Per-Parcel Evidence & EUDR Export ✅
+
+| Order | Issue | Title | Status | Depends On |
+|-------|-------|-------|--------|------------|
+| F.0 | #583 | Data model cleanup: typed models, manifest, run timing | ✅ PR #620 | — |
+| F.1 | #578 | Per-AOI enrichment: weather, NDVI, change detection | ✅ PR #620 | #583 |
+| F.2 | #574 | Enrichment sub-step progress in UI | ✅ | #578 |
+| F.3 | #579 | Frontend per-AOI evidence + polygon interaction | ✅ PR #620 | #578 |
+| F.4 | #581 | Spatial clustering for wide-spread submissions | ✅ d01f642 | #578 |
+| F.5 | #582 | EUDR per-parcel deforestation evidence export | ✅ aee1756 | #578, #579 |
+| F.6 | #585 | Progressive delivery: stream per-AOI results | ✅ PR #626 | #578 |
+| F.7 | #587 | Audit-grade EUDR PDF report | ✅ f586892 | #578, #582 |
+
+## Stage 2G — EUDR Compliance Product ✅ (bar revenue)
+
+Master tracker: #606. 21/22 issues closed. Only #613 (EUDR metered
+Stripe billing) remains — tracked in Stage 2D (R.3) and 2G.5.
+
+### 2G.1 — Data Sources ✅
+
+| Order | Issue | Title | Dataset |
+|-------|-------|-------|---------|
+| D.1 | #604 | ESA WorldCover overlay | `esa-worldcover` 10m |
+| D.2 | #607 | IO Annual LULC year-over-year | `io-lulc-annual-v02` 10m |
+| D.3 | #608 | ALOS Forest/Non-Forest radar | `alos-fnf-mosaic` 25m |
+| D.4 | #609 | Landsat historical NDVI baseline | `landsat-c2-l2` 30m |
+
+### 2G.2 — Pipeline Logic ✅
+
+| Order | Issue | Title |
+|-------|-------|-------|
+| L.1 | #600 | EUDR mode: post-2020 date filtering |
+| L.2 | #601 | Coordinate-to-polygon converter (lat/lon, CSV) |
+| L.3 | #603 | Deforestation-free determination per AOI |
+
+### 2G.3 — Org & User Management ✅
+
+| Order | Issue | Title |
+|-------|-------|-------|
+| ORG.1 | #614 | Org/team data model with email invites |
+
+### 2G.4 — Frontend ✅
+
+| Order | Issue | Title |
+|-------|-------|-------|
+| FE.1 | #611 | JS module decomposition (core, pipeline, evidence) |
+| FE.2 | #630 | EUDR-specific UI polish on `/eudr/` |
+| FE.3 | #605 | EUDR landing page + sitemap |
+| FE.4 | #602 | Methodology page |


### PR DESCRIPTION
## Summary

Roadmap cleanup and documentation hygiene to prepare for the next round of work.

### Changes

**Archive completed stages** — Moved M1–M4, Stage 1, 2A/2B, P0–P3, Stage 2C, and Stage 2F detail to `docs/archive/COMPLETED_STAGES.md`. The roadmap now has a one-line summary with a link instead of 80+ lines of completed tables.

**Fix stale statuses:**
- #401 (dev/prod deployment flows): was "🔄 In PR" but closed on 2026-04-11 → ✅ Closed
- 2E.2/2E.3/2E.4: removed "(needs #401)" dependency markers since #401 is done
- 2G status: 20/22 → 21/22 (#589 billing ledger merged as PR #629)

**Add verification & validation instructions** — New `.github/instructions/verification-validation.instructions.md` enforcing:
- Full test suite before PRs
- CI must pass before merge
- Review gate discipline
- Regression prevention principles (never weaken tests, security gates are load-bearing)

**Close stale issues:**
- #538 — MI hang: resolved, pipeline verified e2e on 2026-04-12
- #420 — Event-driven pipeline: all 4 slices completed

**Update #606 master tracker** — Body updated to reflect 21/22 closed, #589 marked ✅ PR #629.

### Issues
Closes #538, closes #420