### PR TITLE
Fix subscribe modal hard-wall bug and add Stage 3A roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,7 @@
 **Single source of truth for what to build next.**
 Issues hold the detail. This list holds the order.
 
-Last updated: 2026-04-19
+Last updated: 2026-04-20
 
 ---
 
@@ -30,8 +30,8 @@ entry page. `/eudr/` ships first; others follow when EUDR reaches revenue.
 in one image. 2 vCPU / 4 GiB, KEDA 1–10 replicas, ~£20/month.
 T2/T3 split (#466, #467) deferred until user volume justifies it.
 
-**Execution order:** 2C → 2D → 2E → 2F → 2G → 3 → 4 → 5.
-Stages 2D and 2E can proceed in parallel.
+**Execution order:** 2C → 2D → 2E → 2F → 2G → 3A → 3 → 4 → 5.
+Stages 2D and 2E can proceed in parallel. Stage 3A is current priority.
 
 ---
 
@@ -159,9 +159,26 @@ All at `/eudr/`. Shared billing/account at `/account/`.
 
 ---
 
+## Stage 3A — EUDR Assessment Management 🔄
+
+**Current priority.** Thin vertical slices that improve how compliance
+officers manage, understand, and act on their EUDR assessments.
+Driven by the EUDR user journey gap analysis (`docs/EUDR_USER_JOURNEYS.md`).
+
+| Order | Issue | Title | Status |
+|-------|-------|-------|--------|
+| 3A.1 | #662 | CSV / coordinate paste upload in EUDR frontend | 🔄 |
+| 3A.2 | #661 | Cost estimator in preflight panel | 🔄 |
+| 3A.3 | #660 | Flagged-parcel quick-review UX in evidence panel | 🔄 |
+
+**Exit:** Compliance officer can paste CSV coordinates, see cost before
+queueing, and understand flagged parcels without external help.
+
+---
+
 ## Stage 3 — Growth & Retention
 
-**Do not start until Stages 2C–2G are materially complete.**
+**Do not start until Stage 3A is complete.**
 Growth features target the EUDR vertical first. Conservation/agriculture
 verticals start here as separate `/conservation/` or `/agri/` apps,
 reusing the shared pipeline and platform.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -163,7 +163,7 @@ All at `/eudr/`. Shared billing/account at `/account/`.
 
 **Current priority.** Thin vertical slices that improve how compliance
 officers manage, understand, and act on their EUDR assessments.
-Driven by the EUDR user journey gap analysis (`docs/EUDR_USER_JOURNEYS.md`).
+Driven by the EUDR user journey gap analysis (`EUDR_USER_JOURNEYS.md`).
 
 | Order | Issue | Title | Status |
 |-------|-------|-------|--------|

--- a/website/css/app.css
+++ b/website/css/app.css
@@ -315,9 +315,10 @@
 
 /* ── EUDR subscribe modal (#613) ── */
 .eudr-subscribe-backdrop{position:fixed;inset:0;z-index:9999;background:rgba(0,0,0,.55);display:flex;align-items:center;justify-content:center}
-.eudr-subscribe-modal{background:var(--bg,#fff);border-radius:12px;padding:32px;max-width:440px;width:90%;box-shadow:0 8px 32px rgba(0,0,0,.2)}
-.eudr-subscribe-modal h3{margin:0 0 12px;font-size:1.3rem}
+.eudr-subscribe-backdrop[hidden]{display:none}
+.eudr-subscribe-modal{background:var(--c-surface,#131f1b);color:var(--c-text,#e4ede8);border:1px solid var(--c-border,#243832);border-radius:12px;padding:32px;max-width:440px;width:90%;box-shadow:0 8px 32px rgba(0,0,0,.4)}
+.eudr-subscribe-modal h3{margin:0 0 12px;font-size:1.3rem;color:var(--c-accent,#5eecc4)}
 .eudr-subscribe-features{margin:16px 0;padding-left:20px}
 .eudr-subscribe-features li{margin-bottom:6px}
 .eudr-subscribe-actions{display:flex;gap:12px;margin-top:20px}
-.eudr-subscribe-note{font-size:.8rem;color:var(--text-secondary,#666);margin-top:12px}
+.eudr-subscribe-note{font-size:.8rem;color:var(--c-muted,#7d9a8d);margin-top:12px}

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -492,7 +492,7 @@
 <div class="eudr-subscribe-backdrop" id="eudr-subscribe-backdrop" hidden>
   <div class="eudr-subscribe-modal" role="dialog" aria-modal="true" aria-labelledby="eudr-modal-title">
     <h3 id="eudr-modal-title">Subscribe to EUDR Pro</h3>
-    <p>You've used your 2 free assessments this month. Subscribe for <strong>£49/month</strong> to continue assessing parcels, or wait until next month for your free allowance to refresh.</p>
+    <p>You've used your 2 free assessments. Subscribe for <strong>£49/month</strong> to continue assessing parcels.</p>
     <ul class="eudr-subscribe-features">
       <li>10 parcel assessments included per month</li>
       <li>Additional parcels at £3 each (volume discounts available)</li>

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -492,7 +492,7 @@
 <div class="eudr-subscribe-backdrop" id="eudr-subscribe-backdrop" hidden>
   <div class="eudr-subscribe-modal" role="dialog" aria-modal="true" aria-labelledby="eudr-modal-title">
     <h3 id="eudr-modal-title">Subscribe to EUDR Pro</h3>
-    <p>You've used your 2 free assessments. Subscribe for <strong>£49/month</strong> to continue assessing parcels.</p>
+    <p>You've used your 2 free assessments this month. Subscribe for <strong>£49/month</strong> to continue assessing parcels, or wait until next month for your free allowance to refresh.</p>
     <ul class="eudr-subscribe-features">
       <li>10 parcel assessments included per month</li>
       <li>Additional parcels at £3 each (volume discounts available)</li>

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -2225,9 +2225,17 @@
       return;
     }
 
-    // EUDR entitlement gate: show subscribe modal when trial is exhausted
+    // EUDR entitlement gate: show subscribe modal when trial is exhausted.
+    // If billing hasn't loaded yet, fetch it before deciding.
     if (EUDR_LOCKED && typeof window.eudrBillingData === 'function') {
       var billing = window.eudrBillingData();
+      if (!billing) {
+        try {
+          await apiDiscoveryReady;
+          var billingRes = await apiFetch('/api/eudr/billing');
+          billing = await billingRes.json();
+        } catch (_) { /* proceed — server will enforce */ }
+      }
       if (billing && !billing.subscribed && billing.trial_remaining != null && billing.trial_remaining <= 0) {
         if (typeof window.showEudrSubscribeModal === 'function') {
           window.showEudrSubscribeModal();

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -2225,6 +2225,17 @@
       return;
     }
 
+    // EUDR entitlement gate: show subscribe modal when trial is exhausted
+    if (EUDR_LOCKED && typeof window.eudrBillingData === 'function') {
+      var billing = window.eudrBillingData();
+      if (billing && !billing.subscribed && billing.trial_remaining != null && billing.trial_remaining <= 0) {
+        if (typeof window.showEudrSubscribeModal === 'function') {
+          window.showEudrSubscribeModal();
+        }
+        return;
+      }
+    }
+
     var button = document.getElementById('app-analysis-submit-btn');
     var textarea = document.getElementById('app-analysis-kml');
     if (!button || !textarea) return;


### PR DESCRIPTION
## Summary

Fixes the subscribe modal acting as an unbypassable hard wall when EUDR credits are exhausted. Previously, the modal covered the entire page on load — blocking history, evidence review, and all navigation.

## Changes

### Bug fix: Modal always visible (CSS)
The `.eudr-subscribe-backdrop` had `display:flex` which overrode the HTML `hidden` attribute. Added `.eudr-subscribe-backdrop[hidden]{display:none}` so the modal stays hidden until explicitly shown.

### Bug fix: Invisible text on modal (theming)
The modal used `var(--bg, #fff)` — a variable that doesn't exist — falling back to white. On the dark-themed site, light text on white was invisible. Now uses the site's design tokens: `--c-surface`, `--c-text`, `--c-accent`, `--c-muted`.

### Feature: Entitlement gate on submit only
Added a check in `queueAnalysis()` that shows the subscribe modal only when the user attempts to submit with an exhausted free trial. History, evidence, and navigation remain fully accessible regardless of credit balance.

### Modal copy update
Updated text to clarify that free assessments refresh monthly ("this month"), reducing urgency/alarm.

### Stage 3A roadmap
Added Stage 3A (Assessment Management) to `docs/ROADMAP.md` with three issues:
- #662 CSV / coordinate paste upload
- #661 Cost estimator in preflight
- #660 Flagged-parcel quick-review UX

## Testing
- Full test suite: 1472 passed, 1 skipped
- Lint and format: clean
- Pre-commit hooks: all passed