### PR TITLE
feat: Stage 3A — EUDR Assessment Management

### DIFF
--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -181,7 +181,22 @@ def _check_eudr_entitlement(
 
     Returns (org_id, entitlement_dict, error_response_or_None).
     """
-    org = get_user_org(user_id)
+    try:
+        org = get_user_org(user_id)
+    except Exception:
+        logger.exception(
+            "Failed to resolve org for EUDR entitlement",
+            extra={"user_id": _redact(user_id)},
+        )
+        return (
+            "",
+            {},
+            error_response(
+                503,
+                "Unable to verify EUDR entitlement right now. Please retry shortly.",
+                req=req,
+            ),
+        )
     if not org:
         return (
             "",
@@ -193,7 +208,22 @@ def _check_eudr_entitlement(
             ),
         )
     org_id = org["org_id"]
-    entitlement = check_eudr_entitlement(org_id)
+    try:
+        entitlement = check_eudr_entitlement(org_id)
+    except Exception:
+        logger.exception(
+            "EUDR entitlement check failed during upload flow",
+            extra={"org_id": org_id, "user_id": _redact(user_id)},
+        )
+        return (
+            org_id,
+            {},
+            error_response(
+                503,
+                "EUDR entitlement service is temporarily unavailable. Please retry.",
+                req=req,
+            ),
+        )
     if not entitlement["allowed"]:
         return (
             org_id,
@@ -304,6 +334,18 @@ def _consume_eudr_trial_if_needed(
         return error_response(
             403,
             "EUDR entitlement exhausted — subscription required",
+            req=req,
+        )
+    except Exception:
+        logger.exception(
+            "EUDR trial consumption failed unexpectedly org=%s",
+            eudr_org_id,
+        )
+        if quota_consumed:
+            _safe_release_quota(user_id, instance_id=submission_id)
+        return error_response(
+            503,
+            "EUDR entitlement service is temporarily unavailable. Please retry.",
             req=req,
         )
     return None

--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -24,6 +24,8 @@ from azure.storage.blob import (
 
 from treesight.config import STORAGE_ACCOUNT_NAME
 from treesight.constants import DEFAULT_INPUT_CONTAINER, DEFAULT_PROVIDER, MAX_KML_FILE_SIZE_BYTES
+from treesight.security.eudr_billing import check_eudr_entitlement, consume_eudr_trial
+from treesight.security.orgs import get_user_org
 from treesight.security.quota import consume_quota, release_quota
 from treesight.security.redact import redact_user_id as _redact
 from treesight.storage import cosmos as _cosmos_mod
@@ -172,52 +174,82 @@ def _build_ticket(body: dict, user_id: str, submission_context: dict) -> dict:
     return ticket
 
 
-@bp.route(route="upload/token", methods=["POST", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
-@require_auth
-def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> func.HttpResponse:
-    """Mint a write-only SAS URL for direct-to-blob KML upload."""
-    if not user_id:
-        return error_response(401, "Missing user identity", req=req)
+def _check_eudr_entitlement(
+    user_id: str, req: func.HttpRequest
+) -> tuple[str, dict, func.HttpResponse | None]:
+    """Validate EUDR entitlement for the requesting user's org.
 
-    if not STORAGE_ACCOUNT_NAME:
-        logger.error("Storage account not configured for SAS generation")
-        return error_response(503, "Service not configured", req=req)
+    Returns (org_id, entitlement_dict, error_response_or_None).
+    """
+    org = get_user_org(user_id)
+    if not org:
+        return (
+            "",
+            {},
+            error_response(
+                403,
+                "EUDR assessments require an org. Create or join an org first.",
+                req=req,
+            ),
+        )
+    org_id = org["org_id"]
+    entitlement = check_eudr_entitlement(org_id)
+    if not entitlement["allowed"]:
+        return (
+            org_id,
+            entitlement,
+            error_response(
+                403,
+                "EUDR entitlement exhausted — subscription required",
+                req=req,
+            ),
+        )
+    return org_id, entitlement, None
 
-    # Consume quota upfront so the runs counter decrements immediately.
-    quota_consumed = False
+
+def _consume_upload_quota(
+    user_id: str, req: func.HttpRequest
+) -> tuple[bool, dict, func.HttpResponse | None]:
+    """Consume quota and compute billing fields.
+
+    Returns (quota_consumed, billing_fields, error_response_or_None).
+    """
     billing_fields: dict = {}
     try:
         consume_quota(user_id)
-        quota_consumed = True
-        try:
-            from treesight.security.billing_ledger import billing_fields_for_submission
-
-            billing_fields = billing_fields_for_submission(user_id)
-        except Exception:
-            logger.warning("Billing classification failed for user=%s", user_id, exc_info=True)
     except ValueError as exc:
-        return error_response(403, str(exc), req=req)
+        return False, {}, error_response(403, str(exc), req=req)
     except Exception:
         logger.exception(
             "Quota storage unavailable for user=%s — allowing submission",
             _redact(user_id),
         )
+        return False, {}, None
 
-    submission_id = str(uuid.uuid4())
-    blob_name = f"analysis/{submission_id}.kml"
-
-    # Parse optional submission context from request body
     try:
-        body = json.loads(req.get_body()) if req.get_body() else {}
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        body = {}
+        from treesight.security.billing_ledger import billing_fields_for_submission
 
-    submission_context = _sanitise_submission_context(body.get("submission_context") or {})
-    effective_provider = _resolve_provider(body, submission_context)
+        billing_fields = billing_fields_for_submission(user_id)
+    except Exception:
+        logger.warning("Billing classification failed for user=%s", user_id, exc_info=True)
 
-    # Write ticket blob — trusted server-side record of who initiated the upload
+    return True, billing_fields, None
+
+
+def _write_ticket_and_mint_sas(
+    body: dict,
+    user_id: str,
+    submission_id: str,
+    blob_name: str,
+    submission_context: dict,
+    quota_consumed: bool,
+    req: func.HttpRequest,
+) -> tuple[str | None, func.HttpResponse | None]:
+    """Write ticket blob and mint SAS URL.
+
+    Returns (sas_url, error_response_or_None).
+    """
     ticket = _build_ticket(body, user_id, submission_context)
-
     try:
         blob_service = get_blob_service_client()
         ticket_blob = blob_service.get_blob_client(
@@ -232,7 +264,7 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
         logger.exception("Failed to write ticket for submission_id=%s", submission_id)
         if quota_consumed:
             _safe_release_quota(user_id, instance_id=submission_id)
-        return error_response(502, "Storage service temporarily unavailable", req=req)
+        return None, error_response(502, "Storage service temporarily unavailable", req=req)
 
     try:
         sas_url, _ = _mint_sas_url(blob_service, blob_name, submission_id)
@@ -240,10 +272,108 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
         logger.exception("Failed to mint SAS URL for submission_id=%s", submission_id)
         if quota_consumed:
             _safe_release_quota(user_id, instance_id=submission_id)
-        return error_response(502, "Storage service temporarily unavailable", req=req)
+        return None, error_response(502, "Storage service temporarily unavailable", req=req)
+
+    return sas_url, None
+
+
+def _consume_eudr_trial_if_needed(
+    is_eudr: bool,
+    entitlement: dict,
+    eudr_org_id: str,
+    quota_consumed: bool,
+    user_id: str,
+    submission_id: str,
+    req: func.HttpRequest,
+) -> func.HttpResponse | None:
+    """Decrement EUDR free-trial counter if applicable.
+
+    Returns error_response or None on success.
+    """
+    if not (is_eudr and entitlement.get("reason") == "free_trial"):
+        return None
+    try:
+        consume_eudr_trial(eudr_org_id)
+    except ValueError:
+        logger.warning(
+            "EUDR trial race: entitlement passed but consume failed org=%s",
+            eudr_org_id,
+        )
+        if quota_consumed:
+            _safe_release_quota(user_id, instance_id=submission_id)
+        return error_response(
+            403,
+            "EUDR entitlement exhausted — subscription required",
+            req=req,
+        )
+    return None
+
+
+@bp.route(route="upload/token", methods=["POST", "OPTIONS"], auth_level=func.AuthLevel.ANONYMOUS)
+@require_auth
+def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> func.HttpResponse:
+    """Mint a write-only SAS URL for direct-to-blob KML upload."""
+    if not user_id:
+        return error_response(401, "Missing user identity", req=req)
+
+    if not STORAGE_ACCOUNT_NAME:
+        logger.error("Storage account not configured for SAS generation")
+        return error_response(503, "Service not configured", req=req)
+
+    # Parse request body early — needed for EUDR entitlement check.
+    try:
+        body = json.loads(req.get_body()) if req.get_body() else {}
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        body = {}
+
+    is_eudr = body.get("eudr_mode") is True
+
+    # ── EUDR entitlement gate ──────────────────────────────────────
+    eudr_org_id: str = ""
+    entitlement: dict = {}
+    if is_eudr:
+        eudr_org_id, entitlement, err = _check_eudr_entitlement(user_id, req)
+        if err:
+            return err
+
+    # Consume quota upfront so the runs counter decrements immediately.
+    quota_consumed, billing_fields, quota_err = _consume_upload_quota(user_id, req)
+    if quota_err:
+        return quota_err
+
+    submission_id = str(uuid.uuid4())
+    blob_name = f"analysis/{submission_id}.kml"
+
+    submission_context = _sanitise_submission_context(body.get("submission_context") or {})
+    effective_provider = _resolve_provider(body, submission_context)
+
+    # Write ticket blob + mint SAS URL
+    sas_url, storage_err = _write_ticket_and_mint_sas(
+        body,
+        user_id,
+        submission_id,
+        blob_name,
+        submission_context,
+        quota_consumed,
+        req,
+    )
+    if storage_err:
+        return storage_err
+
+    # ── EUDR trial consumption ─────────────────────────────────────
+    eudr_err = _consume_eudr_trial_if_needed(
+        is_eudr,
+        entitlement,
+        eudr_org_id,
+        quota_consumed,
+        user_id,
+        submission_id,
+        req,
+    )
+    if eudr_err:
+        return eudr_err
 
     # Persist submission record only after SAS minting succeeds
-    # so a minting failure doesn't leave a phantom run.
     submitted_at = datetime.datetime.now(datetime.UTC).isoformat()
     from treesight.models.records import RunRecord
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,8 +30,8 @@ entry page. `/eudr/` ships first; others follow when EUDR reaches revenue.
 in one image. 2 vCPU / 4 GiB, KEDA 1–10 replicas, ~£20/month.
 T2/T3 split (#466, #467) deferred until user volume justifies it.
 
-**Execution order:** 2C → 2D → 2E → 2F → 2G → 3A → 3 → 4 → 5.
-Stages 2D and 2E can proceed in parallel. Stage 3A is current priority.
+**Execution order:** 2C → 2D → 2E → 2F → 2G → 3A → 3B → 3 → 4 → 5.
+Stages 2D and 2E can proceed in parallel. Stage 3B is next priority.
 
 ---
 
@@ -39,12 +39,12 @@ Stages 2D and 2E can proceed in parallel. Stage 3A is current priority.
 
 | PR | Summary |
 |----|---------|  
+| (pending) | feat: Stage 3A — EUDR assessment management: entitlement gate, CSV upload, cost estimator, flagged-parcel review (closes #660, #661, #662, #664) |
+| #663 | fix: Subscribe modal hard-wall bug, EUDR entitlement gate on submit, dark theme modal styling |
 | #657 | feat: Stage 2G completion — EUDR metered billing, Landsat deep integration, EUDR content cluster (closes #612, #613, #535, #617) |
 | #655 | fix: Resolve code scanning alerts — repeated import, clear-text logging |
 | #653 | fix: Close check_auth() HMAC bypass — endpoint auth audit (fixes #572) |
 | #652 | Archive completed stages, fix stale statuses, add verification instructions (closes #538, #420) |
-| #650 | Evidence run ID badge in evidence header |
-| #642 | Cosmos DB: scope public network access to dev only (fixes #640) |
 
 ---
 
@@ -159,26 +159,47 @@ All at `/eudr/`. Shared billing/account at `/account/`.
 
 ---
 
-## Stage 3A — EUDR Assessment Management 🔄
+## Stage 3A — EUDR Assessment Management ✅
 
-**Current priority.** Thin vertical slices that improve how compliance
+**Complete.** Thin vertical slices that improve how compliance
 officers manage, understand, and act on their EUDR assessments.
 Driven by the EUDR user journey gap analysis (`EUDR_USER_JOURNEYS.md`).
 
 | Order | Issue | Title | Status |
 |-------|-------|-------|--------|
-| 3A.1 | #662 | CSV / coordinate paste upload in EUDR frontend | 🔄 |
-| 3A.2 | #661 | Cost estimator in preflight panel | 🔄 |
-| 3A.3 | #660 | Flagged-parcel quick-review UX in evidence panel | 🔄 |
+| 3A.0 | #664 | Server-side EUDR entitlement enforcement | ✅ |
+| 3A.1 | #662 | CSV / coordinate paste upload in EUDR frontend | ✅ |
+| 3A.2 | #661 | Cost estimator in preflight panel | ✅ |
+| 3A.3 | #660 | Flagged-parcel quick-review UX in evidence panel | ✅ |
 
-**Exit:** Compliance officer can paste CSV coordinates, see cost before
-queueing, and understand flagged parcels without external help.
+**Exit:** Server-side billing enforcement is load-bearing. Compliance
+officer can paste CSV coordinates, see cost before queueing, and
+understand flagged parcels without external help.
+
+---
+
+## Stage 3B — EUDR Evidence Quality
+
+**Do not start until Stage 3A is complete.** Improves evidence
+trustworthiness and usability for compliance officers reviewing
+deforestation-free determinations.
+
+| Order | Issue | Title | Status |
+|-------|-------|-------|--------|
+| 3B.1 | #647 | Defensible PDF export: embed imagery, maps, and visual evidence | Open |
+| 3B.2 | #649 | Evidence provenance: traceability from viewer back to source imagery | Open |
+| 3B.3 | #646 | Imagery viewer: dynamic layer picker with smart defaults | Open |
+| 3B.4 | #645 | Imagery quality gate: reject/deprioritise low-res for small AOIs | Open |
+
+**Exit:** Compliance officer can export audit-grade PDF with embedded
+evidence, trace any result back to source imagery, and review layers
+interactively.
 
 ---
 
 ## Stage 3 — Growth & Retention
 
-**Do not start until Stage 3A is complete.**
+**Do not start until Stage 3B is complete.**
 Growth features target the EUDR vertical first. Conservation/agriculture
 verticals start here as separate `/conservation/` or `/agri/` apps,
 reusing the shared pipeline and platform.
@@ -195,6 +216,7 @@ reusing the shared pipeline and platform.
 | 3.8 | — | Shareable analysis links | — |
 | 3.9 | #618 | Brazilian authoritative data enrichment (PRODES, DETER, CAR) | Open |
 | 3.10 | #619 | Evaluate Mapbox/Maxar satellite basemap | Open |
+| 3.11 | #437 | End-to-end validation: 200+ AOI KMZ at scale | Open |
 
 Future enrichment sources: INPE PRODES & DETER (confirmed WFS access),
 CAR/SICAR property registry, MapBiomas, MODIS Burned Area, ESA CCI Land Cover,
@@ -250,6 +272,9 @@ GFW alerts.
 | #525 | Skip unchanged app settings | Next deploy PR |
 | #526 | Batch tofu output calls | Next deploy PR |
 | #529 | Split function app BFF + pipeline | Superseded by #466 |
+| #463 | 3-tier architecture (SWA API / orchestrator / compute) | Superseded by #466 |
+| #424 | Migrate read-only endpoints to SWA functions | Stage 5 infra split |
+| #599 | EUDR competitive analysis & feature gap assessment | Next product review |
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,7 +39,7 @@ Stages 2D and 2E can proceed in parallel. Stage 3B is next priority.
 
 | PR | Summary |
 |----|---------|  
-| (pending) | feat: Stage 3A — EUDR assessment management: entitlement gate, CSV upload, cost estimator, flagged-parcel review (closes #660, #661, #662, #664) |
+| #665 | feat: Stage 3A — EUDR assessment management: entitlement gate, CSV upload, cost estimator, flagged-parcel review (closes #660, #661, #662, #664) |
 | #663 | fix: Subscribe modal hard-wall bug, EUDR entitlement gate on submit, dark theme modal styling |
 | #657 | feat: Stage 2G completion — EUDR metered billing, Landsat deep integration, EUDR content cluster (closes #612, #613, #535, #617) |
 | #655 | fix: Resolve code scanning alerts — repeated import, clear-text logging |

--- a/tests/test_upload_endpoints.py
+++ b/tests/test_upload_endpoints.py
@@ -489,10 +489,14 @@ class TestUploadTokenEudrEntitlement:
         mock_consume_trial.side_effect = ValueError("Trial exhausted")
 
         req = _make_req("/api/upload/token", method="POST", body={"eudr_mode": True})
-        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+        with (
+            patch("blueprints.upload._safe_release_quota") as mock_release,
+            patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"),
+        ):
             resp = upload_token(req)
 
         assert resp.status_code == 403
+        mock_release.assert_called_once()
 
 
 # ===================================================================

--- a/tests/test_upload_endpoints.py
+++ b/tests/test_upload_endpoints.py
@@ -267,9 +267,15 @@ class TestUploadToken:
         assert record["feature_count"] == 3
         assert record["aoi_count"] == 2
 
+    @patch("blueprints.upload.consume_eudr_trial")
+    @patch(
+        "blueprints.upload.check_eudr_entitlement",
+        return_value={"allowed": True, "reason": "free_trial"},
+    )
+    @patch("blueprints.upload.get_user_org", return_value={"org_id": "org-1", "name": "Test Org"})
     @patch("blueprints.upload.generate_blob_sas")
     @patch("blueprints.upload.get_blob_service_client")
-    def test_eudr_mode_true_in_ticket(self, mock_bsc, mock_gen_sas):
+    def test_eudr_mode_true_in_ticket(self, mock_bsc, mock_gen_sas, mock_org, mock_ent, mock_trial):
         from blueprints.upload import upload_token
 
         mock_blob_client = MagicMock()
@@ -325,9 +331,17 @@ class TestUploadToken:
         ticket_data = json.loads(mock_blob_client.upload_blob.call_args[0][0])
         assert "eudr_mode" not in ticket_data
 
+    @patch("blueprints.upload.consume_eudr_trial")
+    @patch(
+        "blueprints.upload.check_eudr_entitlement",
+        return_value={"allowed": True, "reason": "free_trial"},
+    )
+    @patch("blueprints.upload.get_user_org", return_value={"org_id": "org-1", "name": "Test Org"})
     @patch("blueprints.upload.generate_blob_sas")
     @patch("blueprints.upload.get_blob_service_client")
-    def test_eudr_mode_stored_in_run_record(self, mock_bsc, mock_gen_sas):
+    def test_eudr_mode_stored_in_run_record(
+        self, mock_bsc, mock_gen_sas, mock_org, mock_ent, mock_trial
+    ):
         from blueprints.upload import upload_token
 
         mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
@@ -340,6 +354,145 @@ class TestUploadToken:
 
         record = self.mock_persist.call_args[0][1]
         assert record["eudr_mode"] is True
+
+
+# ===================================================================
+# EUDR entitlement enforcement on upload/token
+# ===================================================================
+
+
+class TestUploadTokenEudrEntitlement:
+    """Server-side EUDR entitlement gate (#664)."""
+
+    def setup_method(self):
+        self._quota_patcher = patch("blueprints.upload.consume_quota")
+        self._release_patcher = patch("blueprints.upload.release_quota")
+        self._persist_patcher = patch("blueprints.upload._persist_submission_record")
+        self.mock_consume_quota = self._quota_patcher.start()
+        self.mock_release_quota = self._release_patcher.start()
+        self.mock_persist = self._persist_patcher.start()
+
+    def teardown_method(self):
+        self._persist_patcher.stop()
+        self._release_patcher.stop()
+        self._quota_patcher.stop()
+
+    @patch("blueprints.upload.get_user_org", return_value=None)
+    def test_eudr_mode_rejects_user_without_org(self, mock_org):
+        from blueprints.upload import upload_token
+
+        req = _make_req("/api/upload/token", method="POST", body={"eudr_mode": True})
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 403
+        data = json.loads(resp.get_body())
+        assert "org" in data["error"].lower()
+        self.mock_consume_quota.assert_not_called()
+
+    @patch(
+        "blueprints.upload.check_eudr_entitlement",
+        return_value={"allowed": False, "reason": "subscription_required"},
+    )
+    @patch("blueprints.upload.get_user_org", return_value={"org_id": "org-1", "name": "Test Org"})
+    def test_eudr_mode_rejects_when_entitlement_denied(self, mock_org, mock_ent):
+        from blueprints.upload import upload_token
+
+        req = _make_req("/api/upload/token", method="POST", body={"eudr_mode": True})
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 403
+        data = json.loads(resp.get_body())
+        assert "subscription" in data["error"].lower() or "entitlement" in data["error"].lower()
+        self.mock_consume_quota.assert_not_called()
+
+    @patch("blueprints.upload.consume_eudr_trial")
+    @patch(
+        "blueprints.upload.check_eudr_entitlement",
+        return_value={"allowed": True, "reason": "free_trial"},
+    )
+    @patch("blueprints.upload.get_user_org", return_value={"org_id": "org-1", "name": "Test Org"})
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_eudr_mode_consumes_trial_when_free(
+        self, mock_bsc, mock_gen_sas, mock_org, mock_ent, mock_consume_trial
+    ):
+        from blueprints.upload import upload_token
+
+        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
+
+        req = _make_req("/api/upload/token", method="POST", body={"eudr_mode": True})
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 200
+        mock_consume_trial.assert_called_once_with("org-1")
+        self.mock_consume_quota.assert_called_once()
+
+    @patch("blueprints.upload.consume_eudr_trial")
+    @patch(
+        "blueprints.upload.check_eudr_entitlement",
+        return_value={"allowed": True, "reason": "subscription"},
+    )
+    @patch("blueprints.upload.get_user_org", return_value={"org_id": "org-1", "name": "Test Org"})
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_eudr_mode_skips_trial_when_subscribed(
+        self, mock_bsc, mock_gen_sas, mock_org, mock_ent, mock_consume_trial
+    ):
+        from blueprints.upload import upload_token
+
+        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
+
+        req = _make_req("/api/upload/token", method="POST", body={"eudr_mode": True})
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 200
+        mock_consume_trial.assert_not_called()
+        self.mock_consume_quota.assert_called_once()
+
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_non_eudr_mode_skips_entitlement_check(self, mock_bsc, mock_gen_sas):
+        """Non-EUDR submissions should not check EUDR entitlement."""
+        from blueprints.upload import upload_token
+
+        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
+
+        req = _make_req("/api/upload/token", method="POST", body={"eudr_mode": False})
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 200
+
+    @patch("blueprints.upload.consume_eudr_trial")
+    @patch(
+        "blueprints.upload.check_eudr_entitlement",
+        return_value={"allowed": True, "reason": "free_trial"},
+    )
+    @patch("blueprints.upload.get_user_org", return_value={"org_id": "org-1", "name": "Test Org"})
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_eudr_mode_refunds_quota_on_trial_consume_failure(
+        self, mock_bsc, mock_gen_sas, mock_org, mock_ent, mock_consume_trial
+    ):
+        """If trial consumption fails after quota was consumed, quota is refunded."""
+        from blueprints.upload import upload_token
+
+        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
+        mock_consume_trial.side_effect = ValueError("Trial exhausted")
+
+        req = _make_req("/api/upload/token", method="POST", body={"eudr_mode": True})
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 403
 
 
 # ===================================================================

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -155,11 +155,32 @@
             </div>
           </div>
           <div id="app-analysis-form-fields" hidden>
+          <!-- ── Input mode tabs ── -->
+          <div class="app-input-tabs" id="app-input-tabs">
+            <button class="app-input-tab active" type="button" data-input-tab="kml" aria-pressed="true">Upload KML</button>
+            <button class="app-input-tab" type="button" data-input-tab="csv" aria-pressed="false">Paste Coordinates</button>
+          </div>
+
+          <!-- ── KML tab ── -->
+          <div class="app-input-panel" id="app-input-panel-kml">
           <label class="app-field-label" for="app-analysis-file">KML or KMZ file</label>
           <input id="app-analysis-file" type="file" accept=".kml,.kmz,application/vnd.google-earth.kml+xml,application/vnd.google-earth.kmz">
           <p class="app-note" id="app-analysis-file-note">Choose a KML or KMZ file, or paste KML below.</p>
           <label class="app-field-label" for="app-analysis-kml">KML Content</label>
           <textarea id="app-analysis-kml" placeholder="Paste KML content here…"></textarea>
+          </div>
+
+          <!-- ── CSV coordinates tab ── -->
+          <div class="app-input-panel" id="app-input-panel-csv" hidden>
+          <label class="app-field-label" for="app-csv-input">Parcel coordinates (CSV)</label>
+          <textarea id="app-csv-input" placeholder="name, lat, lon&#10;Plot A, 51.5074, -0.1278&#10;Plot B, 48.8566, 2.3522"></textarea>
+          <p class="app-note" id="app-csv-input-note">One row per parcel: <code>name, lat, lon</code>. Points are buffered to 100 m polygons.</p>
+          <div class="app-csv-actions">
+            <button class="btn btn-secondary" id="app-csv-convert-btn" type="button">Convert to KML</button>
+          </div>
+          <div class="app-csv-status" id="app-csv-status" hidden></div>
+          </div>
+
           <div class="app-preflight-card" id="app-analysis-preflight">
             <div class="app-preflight-header">
               <div>
@@ -178,6 +199,7 @@
               <div><span>AOIs</span><strong id="app-preflight-aois">0</strong></div>
               <div><span>Spread</span><strong id="app-preflight-spread">—</strong></div>
               <div><span>Quota impact</span><strong id="app-preflight-quota">—</strong></div>
+              <div><span>Cost estimate</span><strong id="app-preflight-cost">—</strong></div>
             </div>
             <div class="app-preflight-list" id="app-preflight-warnings">
               <div class="app-preflight-item" data-tone="info">Preflight will show warnings here after you paste or upload KML.</div>
@@ -332,6 +354,7 @@
                     <div class="app-evidence-aoi-detail-name" id="app-evidence-aoi-detail-name"></div>
                     <div class="app-evidence-aoi-detail-grid" id="app-evidence-aoi-detail-grid"></div>
                     <div class="app-evidence-aoi-determination" id="app-evidence-aoi-determination" hidden></div>
+                    <div class="app-evidence-flags" id="app-evidence-flags" hidden></div>
                   </div>
                 </div>
               </div>

--- a/website/css/app.css
+++ b/website/css/app.css
@@ -183,6 +183,19 @@
 .app-evidence-aoi-determination{padding:10px 12px;border-radius:10px;font-size:.8rem;line-height:1.5;margin-top:6px}
 .app-evidence-aoi-determination.compliant{background:rgba(63,185,80,.1);border:1px solid rgba(63,185,80,.24)}
 .app-evidence-aoi-determination.non-compliant{background:rgba(248,81,73,.1);border:1px solid rgba(248,81,73,.24)}
+/* Flag detail cards */
+.app-evidence-flags{display:flex;flex-direction:column;gap:8px;margin-top:8px}
+.app-flag-banner{padding:10px 14px;border-radius:var(--radius);font-size:.82rem;font-weight:600;line-height:1.5}
+.app-flag-banner.has-high{background:rgba(248,81,73,.12);border:1px solid rgba(248,81,73,.28);color:#ffb2ad}
+.app-flag-banner.moderate-only{background:rgba(227,176,42,.12);border:1px solid rgba(227,176,42,.28);color:#f0d877}
+.app-flag-card{padding:10px 14px;border-radius:var(--radius);font-size:.8rem;line-height:1.5;background:var(--c-surface);border:1px solid var(--c-border)}
+.app-flag-card .flag-header{display:flex;align-items:center;gap:8px;margin-bottom:4px}
+.app-flag-badge{display:inline-block;padding:2px 8px;border-radius:10px;font-size:.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.04em}
+.app-flag-badge.high{background:rgba(248,81,73,.2);color:#ffb2ad}
+.app-flag-badge.moderate{background:rgba(227,176,42,.2);color:#f0d877}
+.app-flag-badge.info{background:rgba(94,236,196,.15);color:var(--c-accent)}
+.app-flag-card .flag-source{font-size:.72rem;color:var(--c-muted);margin-top:2px}
+.app-flag-card .flag-action{font-size:.78rem;color:var(--c-accent);margin-top:4px}
 .app-evidence-ai-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:8px}
 .app-evidence-ai-header .btn{padding:5px 12px;font-size:.78rem;min-width:0}
 .app-evidence-ai-loading{font-size:.82rem;color:var(--c-muted);padding:8px 0}
@@ -234,6 +247,15 @@
 .app-eudr-toggle input[type=checkbox]{accent-color:var(--c-green);width:16px;height:16px;cursor:pointer}
 .app-eudr-toggle .app-note{width:100%;margin:0}
 .app-analysis-queue-btn{width:100%;padding:14px;font-size:1rem;font-weight:700}
+/* Input mode tabs (KML / CSV) */
+.app-input-tabs{display:flex;gap:4px;margin-bottom:8px}
+.app-input-tab{padding:8px 16px;font-size:.82rem;font-weight:600;border:1px solid var(--c-border);border-radius:var(--radius) var(--radius) 0 0;background:transparent;color:var(--c-muted);cursor:pointer;transition:background .15s,color .15s}
+.app-input-tab.active{background:var(--c-surface);color:var(--c-accent);border-bottom-color:var(--c-surface)}
+.app-input-panel[hidden]{display:none}
+.app-csv-actions{margin-top:6px}
+.app-csv-status{margin-top:6px;font-size:.82rem;line-height:1.5;padding:8px 12px;border-radius:var(--radius)}
+.app-csv-status[data-tone="error"]{background:rgba(248,81,73,.12);border:1px solid rgba(248,81,73,.28);color:#ffb2ad}
+.app-csv-status[data-tone="info"]{background:rgba(94,236,196,.1);border:1px solid rgba(94,236,196,.25);color:var(--c-text)}
 .app-callout{padding:12px 14px;border-radius:var(--radius);font-size:.82rem;line-height:1.5}
 .app-callout[data-tone="info"]{background:rgba(94,236,196,.1);border:1px solid rgba(94,236,196,.25);color:var(--c-text)}
 .app-callout[data-tone="error"]{background:rgba(248,81,73,.12);border:1px solid rgba(248,81,73,.28);color:#ffb2ad}

--- a/website/css/app.css
+++ b/website/css/app.css
@@ -188,6 +188,7 @@
 .app-flag-banner{padding:10px 14px;border-radius:var(--radius);font-size:.82rem;font-weight:600;line-height:1.5}
 .app-flag-banner.has-high{background:rgba(248,81,73,.12);border:1px solid rgba(248,81,73,.28);color:#ffb2ad}
 .app-flag-banner.moderate-only{background:rgba(227,176,42,.12);border:1px solid rgba(227,176,42,.28);color:#f0d877}
+.app-flag-banner.info-only{background:rgba(56,132,244,.12);border:1px solid rgba(56,132,244,.28);color:#79b8ff}
 .app-flag-card{padding:10px 14px;border-radius:var(--radius);font-size:.8rem;line-height:1.5;background:var(--c-surface);border:1px solid var(--c-border)}
 .app-flag-card .flag-header{display:flex;align-items:center;gap:8px;margin-bottom:4px}
 .app-flag-badge{display:inline-block;padding:2px 8px;border-radius:10px;font-size:.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.04em}

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -103,7 +103,7 @@
           <div class="app-first-run-content">
             <div class="section-label">Get Started</div>
             <h3>Welcome to EUDR Due Diligence</h3>
-            <p class="app-first-run-note">You have no due diligence runs yet. Upload a KML file with your parcel boundaries. Canopex will search post-2020 satellite imagery across Sentinel-2, ESA WorldCover, IO LULC, ALOS radar, and more — then assess deforestation risk and assemble an evidence pack for EUDR compliance.</p>
+            <p class="app-first-run-note">You have no due diligence runs yet. Upload a KML file with your parcel boundaries, or paste CSV coordinates (name, lat, lon). Canopex will search post-2020 satellite imagery across Sentinel-2, ESA WorldCover, IO LULC, ALOS radar, and more — then assess deforestation risk and assemble an evidence pack for EUDR compliance.</p>
             <div class="app-first-run-actions">
               <a class="btn btn-primary" id="app-first-run-cta" href="#app-analysis-card">Start Your First Assessment</a>
               <a class="btn btn-secondary" href="/docs/kml-guide.html">KML Guide</a>
@@ -113,8 +113,8 @@
           <div class="app-first-run-checklist">
             <div class="section-label">Quick Checklist</div>
             <ol>
-              <li>Prepare a KML or KMZ file with parcel polygon boundaries</li>
-              <li>Upload it in the New Due Diligence panel below</li>
+              <li>Prepare a KML/KMZ file with parcel boundaries, or a CSV with name, lat, lon columns</li>
+              <li>Upload the file or paste coordinates in the New Due Diligence panel below</li>
               <li>Queue the pipeline — imagery is restricted to post-Dec 2020 per Regulation 2023/1115</li>
               <li>Review multi-source evidence: NDVI time series, land cover, radar, fire, weather</li>
               <li>Export audit-grade PDF with per-parcel deforestation-free determination</li>
@@ -167,11 +167,32 @@
             </div>
           </div>
           <div id="app-analysis-form-fields" hidden>
+          <!-- ── Input mode tabs ── -->
+          <div class="app-input-tabs" id="app-input-tabs">
+            <button class="app-input-tab active" type="button" data-input-tab="kml" aria-pressed="true">Upload KML</button>
+            <button class="app-input-tab" type="button" data-input-tab="csv" aria-pressed="false">Paste Coordinates</button>
+          </div>
+
+          <!-- ── KML tab ── -->
+          <div class="app-input-panel" id="app-input-panel-kml">
           <label class="app-field-label" for="app-analysis-file">KML or KMZ file</label>
           <input id="app-analysis-file" type="file" accept=".kml,.kmz,application/vnd.google-earth.kml+xml,application/vnd.google-earth.kmz">
           <p class="app-note" id="app-analysis-file-note">Choose a KML or KMZ file with your parcel boundaries, or paste KML below.</p>
           <label class="app-field-label" for="app-analysis-kml">KML Content</label>
           <textarea id="app-analysis-kml" placeholder="Paste KML content here…"></textarea>
+          </div>
+
+          <!-- ── CSV coordinates tab ── -->
+          <div class="app-input-panel" id="app-input-panel-csv" hidden>
+          <label class="app-field-label" for="app-csv-input">Parcel coordinates (CSV)</label>
+          <textarea id="app-csv-input" placeholder="name, lat, lon&#10;Plot A, -3.4653, -62.2159&#10;Plot B, -2.8912, -60.0217"></textarea>
+          <p class="app-note" id="app-csv-input-note">One row per parcel: <code>name, lat, lon</code>. Points are buffered to 100 m polygons.</p>
+          <div class="app-csv-actions">
+            <button class="btn btn-secondary" id="app-csv-convert-btn" type="button">Convert to KML</button>
+          </div>
+          <div class="app-csv-status" id="app-csv-status" hidden></div>
+          </div>
+
           <div class="app-preflight-card" id="app-analysis-preflight">
             <div class="app-preflight-header">
               <div>
@@ -190,6 +211,7 @@
               <div><span>Parcels</span><strong id="app-preflight-aois">0</strong></div>
               <div><span>Spread</span><strong id="app-preflight-spread">—</strong></div>
               <div><span>Quota impact</span><strong id="app-preflight-quota">—</strong></div>
+              <div><span>Cost estimate</span><strong id="app-preflight-cost">—</strong></div>
             </div>
             <div class="app-preflight-list" id="app-preflight-warnings">
               <div class="app-preflight-item" data-tone="info">Preflight will show warnings here after you paste or upload KML.</div>
@@ -339,6 +361,7 @@
                     <div class="app-evidence-aoi-detail-name" id="app-evidence-aoi-detail-name"></div>
                     <div class="app-evidence-aoi-detail-grid" id="app-evidence-aoi-detail-grid"></div>
                     <div class="app-evidence-aoi-determination" id="app-evidence-aoi-determination" hidden></div>
+                    <div class="app-evidence-flags" id="app-evidence-flags" hidden></div>
                   </div>
                 </div>
               </div>

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -2024,6 +2024,144 @@
     });
   }
 
+  // ── Cost estimator for EUDR preflight ────────────────────────
+  function computeEudrCostEstimate(parcelCount) {
+    if (!EUDR_LOCKED || !parcelCount) return '—';
+    var billing = typeof window.eudrBillingData === 'function' ? window.eudrBillingData() : null;
+    if (!billing) return '—';
+
+    if (!billing.subscribed) {
+      var remaining = billing.trial_remaining != null ? billing.trial_remaining : 0;
+      if (remaining > 0) return parcelCount + ' parcel' + (parcelCount !== 1 ? 's' : '') + ' · ' + remaining + ' of 2 free left';
+      return 'Subscribe to continue';
+    }
+
+    // Pro subscriber — check included parcels vs overage
+    var used = billing.period_parcels_used || 0;
+    var included = billing.included_parcels || 10;
+    var afterSubmit = used + parcelCount;
+    if (afterSubmit <= included) {
+      return parcelCount + ' parcel' + (parcelCount !== 1 ? 's' : '') + ' included';
+    }
+    var overageParcels = afterSubmit - included;
+    var rate = overageParcels >= 500 ? 1.80 : overageParcels >= 100 ? 2.50 : 3.00;
+    var cost = (overageParcels * rate).toFixed(2);
+    return overageParcels + ' overage × £' + rate.toFixed(2) + ' = £' + cost;
+  }
+
+  // ── Input tab switching (KML / CSV) ──────────────────────────
+  function switchInputTab(tabName) {
+    var tabs = document.querySelectorAll('[data-input-tab]');
+    tabs.forEach(function(tab) {
+      var isActive = tab.getAttribute('data-input-tab') === tabName;
+      tab.classList.toggle('active', isActive);
+      tab.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+    var kmlPanel = document.getElementById('app-input-panel-kml');
+    var csvPanel = document.getElementById('app-input-panel-csv');
+    if (kmlPanel) kmlPanel.hidden = tabName !== 'kml';
+    if (csvPanel) csvPanel.hidden = tabName !== 'csv';
+  }
+
+  // ── CSV coordinate parsing and conversion ───────────────────
+  function parseCSVCoordinates(text) {
+    var lines = text.trim().split(/\r?\n/).filter(Boolean);
+    if (lines.length === 0) return { plots: [], errors: ['No data entered'] };
+
+    var plots = [];
+    var errors = [];
+    var startIdx = 0;
+
+    // Detect header row
+    var firstLine = lines[0].toLowerCase().replace(/\s/g, '');
+    if (firstLine.indexOf('name') >= 0 && (firstLine.indexOf('lat') >= 0 || firstLine.indexOf('lon') >= 0)) {
+      startIdx = 1;
+    }
+
+    for (var i = startIdx; i < lines.length; i++) {
+      var parts = lines[i].split(',').map(function(s) { return s.trim(); });
+      if (parts.length < 3) {
+        errors.push('Row ' + (i + 1) + ': expected name, lat, lon — got ' + parts.length + ' columns');
+        continue;
+      }
+      var name = parts[0] || 'Parcel ' + (plots.length + 1);
+      var lat = parseFloat(parts[1]);
+      var lon = parseFloat(parts[2]);
+      if (isNaN(lat) || isNaN(lon)) {
+        errors.push('Row ' + (i + 1) + ': invalid coordinates (' + parts[1] + ', ' + parts[2] + ')');
+        continue;
+      }
+      if (lat < -90 || lat > 90 || lon < -180 || lon > 180) {
+        errors.push('Row ' + (i + 1) + ': coordinates out of range (lat: ' + lat + ', lon: ' + lon + ')');
+        continue;
+      }
+      plots.push({ name: name, lat: lat, lon: lon });
+    }
+    return { plots: plots, errors: errors };
+  }
+
+  async function convertCSVToKml() {
+    var textarea = document.getElementById('app-csv-input');
+    var statusEl = document.getElementById('app-csv-status');
+    var convertBtn = document.getElementById('app-csv-convert-btn');
+    if (!textarea || !statusEl) return;
+
+    var text = textarea.value.trim();
+    if (!text) {
+      statusEl.hidden = false;
+      statusEl.setAttribute('data-tone', 'error');
+      statusEl.textContent = 'Paste coordinate data first.';
+      return;
+    }
+
+    var parsed = parseCSVCoordinates(text);
+    if (parsed.errors.length > 0 && parsed.plots.length === 0) {
+      statusEl.hidden = false;
+      statusEl.setAttribute('data-tone', 'error');
+      statusEl.textContent = parsed.errors.join('; ');
+      return;
+    }
+    if (parsed.plots.length === 0) {
+      statusEl.hidden = false;
+      statusEl.setAttribute('data-tone', 'error');
+      statusEl.textContent = 'No valid coordinates found.';
+      return;
+    }
+
+    if (convertBtn) { convertBtn.disabled = true; convertBtn.textContent = 'Converting…'; }
+    statusEl.hidden = false;
+    statusEl.setAttribute('data-tone', 'info');
+    var warningText = parsed.errors.length > 0 ? ' (' + parsed.errors.length + ' rows skipped)' : '';
+    statusEl.textContent = 'Converting ' + parsed.plots.length + ' parcels…' + warningText;
+
+    try {
+      await apiDiscoveryReady;
+      var res = await apiFetch('/api/convert-coordinates', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ doc_name: 'EUDR Parcels', buffer_m: 100, plots: parsed.plots })
+      });
+      var kmlText = await res.text();
+
+      // Put converted KML into the KML textarea and switch to KML tab
+      var kmlTextarea = document.getElementById('app-analysis-kml');
+      if (kmlTextarea) {
+        kmlTextarea.value = kmlText;
+        updateAnalysisPreflight(kmlText);
+      }
+      switchInputTab('kml');
+      statusEl.hidden = true;
+
+      var fileNote = document.getElementById('app-analysis-file-note');
+      if (fileNote) fileNote.textContent = 'Generated from ' + parsed.plots.length + ' coordinate' + (parsed.plots.length !== 1 ? 's' : '') + '.';
+    } catch (err) {
+      statusEl.setAttribute('data-tone', 'error');
+      statusEl.textContent = (err.body && err.body.error) || 'Coordinate conversion failed. Check your data and try again.';
+    } finally {
+      if (convertBtn) { convertBtn.disabled = false; convertBtn.textContent = 'Convert to KML'; }
+    }
+  }
+
   function updateAnalysisPreflight(text) {
     var headlineEl = document.getElementById('app-preflight-headline');
     var modeEl = document.getElementById('app-preflight-mode');
@@ -2032,6 +2170,7 @@
     var aoisEl = document.getElementById('app-preflight-aois');
     var spreadEl = document.getElementById('app-preflight-spread');
     var quotaEl = document.getElementById('app-preflight-quota');
+    var costEl = document.getElementById('app-preflight-cost');
     if (!headlineEl || !modeEl || !summaryEl || !featuresEl || !aoisEl || !spreadEl || !quotaEl) return null;
 
     var role = currentRoleConfig();
@@ -2045,6 +2184,7 @@
       aoisEl.textContent = '0';
       spreadEl.textContent = '—';
       quotaEl.textContent = '—';
+      if (costEl) costEl.textContent = '—';
       renderPreflightWarnings([{ tone: 'info', text: 'Preflight will show warnings here after you paste or upload KML.' }]);
       renderPreflightMap(null);
       var submitBtn = document.getElementById('app-analysis-submit-btn');
@@ -2062,6 +2202,7 @@
       aoisEl.textContent = '—';
       spreadEl.textContent = '—';
       quotaEl.textContent = '—';
+      if (costEl) costEl.textContent = '—';
       renderPreflightWarnings([{ tone: 'error', text: preflight.error }]);
       renderPreflightMap(null);
       return preflight;
@@ -2074,6 +2215,7 @@
     aoisEl.textContent = String(preflight.aoiCount);
     spreadEl.textContent = formatDistance(preflight.maxSpreadKm);
     quotaEl.textContent = preflight.quotaImpact;
+    if (costEl) costEl.textContent = computeEudrCostEstimate(preflight.aoiCount);
     renderPreflightWarnings(preflight.warnings);
     renderPreflightMap(preflight.polygons);
     var submitBtn = document.getElementById('app-analysis-submit-btn');
@@ -2789,6 +2931,12 @@
   if (kmlInput) kmlInput.addEventListener('input', function() { updateAnalysisPreflight(this.value); });
   var fileInput = document.getElementById('app-analysis-file');
   if (fileInput) fileInput.addEventListener('change', function() { if (this.files && this.files[0]) loadAnalysisFile(this.files[0]); });
+
+  // Input tab switching (KML / CSV)
+  document.querySelectorAll('[data-input-tab]').forEach(function(tab) {
+    tab.addEventListener('click', function() { switchInputTab(this.getAttribute('data-input-tab')); });
+  });
+  bindClick('app-csv-convert-btn', convertCSVToKml);
 
   // Evidence surface controls
   bindClick('app-map-play-btn', toggleEvidencePlay);

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -2032,18 +2032,18 @@
 
     if (!billing.subscribed) {
       var remaining = billing.trial_remaining != null ? billing.trial_remaining : 0;
-      if (remaining > 0) return parcelCount + ' parcel' + (parcelCount !== 1 ? 's' : '') + ' · ' + remaining + ' of 2 free left';
+      if (remaining > 0) return parcelCount + ' parcel' + (parcelCount !== 1 ? 's' : '') + ' · ' + remaining + ' free assessment' + (remaining !== 1 ? 's' : '') + ' left';
       return 'Subscribe to continue';
     }
 
-    // Pro subscriber — check included parcels vs overage
+    // Pro subscriber — estimate only the incremental overage caused by this submission
     var used = billing.period_parcels_used || 0;
     var included = billing.included_parcels || 10;
-    var afterSubmit = used + parcelCount;
-    if (afterSubmit <= included) {
+    var remainingIncluded = Math.max(included - used, 0);
+    var overageParcels = Math.max(parcelCount - remainingIncluded, 0);
+    if (overageParcels === 0) {
       return parcelCount + ' parcel' + (parcelCount !== 1 ? 's' : '') + ' included';
     }
-    var overageParcels = afterSubmit - included;
     var rate = overageParcels >= 500 ? 1.80 : overageParcels >= 100 ? 2.50 : 3.00;
     var cost = (overageParcels * rate).toFixed(2);
     return overageParcels + ' overage × £' + rate.toFixed(2) + ' = £' + cost;

--- a/website/js/canopex-evidence-render.js
+++ b/website/js/canopex-evidence-render.js
@@ -411,19 +411,107 @@
         detEl.textContent = det.deforestation_free
           ? '\u2705 Deforestation-free (' + (det.confidence || 'medium') + ' confidence)'
           : '\u26A0\uFE0F Risk detected — ' + (det.reason || 'see full report');
+        renderFlagCards(det.flags || []);
       } else {
         detEl.hidden = true;
+        renderFlagCards([]);
       }
     }
+  }
+
+  // ── Flag severity classification and rendering ─────────────
+  var FLAG_RULES = [
+    { pattern: /vegetation loss/i, severity: 'high', source: 'Change detection', action: 'Compare RGB imagery in the timeline to verify the loss area.' },
+    { pattern: /NDVI trajectory is declining/i, severity: 'high', source: 'NDVI analysis', action: 'Check the weather panel for drought correlation before concluding deforestation.' },
+    { pattern: /Mean NDVI delta/i, severity: 'moderate', source: 'NDVI analysis', action: 'Review the NDVI time series for seasonal patterns vs permanent loss.' },
+    { pattern: /WDPA protected area/i, severity: 'info', source: 'WDPA overlay', action: 'Verify the parcel boundary does not overlap a protected area buffer zone.' },
+    { pattern: /IO LULC.*land-cover change/i, severity: 'moderate', source: 'IO Annual LULC', action: 'Review the IO LULC transition data for the specific land-cover class change.' },
+    { pattern: /IO LULC.*tree cover.*declining/i, severity: 'high', source: 'IO Annual LULC', action: 'Cross-reference with WorldCover baseline to confirm tree cover loss timeline.' },
+    { pattern: /ALOS.*forest/i, severity: 'moderate', source: 'ALOS FNF', action: 'Compare ALOS forest/non-forest classification with Sentinel-2 imagery.' }
+  ];
+
+  function classifyFlag(flagText) {
+    for (var i = 0; i < FLAG_RULES.length; i++) {
+      var rule = FLAG_RULES[i];
+      if (rule.pattern.test(flagText)) {
+        return { text: flagText, severity: rule.severity, source: rule.source, action: rule.action };
+      }
+    }
+    return { text: flagText, severity: 'info', source: 'Assessment', action: '' };
+  }
+
+  function renderFlagCards(flags) {
+    var container = document.getElementById('app-evidence-flags');
+    if (!container) return;
+    container.textContent = '';
+
+    if (!flags || !flags.length) {
+      container.hidden = true;
+      return;
+    }
+    container.hidden = false;
+
+    var classified = flags.map(classifyFlag);
+    var highCount = classified.filter(function(f) { return f.severity === 'high'; }).length;
+    var modCount = classified.filter(function(f) { return f.severity === 'moderate'; }).length;
+    var infoCount = classified.filter(function(f) { return f.severity === 'info'; }).length;
+
+    // Summary banner
+    var banner = document.createElement('div');
+    banner.className = 'app-flag-banner ' + (highCount > 0 ? 'has-high' : 'moderate-only');
+    var parts = [];
+    if (highCount > 0) parts.push(highCount + ' high concern');
+    if (modCount > 0) parts.push(modCount + ' moderate');
+    if (infoCount > 0) parts.push(infoCount + ' informational');
+    banner.textContent = flags.length + ' flag' + (flags.length !== 1 ? 's' : '') + ' raised \u2014 ' + parts.join(', ');
+    container.appendChild(banner);
+
+    // Individual flag cards
+    classified.forEach(function(flag) {
+      var card = document.createElement('div');
+      card.className = 'app-flag-card';
+
+      var header = document.createElement('div');
+      header.className = 'flag-header';
+
+      var badge = document.createElement('span');
+      badge.className = 'app-flag-badge ' + flag.severity;
+      badge.textContent = flag.severity === 'high' ? 'High' : flag.severity === 'moderate' ? 'Moderate' : 'Info';
+      header.appendChild(badge);
+
+      var text = document.createElement('span');
+      text.textContent = flag.text;
+      header.appendChild(text);
+
+      card.appendChild(header);
+
+      if (flag.source) {
+        var source = document.createElement('div');
+        source.className = 'flag-source';
+        source.textContent = 'Source: ' + flag.source;
+        card.appendChild(source);
+      }
+
+      if (flag.action) {
+        var action = document.createElement('div');
+        action.className = 'flag-action';
+        action.textContent = '\uD83D\uDCA1 ' + flag.action;
+        card.appendChild(action);
+      }
+
+      container.appendChild(card);
+    });
   }
 
   function clearAoiDetail() {
     var detail = document.getElementById('app-evidence-aoi-detail');
     var grid = document.getElementById('app-evidence-aoi-detail-grid');
     var detEl = document.getElementById('app-evidence-aoi-determination');
+    var flagsEl = document.getElementById('app-evidence-flags');
     if (detail) detail.hidden = true;
     if (grid) grid.textContent = '';
     if (detEl) { detEl.hidden = true; detEl.textContent = ''; }
+    if (flagsEl) { flagsEl.hidden = true; flagsEl.textContent = ''; }
   }
 
   window.CanopexEvidenceRender = {

--- a/website/js/canopex-evidence-render.js
+++ b/website/js/canopex-evidence-render.js
@@ -458,7 +458,13 @@
 
     // Summary banner
     var banner = document.createElement('div');
-    banner.className = 'app-flag-banner ' + (highCount > 0 ? 'has-high' : 'moderate-only');
+    var bannerStateClass = 'info-only';
+    if (highCount > 0) {
+      bannerStateClass = 'has-high';
+    } else if (modCount > 0) {
+      bannerStateClass = 'moderate-only';
+    }
+    banner.className = 'app-flag-banner ' + bannerStateClass;
     var parts = [];
     if (highCount > 0) parts.push(highCount + ' high concern');
     if (modCount > 0) parts.push(modCount + ' moderate');
@@ -476,7 +482,13 @@
 
       var badge = document.createElement('span');
       badge.className = 'app-flag-badge ' + flag.severity;
-      badge.textContent = flag.severity === 'high' ? 'High' : flag.severity === 'moderate' ? 'Moderate' : 'Info';
+      var badgeLabel = 'Info';
+      if (flag.severity === 'high') {
+        badgeLabel = 'High';
+      } else if (flag.severity === 'moderate') {
+        badgeLabel = 'Moderate';
+      }
+      badge.textContent = badgeLabel;
       header.appendChild(badge);
 
       var text = document.createElement('span');


### PR DESCRIPTION
## Stage 3A — EUDR Assessment Management

Delivers all four Stage 3A items, driven by the EUDR user journey gap analysis.

### 3A.0 — Server-side EUDR entitlement enforcement (#664)

- Blocks EUDR submissions when org has no active subscription and no remaining free-trial credits
- `_check_eudr_entitlement()` validates org membership + entitlement before quota consumption
- `_consume_eudr_trial_if_needed()` decrements free-trial counter after successful SAS minting
- Race condition handling: refunds quota if trial consumption fails after allocation
- 6 new tests in `TestUploadTokenEudrEntitlement`, all 26 upload tests green

### 3A.1 — CSV / coordinate paste upload (#662)

- Input mode tabs (Upload KML / Paste Coordinates) in both EUDR and main app HTML
- `parseCSVCoordinates()` with header detection and lat/lon range validation
- `convertCSVToKml()` POSTs to `/api/convert-coordinates`, populates KML textarea
- Auto-switches to KML tab after successful conversion

### 3A.2 — Cost estimator in preflight (#661)

- `computeEudrCostEstimate()` with graduated pricing tiers (£3/parcel, £2.50 at 100+, £1.80 at 500+)
- Shows free-trial remaining, included parcels, or overage cost in preflight grid
- Wired into all three preflight display states (reset, error, success)

### 3A.3 — Flagged-parcel quick-review UX (#660)

- Flag severity classification by pattern matching: 🔴 high (vegetation loss, declining trajectory), 🟡 moderate (NDVI delta, land-cover change), ℹ️ info (WDPA overlap)
- Summary banner with flag count breakdown by severity
- Per-flag explanation cards: detection description, data source, recommended action
- Non-flagged (deforestation-free) parcels unaffected

### Files changed

| File | Change |
|------|--------|
| `blueprints/upload.py` | EUDR entitlement gate + helper extraction to reduce complexity |
| `tests/test_upload_endpoints.py` | 6 new entitlement tests + existing test mock updates |
| `website/eudr/index.html` | Input tabs, CSV panel, cost cell, flags container |
| `website/app/index.html` | Same tab/CSV/cost/flags changes |
| `website/css/app.css` | Tab, CSV, flag card styles |
| `website/js/app-shell.js` | CSV parsing, cost estimator, tab switching |
| `website/js/canopex-evidence-render.js` | Flag classification, severity badges, explanation cards |
| `docs/ROADMAP.md` | Stage 3A marked ✅, Recently Landed updated |

### Validation

- 1493 tests pass, 27 skipped
- `ruff check` clean, `ruff format` clean, `pyright` clean
- All pre-commit hooks pass

Closes #660, #661, #662, #664