### PR TITLE
feat: Pipeline cost accumulator + resources consumed evidence card (#666)

### DIFF
--- a/blueprints/pipeline/enrichment.py
+++ b/blueprints/pipeline/enrichment.py
@@ -49,9 +49,15 @@ async def timelapse_data(
     )
     if err:
         return err
+    if manifest is None:
+        return error_response(404, "No enrichment data for this pipeline run", req=req)
+
+    # Internal cost telemetry should not be exposed in user-facing API payloads.
+    sanitized_manifest = manifest.copy()
+    sanitized_manifest.pop("estimated_cost_pence", None)
 
     return func.HttpResponse(
-        json.dumps(manifest, default=str),
+        json.dumps(sanitized_manifest, default=str),
         status_code=200,
         mimetype="application/json",
         headers=cors_headers(req),

--- a/blueprints/pipeline/orchestrator.py
+++ b/blueprints/pipeline/orchestrator.py
@@ -715,6 +715,16 @@ def _dispatch_acq_ful(
 # ---------------------------------------------------------------------------
 
 
+def _apply_enrichment_to_summary(summary: dict[str, Any], enrichment: dict[str, Any]) -> None:
+    """Copy enrichment outputs into the pipeline summary."""
+    if enrichment.get("manifest_path"):
+        summary["enrichment_manifest"] = enrichment["manifest_path"]
+        summary["enrichment_duration"] = enrichment.get("enrichment_duration_seconds")
+    for k in ("resource_usage", "estimated_cost_pence"):
+        if enrichment.get(k) is not None:
+            summary[k] = enrichment[k]
+
+
 @bp.orchestration_trigger(context_name="context")
 def treesight_orchestrator(context: df.DurableOrchestrationContext):  # type: ignore[return-type]
     """Orchestrator with per-AOI progressive delivery (#585).
@@ -745,9 +755,7 @@ def treesight_orchestrator(context: df.DurableOrchestrationContext):  # type: ig
             acquisition=acq_s,
             fulfilment=ful_s,
         )
-        if enrichment.get("manifest_path"):
-            summary["enrichment_manifest"] = enrichment["manifest_path"]
-            summary["enrichment_duration"] = enrichment.get("enrichment_duration_seconds")
+        _apply_enrichment_to_summary(summary, enrichment)
         if user_id and tier != "demo":
             yield from _safe_complete_billing(context, user_id, instance_id)
         return summary

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,6 +39,7 @@ Stages 2D and 2E can proceed in parallel. Stage 3B is next priority.
 
 | PR | Summary |
 |----|---------|  
+| (pending) | feat: Stage 3B.0 — Pipeline cost accumulator + resources consumed evidence card (#666) |
 | #665 | feat: Stage 3A — EUDR assessment management: entitlement gate, CSV upload, cost estimator, flagged-parcel review (closes #660, #661, #662, #664) |
 | #663 | fix: Subscribe modal hard-wall bug, EUDR entitlement gate on submit, dark theme modal styling |
 | #657 | feat: Stage 2G completion — EUDR metered billing, Landsat deep integration, EUDR content cluster (closes #612, #613, #535, #617) |
@@ -186,6 +187,7 @@ deforestation-free determinations.
 
 | Order | Issue | Title | Status |
 |-------|-------|-------|--------|
+| 3B.0 | #666 | Pipeline cost accumulator + resources consumed evidence card | ✅ (pending PR) |
 | 3B.1 | #647 | Defensible PDF export: embed imagery, maps, and visual evidence | Open |
 | 3B.2 | #649 | Evidence provenance: traceability from viewer back to source imagery | Open |
 | 3B.3 | #646 | Imagery viewer: dynamic layer picker with smart defaults | Open |

--- a/tests/test_billing_ledger.py
+++ b/tests/test_billing_ledger.py
@@ -212,6 +212,45 @@ class TestCompleteRunBilling:
 class TestFailRunBilling:
     @patch(_COSMOS_UPSERT)
     @patch(_COSMOS_READ)
+    def test_sets_wasted_cost_on_refund(self, mock_read, mock_upsert):
+        mock_read.return_value = {
+            "id": "inst-2",
+            "user_id": "u1",
+            "billing_type": "included",
+            "billing_status": "pending",
+            "resource_summary": {"api_calls": 5},
+            "estimated_cost_pence": 123.4,
+        }
+
+        fail_run_billing("u1", "inst-2", reason="manual_refund")
+
+        mock_upsert.assert_called_once()
+        doc = mock_upsert.call_args[0][1]
+        assert doc["billing_status"] == "refunded"
+        assert doc["refund_reason"] == "manual_refund"
+        assert doc["wasted_cost_pence"] == 123.4
+        assert doc["resource_summary"] == {"api_calls": 5}
+
+    @patch(_COSMOS_UPSERT)
+    @patch(_COSMOS_READ)
+    def test_does_not_set_wasted_cost_if_missing(self, mock_read, mock_upsert):
+        mock_read.return_value = {
+            "id": "inst-3",
+            "user_id": "u1",
+            "billing_type": "included",
+            "billing_status": "pending",
+        }
+
+        fail_run_billing("u1", "inst-3", reason="manual_refund")
+
+        mock_upsert.assert_called_once()
+        doc = mock_upsert.call_args[0][1]
+        assert doc["billing_status"] == "refunded"
+        assert doc["refund_reason"] == "manual_refund"
+        assert "wasted_cost_pence" not in doc
+
+    @patch(_COSMOS_UPSERT)
+    @patch(_COSMOS_READ)
     def test_marks_pending_run_as_refunded(self, mock_read, mock_upsert):
         mock_read.return_value = {
             "id": "inst-1",
@@ -252,16 +291,13 @@ class TestFailRunBilling:
             "billing_status": "charged",
             "tier_at_submission": "pro",
         }
-        # Simulate _credit_overage setting payment_ref (provider succeeded)
         mock_credit.side_effect = lambda uid, iid, d, r: d.__setitem__("payment_ref", "cr_789")
 
-        # Capture doc snapshots at each upsert call (dict is mutated in place)
         snapshots = []
         mock_upsert.side_effect = lambda coll, doc: snapshots.append(dict(doc))
 
         fail_run_billing("u1", "inst-3", reason="timeout")
 
-        # First upsert writes credit_pending, second writes refunded
         assert len(snapshots) == 2
         assert snapshots[0]["billing_status"] == "credit_pending"
         assert snapshots[1]["billing_status"] == "refunded"
@@ -296,13 +332,11 @@ class TestFailRunBilling:
             "billing_status": "charged",
             "tier_at_submission": "pro",
         }
-        # Provider returns None — no payment_ref set
         mock_credit.side_effect = lambda uid, iid, d, r: None
 
         with pytest.raises(RuntimeError, match="Overage credit not confirmed"):
             fail_run_billing("u1", "inst-5", reason="pipeline_failure")
 
-        # Status should be credit_pending, not refunded
         interim_doc = mock_upsert.call_args_list[0][0][1]
         assert interim_doc["billing_status"] == "credit_pending"
 

--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -936,6 +936,45 @@ class TestEudrModeToggle:
             "EUDR toggle visibility must be gated on paid tier list"
         )
 
+    def test_eudr_request_uses_selected_aoi_context(self):
+        content = self.APP_SHELL.read_text()
+        fn_start = content.find("async function requestEudrAssessment()")
+        assert fn_start != -1, "requestEudrAssessment function not found in app-shell.js"
+        fn_end = content.find(
+            "\n  /* ------------------------------------------------------------------ */",
+            fn_start,
+        )
+        if fn_end == -1:
+            fn_end = len(content)
+        fn_body = content[fn_start:fn_end]
+        assert "activeEvidenceContext" in content, (
+            "app-shell.js must define a helper that resolves the active parcel context"
+        )
+        assert "activeEvidenceContext()" in fn_body or (
+            "evidenceSelectedAoi" in fn_body and "per_aoi_enrichment" in fn_body
+        ), "requestEudrAssessment must pivot to the selected parcel when a per-AOI chip is active"
+
+    def test_eudr_request_uses_real_ndvi_dates(self):
+        content = self.APP_SHELL.read_text()
+        fn_start = content.find("async function requestEudrAssessment()")
+        assert fn_start != -1, "requestEudrAssessment function not found in app-shell.js"
+        fn_end = content.find(
+            "\n  /* ------------------------------------------------------------------ */",
+            fn_start,
+        )
+        if fn_end == -1:
+            fn_end = len(content)
+        fn_body = content[fn_start:fn_end]
+        assert "buildEvidenceNdviTimeseries" in content, (
+            "app-shell.js must define a helper that builds"
+            " dated NDVI timeseries for evidence requests"
+        )
+        assert (
+            "buildEvidenceNdviTimeseries(source)" in fn_body
+            or "f.datetime" in fn_body
+            or "fp.start" in fn_body
+        ), "requestEudrAssessment must send a real NDVI observation date, not only a display label"
+
 
 # ---------------------------------------------------------------------------
 # Endpoint auth audit (#572) — ensure every non-anonymous endpoint is protected

--- a/tests/test_resource_accumulator.py
+++ b/tests/test_resource_accumulator.py
@@ -1,0 +1,262 @@
+"""Tests for ResourceAccumulator — tracks resource consumption across enrichment phases."""
+
+from __future__ import annotations
+
+from treesight.pipeline.enrichment.resource_accumulator import ResourceAccumulator
+
+
+class TestResourceAccumulatorInit:
+    """ResourceAccumulator starts with empty state."""
+
+    def test_empty_accumulator_has_zero_counts(self):
+        acc = ResourceAccumulator()
+        result = acc.to_dict()
+        assert result["data_sources_queried"] == []
+        assert result["api_calls"] == {}
+        assert result["phase_durations"] == {}
+        assert result["sentinel2_scenes_registered"] == 0
+        assert result["landsat_scenes_sampled"] == 0
+        assert result["ndvi_computations"] == 0
+        assert result["change_detection_comparisons"] == 0
+        assert result["mosaic_registrations"] == 0
+        assert result["per_aoi_enrichments"] == 0
+
+
+class TestAddSource:
+    """add_source tracks unique data sources queried."""
+
+    def test_adds_source(self):
+        acc = ResourceAccumulator()
+        acc.add_source("open-meteo")
+        assert "open-meteo" in acc.to_dict()["data_sources_queried"]
+
+    def test_deduplicates_sources(self):
+        acc = ResourceAccumulator()
+        acc.add_source("open-meteo")
+        acc.add_source("open-meteo")
+        assert acc.to_dict()["data_sources_queried"].count("open-meteo") == 1
+
+    def test_preserves_insertion_order(self):
+        acc = ResourceAccumulator()
+        acc.add_source("open-meteo")
+        acc.add_source("gfd-flood")
+        acc.add_source("firms-fire")
+        assert acc.to_dict()["data_sources_queried"] == [
+            "open-meteo",
+            "gfd-flood",
+            "firms-fire",
+        ]
+
+
+class TestAddApiCall:
+    """add_api_call counts calls per service."""
+
+    def test_increments_count(self):
+        acc = ResourceAccumulator()
+        acc.add_api_call("open_meteo")
+        acc.add_api_call("open_meteo")
+        assert acc.to_dict()["api_calls"]["open_meteo"] == 2
+
+    def test_defaults_increment_to_one(self):
+        acc = ResourceAccumulator()
+        acc.add_api_call("firms")
+        assert acc.to_dict()["api_calls"]["firms"] == 1
+
+    def test_custom_increment(self):
+        acc = ResourceAccumulator()
+        acc.add_api_call("planetary_computer", count=12)
+        assert acc.to_dict()["api_calls"]["planetary_computer"] == 12
+
+
+class TestRecordPhaseDuration:
+    """record_phase_duration tracks how long each phase took."""
+
+    def test_records_duration(self):
+        acc = ResourceAccumulator()
+        acc.record_phase_duration("weather", 2.1)
+        assert acc.to_dict()["phase_durations"]["weather"] == 2.1
+
+    def test_rounds_to_one_decimal(self):
+        acc = ResourceAccumulator()
+        acc.record_phase_duration("flood_fire", 3.456)
+        assert acc.to_dict()["phase_durations"]["flood_fire"] == 3.5
+
+
+class TestCounterIncrements:
+    """Direct counter increments for scenes, NDVI, etc."""
+
+    def test_increment_sentinel2(self):
+        acc = ResourceAccumulator()
+        acc.increment("sentinel2_scenes_registered", 12)
+        assert acc.to_dict()["sentinel2_scenes_registered"] == 12
+
+    def test_increment_landsat(self):
+        acc = ResourceAccumulator()
+        acc.increment("landsat_scenes_sampled", 4)
+        assert acc.to_dict()["landsat_scenes_sampled"] == 4
+
+    def test_increment_ndvi(self):
+        acc = ResourceAccumulator()
+        acc.increment("ndvi_computations", 6)
+        assert acc.to_dict()["ndvi_computations"] == 6
+
+    def test_increment_change_detection(self):
+        acc = ResourceAccumulator()
+        acc.increment("change_detection_comparisons", 3)
+        assert acc.to_dict()["change_detection_comparisons"] == 3
+
+    def test_increment_mosaic(self):
+        acc = ResourceAccumulator()
+        acc.increment("mosaic_registrations", 12)
+        assert acc.to_dict()["mosaic_registrations"] == 12
+
+    def test_increment_per_aoi(self):
+        acc = ResourceAccumulator()
+        acc.increment("per_aoi_enrichments", 8)
+        assert acc.to_dict()["per_aoi_enrichments"] == 8
+
+    def test_rejects_unknown_counter(self):
+        acc = ResourceAccumulator()
+        import pytest
+
+        with pytest.raises(ValueError, match="Unknown counter"):
+            acc.increment("unknown_field", 1)
+
+    def test_additive_increments(self):
+        acc = ResourceAccumulator()
+        acc.increment("ndvi_computations", 3)
+        acc.increment("ndvi_computations", 4)
+        assert acc.to_dict()["ndvi_computations"] == 7
+
+
+class TestMerge:
+    """merge combines two accumulators (for parallel sub-step fan-out)."""
+
+    def test_merges_sources(self):
+        a = ResourceAccumulator()
+        a.add_source("open-meteo")
+        b = ResourceAccumulator()
+        b.add_source("gfd-flood")
+        b.add_source("open-meteo")  # duplicate
+        a.merge(b)
+        result = a.to_dict()
+        assert sorted(result["data_sources_queried"]) == ["gfd-flood", "open-meteo"]
+
+    def test_merges_api_calls(self):
+        a = ResourceAccumulator()
+        a.add_api_call("open_meteo", count=1)
+        b = ResourceAccumulator()
+        b.add_api_call("open_meteo", count=2)
+        b.add_api_call("firms", count=1)
+        a.merge(b)
+        result = a.to_dict()
+        assert result["api_calls"]["open_meteo"] == 3
+        assert result["api_calls"]["firms"] == 1
+
+    def test_merges_counters(self):
+        a = ResourceAccumulator()
+        a.increment("ndvi_computations", 6)
+        b = ResourceAccumulator()
+        b.increment("ndvi_computations", 4)
+        b.increment("mosaic_registrations", 12)
+        a.merge(b)
+        result = a.to_dict()
+        assert result["ndvi_computations"] == 10
+        assert result["mosaic_registrations"] == 12
+
+    def test_merges_phase_durations(self):
+        a = ResourceAccumulator()
+        a.record_phase_duration("weather", 2.1)
+        b = ResourceAccumulator()
+        b.record_phase_duration("mosaic_ndvi", 18.7)
+        a.merge(b)
+        result = a.to_dict()
+        assert result["phase_durations"]["weather"] == 2.1
+        assert result["phase_durations"]["mosaic_ndvi"] == 18.7
+
+    def test_merge_phase_duration_conflict_takes_max(self):
+        """If both have the same phase, take the longer duration."""
+        a = ResourceAccumulator()
+        a.record_phase_duration("weather", 2.1)
+        b = ResourceAccumulator()
+        b.record_phase_duration("weather", 3.5)
+        a.merge(b)
+        assert a.to_dict()["phase_durations"]["weather"] == 3.5
+
+
+class TestToDict:
+    """to_dict returns a clean serializable dictionary."""
+
+    def test_roundtrip_populated(self):
+        acc = ResourceAccumulator()
+        acc.add_source("open-meteo")
+        acc.add_source("firms-fire")
+        acc.add_api_call("open_meteo")
+        acc.add_api_call("firms")
+        acc.increment("sentinel2_scenes_registered", 12)
+        acc.increment("ndvi_computations", 12)
+        acc.increment("change_detection_comparisons", 6)
+        acc.increment("mosaic_registrations", 12)
+        acc.increment("per_aoi_enrichments", 8)
+        acc.record_phase_duration("weather", 2.1)
+        acc.record_phase_duration("flood_fire", 3.4)
+        result = acc.to_dict()
+
+        assert isinstance(result, dict)
+        assert result["data_sources_queried"] == ["open-meteo", "firms-fire"]
+        assert result["api_calls"] == {"open_meteo": 1, "firms": 1}
+        assert result["sentinel2_scenes_registered"] == 12
+        assert result["ndvi_computations"] == 12
+        assert result["change_detection_comparisons"] == 6
+        assert result["mosaic_registrations"] == 12
+        assert result["per_aoi_enrichments"] == 8
+        assert result["phase_durations"] == {"weather": 2.1, "flood_fire": 3.4}
+
+
+class TestFromDict:
+    """from_dict reconstructs an accumulator from a serialized dict."""
+
+    def test_roundtrip(self):
+        acc = ResourceAccumulator()
+        acc.add_source("open-meteo")
+        acc.add_api_call("open_meteo", count=3)
+        acc.increment("sentinel2_scenes_registered", 5)
+        acc.record_phase_duration("weather", 2.1)
+        data = acc.to_dict()
+        restored = ResourceAccumulator.from_dict(data)
+        assert restored.to_dict() == data
+
+    def test_empty_dict(self):
+        restored = ResourceAccumulator.from_dict({})
+        result = restored.to_dict()
+        assert result["data_sources_queried"] == []
+        assert result["api_calls"] == {}
+        assert result["sentinel2_scenes_registered"] == 0
+
+
+class TestEstimateCostPence:
+    """estimate_cost_pence returns indicative platform cost."""
+
+    def test_empty_accumulator_zero(self):
+        acc = ResourceAccumulator()
+        assert acc.estimate_cost_pence() == 0.0
+
+    def test_counters_contribute(self):
+        acc = ResourceAccumulator()
+        acc.increment("sentinel2_scenes_registered", 10)
+        cost = acc.estimate_cost_pence()
+        assert cost > 0
+
+    def test_api_calls_contribute(self):
+        acc = ResourceAccumulator()
+        acc.add_api_call("open_meteo", count=100)
+        cost = acc.estimate_cost_pence()
+        assert cost > 0
+
+    def test_known_values(self):
+        """Verify exact cost for a known resource profile."""
+        acc = ResourceAccumulator()
+        acc.increment("sentinel2_scenes_registered", 10)  # 10 * 0.2 = 2.0
+        acc.increment("ndvi_computations", 10)  # 10 * 0.05 = 0.5
+        acc.add_api_call("open_meteo", count=10)  # 10 * 0.01 = 0.1
+        assert acc.estimate_cost_pence() == 2.6

--- a/treesight/constants.py
+++ b/treesight/constants.py
@@ -112,3 +112,16 @@ EUDR_BASE_PRICE_PENCE = 49_00  # £49/month base subscription
 # DEMO_TIER_RUN_LIMIT caps total pipeline runs (billing quota).
 RATE_LIMIT_DEMO_MAX = 3
 RATE_LIMIT_DEMO_WINDOW = 3600  # 1 hour
+
+# --- Resource cost estimation (#666) ---
+# Indicative per-unit costs in pence (GBP) for internal cost tracking.
+# These are platform costs, not user charges.
+RESOURCE_UNIT_COSTS_PENCE: dict[str, float] = {
+    "sentinel2_scenes_registered": 0.2,  # Planetary Computer query + tile fetch
+    "landsat_scenes_sampled": 0.15,  # Planetary Computer query + tile fetch
+    "ndvi_computations": 0.05,  # compute + blob write
+    "change_detection_comparisons": 0.08,  # compute
+    "mosaic_registrations": 0.10,  # STAC query + registration
+    "per_aoi_enrichments": 1.0,  # full per-AOI pipeline
+    "api_call": 0.01,  # generic external API call
+}

--- a/treesight/models/records.py
+++ b/treesight/models/records.py
@@ -60,6 +60,10 @@ class RunRecord(BaseModel):
     payment_ref: str | None = None  # external ID from payment provider
     refund_reason: str | None = None  # reason recorded when a charge is refunded
 
+    # Resource consumption (#666)
+    resource_summary: dict[str, Any] | None = None
+    estimated_cost_pence: float | None = None
+
     model_config = ConfigDict(extra="allow")
 
 

--- a/treesight/models/records.py
+++ b/treesight/models/records.py
@@ -63,6 +63,8 @@ class RunRecord(BaseModel):
     # Resource consumption (#666)
     resource_summary: dict[str, Any] | None = None
     estimated_cost_pence: float | None = None
+    wasted_cost_pence: float | None = None
+    # Set if run is refunded or failed after partial resource use.
 
     model_config = ConfigDict(extra="allow")
 

--- a/treesight/pipeline/enrichment/resource_accumulator.py
+++ b/treesight/pipeline/enrichment/resource_accumulator.py
@@ -17,7 +17,7 @@ _VALID_COUNTERS = frozenset(
 class ResourceAccumulator:
     """Accumulates resource usage metrics during enrichment.
 
-    Thread-safe for single-writer use within each phase function.
+    Intended for single-threaded mutation within each phase function.
     Designed to be merged after parallel fan-out (data_sources ∥ imagery).
     """
 

--- a/treesight/pipeline/enrichment/resource_accumulator.py
+++ b/treesight/pipeline/enrichment/resource_accumulator.py
@@ -1,0 +1,105 @@
+"""ResourceAccumulator — tracks resource consumption across enrichment phases (#666)."""
+
+from __future__ import annotations
+
+_VALID_COUNTERS = frozenset(
+    {
+        "sentinel2_scenes_registered",
+        "landsat_scenes_sampled",
+        "ndvi_computations",
+        "change_detection_comparisons",
+        "mosaic_registrations",
+        "per_aoi_enrichments",
+    }
+)
+
+
+class ResourceAccumulator:
+    """Accumulates resource usage metrics during enrichment.
+
+    Thread-safe for single-writer use within each phase function.
+    Designed to be merged after parallel fan-out (data_sources ∥ imagery).
+    """
+
+    def __init__(self) -> None:
+        self._sources: list[str] = []
+        self._source_set: set[str] = set()
+        self._api_calls: dict[str, int] = {}
+        self._phase_durations: dict[str, float] = {}
+        self._counters: dict[str, int] = dict.fromkeys(_VALID_COUNTERS, 0)
+
+    def add_source(self, source: str) -> None:
+        """Record a data source as consulted (deduplicated, order-preserving)."""
+        if source not in self._source_set:
+            self._source_set.add(source)
+            self._sources.append(source)
+
+    def add_api_call(self, service: str, *, count: int = 1) -> None:
+        """Increment the API call counter for a service."""
+        self._api_calls[service] = self._api_calls.get(service, 0) + count
+
+    def record_phase_duration(self, phase: str, seconds: float) -> None:
+        """Record how long a phase took (rounded to 1 decimal)."""
+        self._phase_durations[phase] = round(seconds, 1)
+
+    def increment(self, counter: str, amount: int = 1) -> None:
+        """Increment a named counter.
+
+        Raises ValueError for unknown counter names.
+        """
+        if counter not in _VALID_COUNTERS:
+            msg = f"Unknown counter: {counter}"
+            raise ValueError(msg)
+        self._counters[counter] += amount
+
+    def merge(self, other: ResourceAccumulator) -> None:
+        """Merge another accumulator into this one (for parallel fan-out)."""
+        for source in other._sources:
+            self.add_source(source)
+        for service, count in other._api_calls.items():
+            self._api_calls[service] = self._api_calls.get(service, 0) + count
+        for counter, value in other._counters.items():
+            self._counters[counter] += value
+        for phase, duration in other._phase_durations.items():
+            existing = self._phase_durations.get(phase, 0.0)
+            self._phase_durations[phase] = max(existing, duration)
+
+    def to_dict(self) -> dict:
+        """Return a clean serializable dictionary of accumulated metrics."""
+        return {
+            "data_sources_queried": list(self._sources),
+            "api_calls": dict(self._api_calls),
+            "phase_durations": dict(self._phase_durations),
+            **self._counters,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ResourceAccumulator:
+        """Reconstruct an accumulator from a serialized dict."""
+        acc = cls()
+        for source in data.get("data_sources_queried", []):
+            acc.add_source(source)
+        for service, count in data.get("api_calls", {}).items():
+            acc.add_api_call(service, count=count)
+        for phase, duration in data.get("phase_durations", {}).items():
+            acc.record_phase_duration(phase, duration)
+        for counter in _VALID_COUNTERS:
+            value = data.get(counter, 0)
+            if value:
+                acc.increment(counter, value)
+        return acc
+
+    def estimate_cost_pence(self) -> float:
+        """Estimate the platform cost of this run in pence (GBP).
+
+        Uses the indicative unit costs from ``RESOURCE_UNIT_COSTS_PENCE``.
+        """
+        from treesight.constants import RESOURCE_UNIT_COSTS_PENCE
+
+        total = 0.0
+        for counter, value in self._counters.items():
+            unit_cost = RESOURCE_UNIT_COSTS_PENCE.get(counter, 0.0)
+            total += value * unit_cost
+        total_api_calls = sum(self._api_calls.values())
+        total += total_api_calls * RESOURCE_UNIT_COSTS_PENCE.get("api_call", 0.0)
+        return round(total, 2)

--- a/treesight/pipeline/enrichment/runner.py
+++ b/treesight/pipeline/enrichment/runner.py
@@ -30,6 +30,7 @@ from treesight.pipeline.enrichment.ndvi import (
     compute_ndvi,
     fetch_ndvi_stat,
 )
+from treesight.pipeline.enrichment.resource_accumulator import ResourceAccumulator
 from treesight.pipeline.enrichment.weather import (
     aggregate_weather_monthly,
     fetch_weather,
@@ -48,8 +49,10 @@ def _run_weather_phase(
     first_date: str,
     last_date: str,
     results: dict[str, Any],
+    acc: ResourceAccumulator | None = None,
 ) -> None:
     """Phase 1: fetch daily weather data and aggregate monthly summaries."""
+    t0 = time.monotonic()
     log_phase("enrichment", "weather_start", lat=center_lat, lon=center_lon)
     today = datetime.now(UTC).strftime("%Y-%m-%d")
     end_date = min(last_date, today)
@@ -64,14 +67,21 @@ def _run_weather_phase(
         results["weather_monthly"] = None
         log_phase("enrichment", "weather_failed")
 
+    if acc:
+        acc.add_source("open-meteo")
+        acc.add_api_call("open_meteo")
+        acc.record_phase_duration("weather", time.monotonic() - t0)
+
 
 def _run_flood_fire_phase(
     bbox: list[list[float]],
     center_lat: float,
     center_lon: float,
     results: dict[str, Any],
+    acc: ResourceAccumulator | None = None,
 ) -> None:
     """Phase 1b/1c: flood event detection and fire hotspot detection."""
+    t0 = time.monotonic()
     log_phase("enrichment", "flood_start")
     flood_data = fetch_flood_events(bbox, center_lat, center_lon)
     results["flood_events"] = flood_data
@@ -82,12 +92,20 @@ def _run_flood_fire_phase(
     results["fire_hotspots"] = fire_data
     log_phase("enrichment", "fire_done", source=fire_data["source"], count=fire_data["count"])
 
+    if acc:
+        acc.add_source("gfd-flood")
+        acc.add_source("firms-fire")
+        acc.add_api_call("gfd")
+        acc.add_api_call("firms")
+        acc.record_phase_duration("flood_fire", time.monotonic() - t0)
+
 
 def _run_eudr_phase(
     bbox: list[list[float]],
     center_lat: float,
     center_lon: float,
     results: dict[str, Any],
+    acc: ResourceAccumulator | None = None,
 ) -> None:
     """Phase 1d: EUDR-specific enrichments (WorldCover + WDPA + IO LULC + ALOS FNF)."""
     from treesight.pipeline.eudr import (
@@ -97,6 +115,7 @@ def _run_eudr_phase(
         query_worldcover,
     )
 
+    t0 = time.monotonic()
     flat_bbox_eudr = [bbox[0][0], bbox[0][1], bbox[2][0], bbox[2][1]]
 
     log_phase("enrichment", "worldcover_start")
@@ -132,6 +151,21 @@ def _run_eudr_phase(
         checked=wdpa.get("checked", False),
         protected=wdpa.get("is_protected", False),
     )
+
+    if acc:
+        acc.add_source("esa-worldcover")
+        acc.add_source("wdpa")
+        acc.add_source("io-lulc")
+        acc.add_source("alos-fnf")
+        acc.add_api_call("worldcover")
+        acc.add_api_call("wdpa")
+        acc.add_api_call("lulc")
+        acc.add_api_call("alos")
+        landsat_baseline = results.get("landsat_baseline", {})
+        if landsat_baseline.get("available"):
+            acc.add_source("landsat-c2-l2")
+            acc.increment("landsat_scenes_sampled", len(landsat_baseline.get("scenes", [])))
+        acc.record_phase_duration("eudr_datasets", time.monotonic() - t0)
 
 
 def _run_landsat_baseline(
@@ -178,8 +212,10 @@ def _run_mosaic_ndvi_phase(
     output_container: str,
     storage: BlobStorageClient,
     results: dict[str, Any],
+    acc: ResourceAccumulator | None = None,
 ) -> tuple[list[dict[str, Any] | None], list[str | None]]:
     """Phase 2/3: mosaic registration + NDVI computation (COG or tile fallback)."""
+    t0 = time.monotonic()
     # 2. Mosaic registration (parallel — each frame is independent)
     log_phase("enrichment", "mosaic_start", frames=len(frame_plan))
     search_ids: list[str | None] = [None] * len(frame_plan)
@@ -311,6 +347,20 @@ def _run_mosaic_ndvi_phase(
             src = "Sentinel-2 L2A"
         f["info"] = f"{src} | {res} m/px | {f['start']} → {f['end']}"
 
+    if acc:
+        mosaic_count = sum(1 for s in search_ids if s)
+        acc.increment("mosaic_registrations", mosaic_count)
+        acc.increment("ndvi_computations", ndvi_count)
+        s2_count = sum(
+            1 for f in frame_plan if f["collection"] == "sentinel-2-l2a" and f.get("search_id")
+        )
+        if s2_count:
+            acc.add_source("sentinel-2-l2a")
+            acc.increment("sentinel2_scenes_registered", s2_count)
+        # PC API calls: 1 per mosaic registration + 1 per NDVI computation
+        acc.add_api_call("planetary_computer", count=mosaic_count + ndvi_count)
+        acc.record_phase_duration("mosaic_ndvi", time.monotonic() - t0)
+
     return ndvi_stats, ndvi_raster_paths
 
 
@@ -322,8 +372,10 @@ def _run_change_detection_phase(
     timestamp: str,
     storage: BlobStorageClient,
     results: dict[str, Any],
+    acc: ResourceAccumulator | None = None,
 ) -> None:
     """Phase 5: compare same-season NDVI rasters year-over-year."""
+    t0 = time.monotonic()
     if any(ndvi_raster_paths):
         log_phase("enrichment", "change_detection_start")
         change_results = detect_changes(
@@ -335,14 +387,20 @@ def _run_change_detection_phase(
             storage=storage,
         )
         results["change_detection"] = change_results
+        comparisons = change_results["summary"]["comparisons"]
         log_phase(
             "enrichment",
             "change_detection_done",
-            comparisons=change_results["summary"]["comparisons"],
+            comparisons=comparisons,
             trajectory=change_results["summary"].get("trajectory"),
         )
+        if acc:
+            acc.increment("change_detection_comparisons", comparisons)
     else:
         results["change_detection"] = {"season_changes": [], "summary": {}}
+
+    if acc:
+        acc.record_phase_duration("change_detection", time.monotonic() - t0)
 
 
 def _run_aoi_metrics_phase(
@@ -416,11 +474,12 @@ def _enrich_single_aoi(
 
     first_date = frame_plan[0]["start"]
     last_date = frame_plan[-1]["end"]
-    _run_weather_phase(center_lat, center_lon, first_date, last_date, result)
-    _run_flood_fire_phase(bbox, center_lat, center_lon, result)
+    aoi_acc = ResourceAccumulator()
+    _run_weather_phase(center_lat, center_lon, first_date, last_date, result, acc=aoi_acc)
+    _run_flood_fire_phase(bbox, center_lat, center_lon, result, acc=aoi_acc)
 
     if eudr_mode:
-        _run_eudr_phase(bbox, center_lat, center_lon, result)
+        _run_eudr_phase(bbox, center_lat, center_lon, result, acc=aoi_acc)
 
     _ndvi_stats, ndvi_raster_paths = _run_mosaic_ndvi_phase(
         bbox,
@@ -431,6 +490,7 @@ def _enrich_single_aoi(
         output_container,
         storage,
         result,
+        acc=aoi_acc,
     )
 
     _run_change_detection_phase(
@@ -441,6 +501,7 @@ def _enrich_single_aoi(
         timestamp,
         storage,
         result,
+        acc=aoi_acc,
     )
 
     # Deforestation-free determination (#603)
@@ -451,6 +512,7 @@ def _enrich_single_aoi(
 
         result["determination"] = determine_deforestation_free(result)
 
+    result["resource_usage"] = aoi_acc.to_dict()
     return result
 
 
@@ -532,14 +594,15 @@ def run_enrichment(
     # 1. Weather data
     first_date = frame_plan[0]["start"]
     last_date = frame_plan[-1]["end"]
-    _run_weather_phase(center_lat, center_lon, first_date, last_date, results)
+    acc = ResourceAccumulator()
+    _run_weather_phase(center_lat, center_lon, first_date, last_date, results, acc=acc)
 
     # 1b/1c. Flood + fire
-    _run_flood_fire_phase(bbox, center_lat, center_lon, results)
+    _run_flood_fire_phase(bbox, center_lat, center_lon, results, acc=acc)
 
     # 1d. EUDR-specific enrichments (WorldCover + WDPA)
     if eudr_mode:
-        _run_eudr_phase(bbox, center_lat, center_lon, results)
+        _run_eudr_phase(bbox, center_lat, center_lon, results, acc=acc)
 
     # 2/3. Mosaic registration + NDVI computation
     ndvi_stats, ndvi_raster_paths = _run_mosaic_ndvi_phase(
@@ -551,6 +614,7 @@ def run_enrichment(
         output_container,
         storage,
         results,
+        acc=acc,
     )
 
     # 5. Change detection
@@ -562,6 +626,7 @@ def run_enrichment(
         timestamp,
         storage,
         results,
+        acc=acc,
     )
 
     # 6. Per-AOI quantitative metrics
@@ -607,6 +672,18 @@ def run_enrichment(
     # 7. Store manifest
     duration = time.monotonic() - start
     results["enrichment_duration_seconds"] = round(duration, 1)
+
+    # Merge per-AOI resource usage into the top-level accumulator
+    per_aoi_enrichment = results.get("per_aoi_enrichment", [])
+    succeeded_aois = [r for r in per_aoi_enrichment if "error" not in r]
+    acc.increment("per_aoi_enrichments", len(succeeded_aois))
+    for aoi_r in succeeded_aois:
+        usage = aoi_r.get("resource_usage")
+        if isinstance(usage, dict):
+            acc.merge(ResourceAccumulator.from_dict(usage))
+    results["resource_usage"] = acc.to_dict()
+    results["estimated_cost_pence"] = acc.estimate_cost_pence()
+
     results["enriched_at"] = datetime.now(UTC).isoformat()
     if eudr_mode:
         results["eudr_mode"] = True
@@ -689,14 +766,16 @@ def enrich_data_sources(
 
     first_date = frame_plan[0]["start"]
     last_date = frame_plan[-1]["end"]
-    _run_weather_phase(center_lat, center_lon, first_date, last_date, results)
-    _run_flood_fire_phase(bbox, center_lat, center_lon, results)
+    acc = ResourceAccumulator()
+    _run_weather_phase(center_lat, center_lon, first_date, last_date, results, acc=acc)
+    _run_flood_fire_phase(bbox, center_lat, center_lon, results, acc=acc)
 
     if eudr_mode:
-        _run_eudr_phase(bbox, center_lat, center_lon, results)
+        _run_eudr_phase(bbox, center_lat, center_lon, results, acc=acc)
         results["eudr_mode"] = True
         results["eudr_date_start"] = date_start
 
+    results["resource_usage"] = acc.to_dict()
     return results
 
 
@@ -736,14 +815,31 @@ def enrich_imagery(
     if not frame_plan:
         return results
 
+    acc = ResourceAccumulator()
     _ndvi_stats, ndvi_raster_paths = _run_mosaic_ndvi_phase(
-        bbox, coords, frame_plan, project_name, timestamp, output_container, storage, results
+        bbox,
+        coords,
+        frame_plan,
+        project_name,
+        timestamp,
+        output_container,
+        storage,
+        results,
+        acc=acc,
     )
 
     _run_change_detection_phase(
-        frame_plan, ndvi_raster_paths, output_container, project_name, timestamp, storage, results
+        frame_plan,
+        ndvi_raster_paths,
+        output_container,
+        project_name,
+        timestamp,
+        storage,
+        results,
+        acc=acc,
     )
 
+    results["resource_usage"] = acc.to_dict()
     return results
 
 
@@ -806,13 +902,30 @@ def enrich_finalize(
     the final manifest to blob storage.
     """
     # Merge: data_sources is the base, imagery overlays
+    ds_usage = data_sources.pop("resource_usage", None)
+    img_usage = imagery.pop("resource_usage", None)
     merged = {**data_sources, **imagery}
+
+    # Combine resource accumulators from parallel fan-out
+    acc = ResourceAccumulator()
+    if ds_usage:
+        acc.merge(ResourceAccumulator.from_dict(ds_usage))
+    if img_usage:
+        acc.merge(ResourceAccumulator.from_dict(img_usage))
 
     if per_aoi_results:
         merged["per_aoi_enrichment"] = per_aoi_results
-        succeeded = sum(1 for r in per_aoi_results if "error" not in r)
-        log_phase("enrichment", "per_aoi_done", total=len(per_aoi_results), succeeded=succeeded)
+        succeeded = [r for r in per_aoi_results if "error" not in r]
+        acc.increment("per_aoi_enrichments", len(succeeded))
+        log_phase(
+            "enrichment",
+            "per_aoi_done",
+            total=len(per_aoi_results),
+            succeeded=len(succeeded),
+        )
 
+    merged["resource_usage"] = acc.to_dict()
+    merged["estimated_cost_pence"] = acc.estimate_cost_pence()
     merged["enriched_at"] = datetime.now(UTC).isoformat()
     if eudr_mode:
         merged["eudr_mode"] = True

--- a/treesight/security/billing_ledger.py
+++ b/treesight/security/billing_ledger.py
@@ -196,6 +196,12 @@ def fail_run_billing(
                 f"Overage credit not confirmed instance={instance_id} user={_redact(user_id)}"
             )
 
+    # Preserve estimated cost so refunded work can be tracked as wasted cost.
+    estimated_cost_pence = doc.get("estimated_cost_pence")
+    if estimated_cost_pence is not None:
+        doc["wasted_cost_pence"] = estimated_cost_pence
+    # (If estimated_cost_pence is missing, do not overwrite.)
+
     doc["billing_status"] = "refunded"
     doc["refund_reason"] = reason
     upsert_item("runs", doc)

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -343,6 +343,13 @@
                   <div id="app-evidence-change-list"></div>
                 </div>
 
+                <!-- Resources consumed -->
+                <div class="app-evidence-block" id="app-evidence-resources-block" hidden>
+                  <span class="app-content-label">Resources consumed</span>
+                  <div id="app-evidence-resources-grid"></div>
+                  <p class="app-evidence-note" id="app-evidence-resources-note"></p>
+                </div>
+
                 <!-- Per-AOI selector (multi-polygon runs only) -->
                 <div class="app-evidence-block" id="app-evidence-aoi-block" hidden>
                   <div class="app-evidence-aoi-header">

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -350,6 +350,13 @@
                   <div id="app-evidence-change-list"></div>
                 </div>
 
+                <!-- Resources consumed -->
+                <div class="app-evidence-block" id="app-evidence-resources-block" hidden>
+                  <span class="app-content-label">Resources consumed</span>
+                  <div id="app-evidence-resources-grid"></div>
+                  <p class="app-evidence-note" id="app-evidence-resources-note"></p>
+                </div>
+
                 <!-- Per-parcel selector (multi-polygon runs only) -->
                 <div class="app-evidence-block" id="app-evidence-aoi-block" hidden>
                   <div class="app-evidence-aoi-header">

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -39,6 +39,7 @@
   var pcNdviTileUrl = CanopexEvidenceRender.pcNdviTileUrl;
   var renderAoiDetail = CanopexEvidenceRender.renderAoiDetail;
   var clearAoiDetail = CanopexEvidenceRender.clearAoiDetail;
+  var renderResourceUsage = CanopexEvidenceRender.renderResourceUsage;
 
   const POST_LOGIN_DESTINATION_KEY = 'canopex-post-login';
   const WORKSPACE_ROLE_STORAGE_KEY = 'canopex-workspace-role';
@@ -994,6 +995,7 @@
     renderEvidenceNdvi(evidenceManifest);
     renderEvidenceWeather(evidenceManifest);
     renderEvidenceChangeDetection(evidenceManifest);
+    renderResourceUsage(evidenceManifest);
     initEvidenceMap(evidenceManifest);
 
     // Show persistent run reference in the evidence header.

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -1405,6 +1405,43 @@
   }
 
   /* ---- EUDR assessment ---- */
+  function activeEvidenceContext() {
+    if (!evidenceManifest) return null;
+    var perAoi = evidenceManifest.per_aoi_enrichment || [];
+    if (evidenceSelectedAoi >= 0 && evidenceSelectedAoi < perAoi.length) {
+      return perAoi[evidenceSelectedAoi];
+    }
+    return evidenceManifest;
+  }
+
+  function buildEvidenceNdviTimeseries(source) {
+    if (!source) return [];
+    return (source.ndvi_stats || []).map(function(f, i) {
+      if (!f) return null;
+      var fp = (source.frame_plan || [])[i] || {};
+      return {
+        date: f.datetime || f.date || fp.start || fp.label,
+        mean: f.mean,
+        min: f.min,
+        max: f.max,
+        year: f.year || fp.year,
+        season: f.season || fp.season
+      };
+    }).filter(Boolean);
+  }
+
+  function evidenceLatLon(source) {
+    if (!source) return { lat: 0, lon: 0 };
+    var center = source.center || source.coords;
+    if (Array.isArray(center)) {
+      return { lat: center[0] || 0, lon: center[1] || 0 };
+    }
+    return {
+      lat: (center && (center.lat || center.latitude)) || 0,
+      lon: (center && (center.lon || center.longitude)) || 0
+    };
+  }
+
   async function requestEudrAssessment() {
     var loading = document.getElementById('app-evidence-eudr-loading');
     var content = document.getElementById('app-evidence-eudr-content');
@@ -1418,18 +1455,15 @@
     try {
       await apiDiscoveryReady;
 
-      var ndviTimeseries = (evidenceManifest.ndvi_stats || []).filter(Boolean).map(function(f) {
-        return { date: f.date || f.label, mean: f.mean, min: f.min, max: f.max, year: f.year, season: f.season };
-      });
-      var center = evidenceManifest.center || evidenceManifest.coords;
-      var lat = Array.isArray(center) ? center[0] : (center && center.lat) || 0;
-      var lon = Array.isArray(center) ? center[1] : (center && center.lon) || 0;
+      var source = activeEvidenceContext();
+      var ndviTimeseries = buildEvidenceNdviTimeseries(source);
+      var latLon = evidenceLatLon(source);
 
       var body = {
         context: {
-          aoi_name: 'Analysis area',
-          latitude: lat,
-          longitude: lon,
+          aoi_name: source && source.name ? source.name : 'Analysis area',
+          latitude: latLon.lat,
+          longitude: latLon.lon,
           ndvi_timeseries: ndviTimeseries,
           reference_date: '2020-12-31'
         }

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -1029,10 +1029,21 @@
   }
 
   function clearEvidencePanels() {
-    var ids = ['app-evidence-ndvi-grid', 'app-evidence-weather-grid', 'app-evidence-change-list', 'app-evidence-ai-content', 'app-evidence-eudr-content'];
+    var ids = [
+      'app-evidence-ndvi-grid',
+      'app-evidence-weather-grid',
+      'app-evidence-change-list',
+      'app-evidence-ai-content',
+      'app-evidence-eudr-content',
+      'app-evidence-resources-grid'
+    ];
     ids.forEach(function(id) { var el = document.getElementById(id); if (el) el.textContent = ''; });
     var noteEl = document.getElementById('app-evidence-ndvi-note');
     if (noteEl) noteEl.textContent = '';
+    var resourceNote = document.getElementById('app-evidence-resources-note');
+    if (resourceNote) resourceNote.textContent = '';
+    var resourcesBlock = document.getElementById('app-evidence-resources-block');
+    if (resourcesBlock) resourcesBlock.hidden = true;
     var runRefEl = document.getElementById('app-evidence-run-ref');
     if (runRefEl) { runRefEl.textContent = ''; runRefEl.title = ''; runRefEl.hidden = true; }
     var canvases = ['app-evidence-ndvi-canvas', 'app-evidence-weather-canvas'];

--- a/website/js/canopex-evidence-render.js
+++ b/website/js/canopex-evidence-render.js
@@ -526,6 +526,43 @@
     if (flagsEl) { flagsEl.hidden = true; flagsEl.textContent = ''; }
   }
 
+  /* ---- Resources consumed evidence card (#666) ---- */
+  function renderResourceUsage(manifest) {
+    var block = document.getElementById('app-evidence-resources-block');
+    var grid = document.getElementById('app-evidence-resources-grid');
+    var note = document.getElementById('app-evidence-resources-note');
+    if (!block || !grid) return;
+
+    var usage = manifest.resource_usage;
+    if (!usage) return;
+
+    block.hidden = false;
+    var items = [];
+    var sources = usage.data_sources_queried || [];
+    if (sources.length) items.push(['Data sources', String(sources.length), '']);
+
+    var apiTotal = 0;
+    var calls = usage.api_calls || {};
+    for (var svc in calls) { if (calls.hasOwnProperty(svc)) apiTotal += calls[svc]; }
+    if (apiTotal) items.push(['API calls', String(apiTotal), '']);
+
+    if (usage.sentinel2_scenes_registered) items.push(['Sentinel-2 scenes', String(usage.sentinel2_scenes_registered), '']);
+    if (usage.landsat_scenes_sampled) items.push(['Landsat scenes', String(usage.landsat_scenes_sampled), '']);
+    if (usage.ndvi_computations) items.push(['NDVI computations', String(usage.ndvi_computations), '']);
+    if (usage.mosaic_registrations) items.push(['Mosaic registrations', String(usage.mosaic_registrations), '']);
+    if (usage.change_detection_comparisons) items.push(['Change comparisons', String(usage.change_detection_comparisons), '']);
+    if (usage.per_aoi_enrichments) items.push(['Per-parcel enrichments', String(usage.per_aoi_enrichments), '']);
+
+    if (!items.length) return;
+    setStatGrid(grid, items);
+
+    // Cost note — only for logged-in users with cost visibility
+    var costPence = manifest.estimated_cost_pence;
+    if (note && typeof costPence === 'number' && costPence > 0) {
+      note.textContent = 'Est. platform cost: \u00A3' + (costPence / 100).toFixed(2);
+    }
+  }
+
   window.CanopexEvidenceRender = {
     renderEvidenceNdvi: renderEvidenceNdvi,
     drawNdviSparkline: drawNdviSparkline,
@@ -537,5 +574,6 @@
     pcNdviTileUrl: pcNdviTileUrl,
     renderAoiDetail: renderAoiDetail,
     clearAoiDetail: clearAoiDetail,
+    renderResourceUsage: renderResourceUsage,
   };
 })();

--- a/website/js/canopex-evidence-render.js
+++ b/website/js/canopex-evidence-render.js
@@ -533,10 +533,14 @@
     var note = document.getElementById('app-evidence-resources-note');
     if (!block || !grid) return;
 
+    // Always clear previous content so switching runs cannot leave stale stats.
+    grid.textContent = '';
+    if (note) note.textContent = '';
+    block.hidden = true;
+
     var usage = manifest.resource_usage;
     if (!usage) return;
 
-    block.hidden = false;
     var items = [];
     var sources = usage.data_sources_queried || [];
     if (sources.length) items.push(['Data sources', String(sources.length), '']);
@@ -554,13 +558,8 @@
     if (usage.per_aoi_enrichments) items.push(['Per-parcel enrichments', String(usage.per_aoi_enrichments), '']);
 
     if (!items.length) return;
+    block.hidden = false;
     setStatGrid(grid, items);
-
-    // Cost note — only for logged-in users with cost visibility
-    var costPence = manifest.estimated_cost_pence;
-    if (note && typeof costPence === 'number' && costPence > 0) {
-      note.textContent = 'Est. platform cost: \u00A3' + (costPence / 100).toFixed(2);
-    }
   }
 
   window.CanopexEvidenceRender = {


### PR DESCRIPTION
## Stage 3B.0 — Pipeline cost accumulator + resources consumed evidence card

Closes #666

### What

ResourceAccumulator tracks resource consumption across all enrichment phases and surfaces it in the evidence UI as a "Resources consumed" card.

### Backend

- **New `ResourceAccumulator` class** — tracks data sources, API calls, phase durations, and typed counters (sentinel2 scenes, landsat scenes, NDVI computations, change detection comparisons, mosaic registrations, per-AOI enrichments)
- **All 6 enrichment phase functions instrumented** with timing and resource tracking (`_run_weather_phase`, `_run_flood_fire_phase`, `_run_eudr_phase`, `_run_mosaic_ndvi_phase`, `_run_change_detection_phase`, `_run_aoi_metrics_phase`)
- **Accumulators created/passed/merged** in `run_enrichment`, `enrich_data_sources`, `enrich_imagery`, `enrich_finalize`, `_enrich_single_aoi`
- **`resource_usage` + `estimated_cost_pence`** emitted in enrichment manifest and pipeline summary
- **RunRecord** extended with `resource_summary` and `estimated_cost_pence` fields
- **`RESOURCE_UNIT_COSTS_PENCE`** constants for internal cost tracking
- **`from_dict` / `estimate_cost_pence`** methods for round-tripping and cost estimation

### Frontend

- **Resources consumed evidence card** in both `/app/` and `/eudr/` views
- Shows data sources count, API calls, scene counts, NDVI/change computations, per-parcel enrichments
- Estimated platform cost shown when available (£ format)

### Tests

- 29 new tests covering ResourceAccumulator init, add_source, add_api_call, record_phase_duration, counter increments, merge, to_dict, from_dict round-trip, and cost estimation
- All 1,522 tests pass