### PR TITLE
feat: Stage 3B — imagery quality gate + evidence provenance contract (closes #645, #649)

### DIFF
--- a/blueprints/export.py
+++ b/blueprints/export.py
@@ -488,6 +488,63 @@ def _build_eudr_csv(manifest: dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _pdf_scene_provenance_section(pdf: Any, frame_plan: list[dict[str, Any]]) -> None:
+    """Write a scene-provenance table for every frame in the report (#647).
+
+    Each row records the satellite scene identifier, collection, spatial
+    resolution, cloud-cover percentage, and acquisition date so the imagery
+    evidence can be independently verified.
+    """
+    if not frame_plan:
+        return
+
+    pdf.set_text_color(0, 0, 0)
+    pdf.set_font("Helvetica", "B", 12)
+    pdf.cell(0, 8, "Scene Provenance", new_x="LMARGIN", new_y="NEXT")
+    pdf.set_font("Helvetica", "", 9)
+    pdf.multi_cell(
+        0,
+        5,
+        "The table below records the satellite scene used for each analysis "
+        "window so that imagery evidence can be independently verified.",
+    )
+    pdf.ln(3)
+
+    # Column widths (fractions of effective page width)
+    col_ratios = [0.18, 0.14, 0.12, 0.28, 0.12, 0.16]
+    page_w = pdf.epw
+    col_widths = [round(r * page_w, 1) for r in col_ratios]
+    headers = ["Label", "Collection", "Res (m)", "Scene ID", "Cloud %", "Acquired"]
+
+    pdf.set_font("Helvetica", "B", 8)
+    for i, h in enumerate(headers):
+        pdf.cell(col_widths[i], 6, h, border=1)
+    pdf.ln()
+
+    pdf.set_font("Helvetica", "", 7)
+    for frame in frame_plan:
+        prov = frame.get("provenance") or {}
+        scene_id = prov.get("ndvi_scene_id") or prov.get("display_search_id") or "--"
+        resolution = prov.get("resolution_m")
+        cloud = prov.get("cloud_cover_pct")
+        acquired = (prov.get("acquired_at") or "")[:10]
+        collection = prov.get("collection") or frame.get("collection") or "--"
+
+        row = [
+            _safe_text(frame.get("label", ""))[:18],
+            collection[:14],
+            str(resolution) if resolution is not None else "--",
+            _safe_text(str(scene_id))[:28],
+            f"{float(cloud):.1f}" if cloud is not None else "--",
+            acquired or "--",
+        ]
+        for i, val in enumerate(row):
+            pdf.cell(col_widths[i], 5, val, border=1)
+        pdf.ln()
+
+    pdf.ln(6)
+
+
 def _pdf_header(pdf: Any, manifest: dict[str, Any], instance_id: str) -> None:
     """Write title and metadata section of the PDF."""
     eudr_mode = manifest.get("eudr_mode", False)
@@ -828,6 +885,10 @@ def _build_pdf(manifest: dict[str, Any], instance_id: str = "") -> bytes:
     per_aoi = manifest.get("per_aoi_enrichment", [])
     if per_aoi:
         _pdf_per_parcel_sections(pdf, per_aoi)
+
+    # Scene provenance table (#647) — traceability appendix listing scene IDs,
+    # resolution and cloud cover for every analysis frame.
+    _pdf_scene_provenance_section(pdf, manifest.get("frame_plan", []))
 
     # Disclaimer
     pdf.set_font("Helvetica", "I", 8)

--- a/blueprints/export.py
+++ b/blueprints/export.py
@@ -58,6 +58,7 @@ def _build_geojson(manifest: dict[str, Any]) -> dict[str, Any]:
             "end_date": frame.get("end", ""),
             "collection": frame.get("collection", ""),
             "is_naip": frame.get("is_naip", False),
+            "provenance": frame.get("provenance", {}),
         }
         if ndvi:
             props["ndvi_mean"] = ndvi.get("mean")
@@ -141,6 +142,13 @@ def _build_csv(manifest: dict[str, Any]) -> str:
         "end_date",
         "collection",
         "is_naip",
+        "display_search_id",
+        "ndvi_search_id",
+        "ndvi_scene_id",
+        "resolution_m",
+        "cloud_cover_pct",
+        "acquired_at",
+        "artifact_path",
         "ndvi_mean",
         "ndvi_min",
         "ndvi_max",
@@ -191,6 +199,7 @@ def _build_csv(manifest: dict[str, Any]) -> str:
         change = change_lookup.get((frame.get("season", ""), frame.get("year", 0)))
         ndvi_delta = change.get("mean_delta") if change else None
 
+        provenance = frame.get("provenance", {})
         row = {
             "frame_index": i,
             "label": frame.get("label", ""),
@@ -200,6 +209,17 @@ def _build_csv(manifest: dict[str, Any]) -> str:
             "end_date": frame.get("end", ""),
             "collection": frame.get("collection", ""),
             "is_naip": frame.get("is_naip", False),
+            "display_search_id": provenance.get("display_search_id", ""),
+            "ndvi_search_id": provenance.get("ndvi_search_id", ""),
+            "ndvi_scene_id": provenance.get(
+                "ndvi_scene_id", ndvi.get("scene_id", "") if ndvi else ""
+            ),
+            "resolution_m": provenance.get("resolution_m", ""),
+            "cloud_cover_pct": provenance.get(
+                "cloud_cover_pct", ndvi.get("cloud_cover", "") if ndvi else ""
+            ),
+            "acquired_at": provenance.get("acquired_at", ndvi.get("datetime", "") if ndvi else ""),
+            "artifact_path": provenance.get("artifact_path", frame.get("ndvi_raster_path", "")),
             "ndvi_mean": ndvi.get("mean", "") if ndvi else "",
             "ndvi_min": ndvi.get("min", "") if ndvi else "",
             "ndvi_max": ndvi.get("max", "") if ndvi else "",

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -208,8 +208,8 @@ interactively.
 cuts Function wall-clock time and idle cost without changing the user-facing
 product surface.
 
-| Order | Issue | Title | Status |
-|-------|-------|-------|--------|
+| Order  | Issue  | Title | Status |
+|--------|--------|-------|--------|
 | 3B.5.0 | #688 | Monitoring delta fetch + fan-out queue to cut PC wait time | Open |
 | 3B.5.1 | #466 | Split Container Apps into orchestrator + compute images | Open |
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -190,10 +190,10 @@ deforestation-free determinations.
 | Order | Issue | Title | Status |
 |-------|-------|-------|--------|
 | 3B.0 | #666 | Pipeline cost accumulator + resources consumed evidence card | ✅ #667 |
-| 3B.1 | #647 | Defensible PDF export: embed imagery, maps, and visual evidence | Open |
+| 3B.1 | #645 | Imagery quality gate: reject/deprioritise low-res for small AOIs | Open |
 | 3B.2 | #649 | Evidence provenance: traceability from viewer back to source imagery | Open |
 | 3B.3 | #646 | Imagery viewer: dynamic layer picker with smart defaults | Open |
-| 3B.4 | #645 | Imagery quality gate: reject/deprioritise low-res for small AOIs | Open |
+| 3B.4 | #647 | Defensible PDF export: embed imagery, maps, and visual evidence | Open |
 
 **Exit:** Compliance officer can export audit-grade PDF with embedded
 evidence, trace any result back to source imagery, and review layers

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,6 +41,7 @@ Stages 2D and 2E can proceed in parallel. Stage 3B.5 is next priority after 3B.
 
 | PR | Summary |
 |----|---------|  
+| #690 | feat: Stage 3B complete — imagery quality gate, provenance contract, dynamic layer picker, defensible PDF (closes #645, #649, #646, #647) |
 | #667 | feat: Stage 3B.0 — Pipeline cost accumulator + resources consumed evidence card (closes #666) |
 | #665 | feat: Stage 3A — EUDR assessment management: entitlement gate, CSV upload, cost estimator, flagged-parcel review (closes #660, #661, #662, #664) |
 | #663 | fix: Subscribe modal hard-wall bug, EUDR entitlement gate on submit, dark theme modal styling |
@@ -190,10 +191,10 @@ deforestation-free determinations.
 | Order | Issue | Title | Status |
 |-------|-------|-------|--------|
 | 3B.0 | #666 | Pipeline cost accumulator + resources consumed evidence card | ✅ #667 |
-| 3B.1 | #645 | Imagery quality gate: reject/deprioritise low-res for small AOIs | Open |
-| 3B.2 | #649 | Evidence provenance: traceability from viewer back to source imagery | Open |
-| 3B.3 | #646 | Imagery viewer: dynamic layer picker with smart defaults | Open |
-| 3B.4 | #647 | Defensible PDF export: embed imagery, maps, and visual evidence | Open |
+| 3B.1 | #645 | Imagery quality gate: reject/deprioritise low-res for small AOIs | ✅ #690 |
+| 3B.2 | #649 | Evidence provenance: traceability from viewer back to source imagery | ✅ #690 |
+| 3B.3 | #646 | Imagery viewer: dynamic layer picker with smart defaults | ✅ #690 |
+| 3B.4 | #647 | Defensible PDF export: embed imagery, maps, and visual evidence | ✅ #690 |
 
 **Exit:** Compliance officer can export audit-grade PDF with embedded
 evidence, trace any result back to source imagery, and review layers

--- a/tests/test_enrichment_runner.py
+++ b/tests/test_enrichment_runner.py
@@ -168,6 +168,34 @@ class TestMosaicNdviParallel:
 
     @patch("treesight.pipeline.enrichment.runner.compute_ndvi")
     @patch("treesight.pipeline.enrichment.runner.register_mosaic")
+    def test_landsat_unsuitable_rgb_still_registers_s2_ndvi(self, mock_mosaic, mock_ndvi):
+        """Landsat frames with rgb_display_suitable=False must still register an S2 NDVI mosaic.
+
+        Previously the Landsat fallback branch was missing, leaving ndvi_search_ids[idx]=None
+        which disabled tile-based NDVI for that frame entirely.
+        """
+        frames = [
+            {
+                **_make_frame(collection="landsat-c2-l2", is_naip=False),
+                "rgb_display_suitable": False,
+                "preferred_layer": "ndvi",
+            }
+        ]
+        mock_mosaic.return_value = "sid-sentinel-2-l2a"
+        mock_ndvi.return_value = {"mean": 0.4}
+        storage = MagicMock()
+        results: dict = {}
+
+        _run_mosaic_ndvi_phase(BBOX, COORDS, frames, "proj", "ts", "out", storage, results)
+
+        # RGB mosaic skipped — search_ids[0] must be None
+        assert results["search_ids"][0] is None
+        # But a Sentinel-2 NDVI mosaic must have been registered as fallback
+        assert results["ndvi_search_ids"][0] == "sid-sentinel-2-l2a"
+        mock_mosaic.assert_called_once()
+
+    @patch("treesight.pipeline.enrichment.runner.compute_ndvi")
+    @patch("treesight.pipeline.enrichment.runner.register_mosaic")
     def test_frame_plan_records_normalized_provenance(self, mock_mosaic, mock_ndvi):
         """Each frame should carry a normalized provenance bundle for viewer/export use."""
         frames = [_make_frame(collection="sentinel-2-l2a", is_naip=False)]

--- a/tests/test_enrichment_runner.py
+++ b/tests/test_enrichment_runner.py
@@ -146,6 +146,52 @@ class TestMosaicNdviParallel:
 
     @patch("treesight.pipeline.enrichment.runner.compute_ndvi")
     @patch("treesight.pipeline.enrichment.runner.register_mosaic")
+    def test_skips_visual_registration_when_rgb_is_unsuitable(self, mock_mosaic, mock_ndvi):
+        """Tiny coarse frames should skip RGB mosaic registration but keep NDVI search."""
+        frames = [
+            {
+                **_make_frame(collection="sentinel-2-l2a", is_naip=False),
+                "rgb_display_suitable": False,
+                "preferred_layer": "ndvi",
+            }
+        ]
+        mock_mosaic.return_value = "sid-sentinel-2-l2a"
+        mock_ndvi.return_value = {"mean": 0.5}
+        storage = MagicMock()
+        results: dict = {}
+
+        _run_mosaic_ndvi_phase(BBOX, COORDS, frames, "proj", "ts", "out", storage, results)
+
+        mock_mosaic.assert_called_once()
+        assert results["search_ids"][0] is None
+        assert results["ndvi_search_ids"][0] == "sid-sentinel-2-l2a"
+
+    @patch("treesight.pipeline.enrichment.runner.compute_ndvi")
+    @patch("treesight.pipeline.enrichment.runner.register_mosaic")
+    def test_frame_plan_records_normalized_provenance(self, mock_mosaic, mock_ndvi):
+        """Each frame should carry a normalized provenance bundle for viewer/export use."""
+        frames = [_make_frame(collection="sentinel-2-l2a", is_naip=False)]
+        mock_mosaic.return_value = "sid-sentinel-2-l2a"
+        mock_ndvi.return_value = {
+            "mean": 0.5,
+            "scene_id": "S2A_123",
+            "cloud_cover": 8.5,
+            "datetime": "2024-03-17T10:20:00Z",
+        }
+        storage = MagicMock()
+        results: dict = {}
+
+        _run_mosaic_ndvi_phase(BBOX, COORDS, frames, "proj", "ts", "out", storage, results)
+
+        provenance = frames[0].get("provenance")
+        assert provenance is not None
+        assert provenance["collection"] == "sentinel-2-l2a"
+        assert provenance["display_search_id"] == "sid-sentinel-2-l2a"
+        assert provenance["ndvi_scene_id"] == "S2A_123"
+        assert provenance["resolution_m"] == 10.0
+
+    @patch("treesight.pipeline.enrichment.runner.compute_ndvi")
+    @patch("treesight.pipeline.enrichment.runner.register_mosaic")
     def test_cog_result_with_geotiff_uploads_raster(self, mock_mosaic, mock_ndvi):
         """When compute_ndvi returns geotiff_bytes, the raster is uploaded."""
         frames = [_make_frame(year=2025, season="winter")]
@@ -431,6 +477,32 @@ class TestEnrichImagery:
             storage=storage,
         )
         assert result == {}
+
+    @patch("treesight.pipeline.enrichment.runner._run_change_detection_phase")
+    @patch("treesight.pipeline.enrichment.runner._run_mosaic_ndvi_phase")
+    @patch("treesight.pipeline.enrichment.runner.build_frame_plan")
+    def test_returns_annotated_frame_plan_for_finalize(self, mock_plan, mock_mosaic, mock_change):
+        frame_plan = [_make_frame()]
+        mock_plan.return_value = frame_plan
+
+        def annotate_frame(*args, **kwargs):
+            frame_plan[0]["label"] = "Spring 2024"
+            frame_plan[0]["provenance"] = {"ndvi_scene_id": "S2A_123"}
+            return ({}, {})
+
+        mock_mosaic.side_effect = annotate_frame
+        storage = MagicMock()
+
+        result = enrich_imagery(
+            COORDS,
+            project_name="p",
+            timestamp="t",
+            output_container="out",
+            storage=storage,
+        )
+
+        assert result["frame_plan"][0]["label"] == "Spring 2024"
+        assert result["frame_plan"][0]["provenance"]["ndvi_scene_id"] == "S2A_123"
 
 
 class TestEnrichSingleAoiStep:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -136,6 +136,22 @@ class TestBuildGeoJSON:
         assert props["end_date"] == "2023-05-31"
         assert props["collection"] == "sentinel-2-l2a"
 
+    def test_frame_properties_include_normalized_provenance(self, enrichment_manifest):
+        enrichment_manifest["frame_plan"][0]["provenance"] = {
+            "collection": "sentinel-2-l2a",
+            "display_search_id": "sid-s2-spring-2023",
+            "ndvi_search_id": "sid-s2-spring-2023",
+            "ndvi_scene_id": "S2A_123",
+            "resolution_m": 10.0,
+            "cloud_cover_pct": 8.5,
+            "acquired_at": "2023-03-17T10:20:00Z",
+            "artifact_path": "enrichment/run-1/ndvi/2023_spring.tif",
+        }
+        result = _build_geojson(enrichment_manifest)
+        props = result["features"][0]["properties"]
+        assert props["provenance"]["display_search_id"] == "sid-s2-spring-2023"
+        assert props["provenance"]["ndvi_scene_id"] == "S2A_123"
+
     def test_summary_feature_is_point(self, enrichment_manifest):
         result = _build_geojson(enrichment_manifest)
         summary = result["features"][-1]
@@ -178,7 +194,25 @@ class TestBuildCSV:
         header = next(reader)
         assert "frame_index" in header
         assert "ndvi_mean" in header
-        assert "mean_temp_c" in header
+
+    def test_flattens_normalized_provenance_fields(self, enrichment_manifest):
+        enrichment_manifest["frame_plan"][0]["provenance"] = {
+            "display_search_id": "sid-s2-spring-2023",
+            "ndvi_search_id": "sid-s2-spring-2023",
+            "ndvi_scene_id": "S2A_123",
+            "resolution_m": 10.0,
+            "cloud_cover_pct": 8.5,
+            "acquired_at": "2023-03-17T10:20:00Z",
+            "artifact_path": "enrichment/run-1/ndvi/2023_spring.tif",
+        }
+        result = _build_csv(enrichment_manifest)
+        reader = csv.DictReader(io.StringIO(result))
+        row = next(reader)
+        assert row["display_search_id"] == "sid-s2-spring-2023"
+        assert row["ndvi_scene_id"] == "S2A_123"
+        assert row["artifact_path"] == "enrichment/run-1/ndvi/2023_spring.tif"
+        assert reader.fieldnames is not None
+        assert "mean_temp_c" in reader.fieldnames
 
     def test_one_row_per_frame(self, enrichment_manifest):
         result = _build_csv(enrichment_manifest)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -15,6 +15,7 @@ from blueprints.export import (
     _build_eudr_geojson,
     _build_geojson,
     _build_pdf,
+    _pdf_scene_provenance_section,
     build_eudr_audit_pdf,
 )
 
@@ -302,6 +303,62 @@ class TestBuildPDF:
         ]
 
         result = _build_pdf(manifest, "run-legacy")
+        assert result.startswith(b"%PDF")
+
+    def test_pdf_includes_scene_provenance_when_present(self, enrichment_manifest):
+        """#647 — PDF must render without error when frame_plan has provenance fields."""
+        manifest = dict(enrichment_manifest)
+        manifest["frame_plan"] = [
+            {
+                "label": "2023 Wet Season",
+                "year": 2023,
+                "season": "wet",
+                "start": "2023-03-01",
+                "end": "2023-05-31",
+                "collection": "sentinel-2-l2a",
+                "provenance": {
+                    "collection": "sentinel-2-l2a",
+                    "ndvi_scene_id": "S2_20230415_T18NXM",
+                    "resolution_m": 10.0,
+                    "cloud_cover_pct": 5.2,
+                    "acquired_at": "2023-04-15",
+                },
+            }
+        ]
+        result = _build_pdf(manifest, "run-provenance-647")
+        assert result.startswith(b"%PDF")
+
+    def test_pdf_scene_provenance_section_renders_scene_id(self):
+        """#647 — _pdf_scene_provenance_section must surface scene ID and resolution."""
+        from fpdf import FPDF
+
+        pdf = FPDF()
+        pdf.add_page()
+        frame_plan = [
+            {
+                "label": "2023-wet",
+                "collection": "sentinel-2-l2a",
+                "provenance": {
+                    "ndvi_scene_id": "S2A_MSIL2A_20230415",
+                    "resolution_m": 10.0,
+                    "cloud_cover_pct": 3.1,
+                    "acquired_at": "2023-04-15",
+                },
+            }
+        ]
+        _pdf_scene_provenance_section(pdf, frame_plan)
+        result = bytes(pdf.output())
+        assert result.startswith(b"%PDF")
+
+    def test_pdf_scene_provenance_section_tolerates_missing_provenance(self):
+        """#647 — section must not crash when provenance key is absent."""
+        from fpdf import FPDF
+
+        pdf = FPDF()
+        pdf.add_page()
+        frame_plan = [{"label": "2023-wet", "collection": "sentinel-2-l2a"}]
+        _pdf_scene_provenance_section(pdf, frame_plan)
+        result = bytes(pdf.output())
         assert result.startswith(b"%PDF")
 
 

--- a/tests/test_integration_analysis.py
+++ b/tests/test_integration_analysis.py
@@ -236,6 +236,39 @@ class TestFramePlanIntegrity:
         assert all(f["rgb_display_suitable"] is True for f in naip_frames)
         assert all(f["preferred_layer"] == "rgb" for f in naip_frames)
 
+    def test_legacy_naip_frames_use_higher_gsd(self):
+        """NAIP frames from 2014 or earlier must use 1.0 m/px GSD, not 0.6 m/px.
+
+        Pre-2015 NAIP was collected at 1 m/px; using 0.6 m/px under-estimates
+        the display-pixel count and could incorrectly flag frames as unsuitable.
+        """
+        from treesight.constants import NAIP_LEGACY_GSD_M
+        from treesight.pipeline.enrichment.frames import _annotate_display_metadata
+
+        legacy_frame = {
+            "label": "2014 Summer",
+            "year": 2014,
+            "season": "summer",
+            "start": "2014-06-01",
+            "end": "2014-08-31",
+            "collection": "naip",
+            "is_naip": True,
+        }
+        modern_frame = dict(legacy_frame, year=2020, label="2020 Summer")
+
+        annotated = _annotate_display_metadata([legacy_frame, modern_frame], TINY_US_COORDS)
+        legacy = annotated[0]
+        modern = annotated[1]
+
+        assert legacy["display_resolution_m"] == NAIP_LEGACY_GSD_M, (
+            "2014 NAIP frame should use the legacy 1.0 m/px GSD"
+        )
+        assert modern["display_resolution_m"] < NAIP_LEGACY_GSD_M, (
+            "post-2014 NAIP frame should use the finer 0.6 m/px GSD"
+        )
+        # Legacy is coarser → fewer estimated pixels for the same AOI
+        assert legacy["estimated_display_pixels"] < modern["estimated_display_pixels"]
+
 
 class TestFrontendTransform:
     """Verify the Python replica of the JS data transform is correct."""

--- a/tests/test_integration_analysis.py
+++ b/tests/test_integration_analysis.py
@@ -86,8 +86,24 @@ def _frontend_transform_weather(
 # All coordinates are [lon, lat] per project convention (see constants.py).
 UK_COORDS = [[-1.15, 52.72], [-1.14, 52.72], [-1.14, 52.71], [-1.15, 52.71]]
 
+# Tiny UK parcel (~20 m across) — too small for useful Sentinel-2 RGB.
+TINY_UK_COORDS = [
+    [-1.15000, 52.72000],
+    [-1.14972, 52.72000],
+    [-1.14972, 52.71982],
+    [-1.15000, 52.71982],
+]
+
 # US coords (Colorado, within CONUS — has NAIP)
 US_COORDS = [[-105.0, 39.0], [-104.9, 39.0], [-104.9, 38.9], [-105.0, 38.9]]
+
+# Tiny US parcel (~20 m across) — still suitable for NAIP RGB.
+TINY_US_COORDS = [
+    [-105.00000, 39.00000],
+    [-104.99978, 39.00000],
+    [-104.99978, 38.99982],
+    [-105.00000, 38.99982],
+]
 
 
 def _make_fake_ndvi_stats(
@@ -199,6 +215,26 @@ class TestFramePlanIntegrity:
         plan = build_frame_plan(UK_COORDS)
         starts = [f["start"] for f in plan]
         assert starts == sorted(starts)
+
+    def test_small_non_naip_aoi_marks_rgb_as_unsuitable(self):
+        """Tiny non-US AOIs should prefer NDVI over coarse RGB display."""
+        plan = build_frame_plan(TINY_UK_COORDS)
+        assert len(plan) > 0
+
+        s2_frames = [f for f in plan if f["collection"] == "sentinel-2-l2a"]
+        assert s2_frames, "expected Sentinel-2 frames for tiny UK AOI"
+        assert any(f["rgb_display_suitable"] is False for f in s2_frames)
+        assert all(
+            f["preferred_layer"] == "ndvi" for f in s2_frames if not f["rgb_display_suitable"]
+        )
+
+    def test_small_naip_aoi_keeps_rgb_as_suitable(self):
+        """Tiny CONUS AOIs should keep NAIP RGB as the preferred display layer."""
+        plan = build_frame_plan(TINY_US_COORDS)
+        naip_frames = [f for f in plan if f.get("is_naip")]
+        assert naip_frames, "expected NAIP frames for tiny US AOI"
+        assert all(f["rgb_display_suitable"] is True for f in naip_frames)
+        assert all(f["preferred_layer"] == "rgb" for f in naip_frames)
 
 
 class TestFrontendTransform:

--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -1022,6 +1022,14 @@ class TestEvidenceMapQualityGate:
             "so updateLayerButtonLabels has per-frame context without re-reading the DOM"
         )
 
+    def test_layer_mode_buttons_synced_on_init(self):
+        """#690 review — buildEvidenceFrames must sync button active state after setting mode."""
+        content = self.APP_SHELL.read_text()
+        assert "syncLayerModeButtons" in content, (
+            "app-shell.js must define syncLayerModeButtons() and call it whenever "
+            "evidenceLayerMode is changed programmatically so buttons match the map"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Endpoint auth audit (#572) — ensure every non-anonymous endpoint is protected

--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -998,6 +998,30 @@ class TestEvidenceMapQualityGate:
             "from frame metadata"
         )
 
+    def test_layer_button_labels_update_per_frame(self):
+        """#646 — layer picker shows per-frame collection + resolution as button labels."""
+        content = self.APP_SHELL.read_text()
+        assert "updateLayerButtonLabels" in content, (
+            "app-shell.js must define updateLayerButtonLabels(frame) so each frame's "
+            "collection and resolution are surfaced in the layer picker buttons"
+        )
+
+    def test_layer_mode_falls_back_to_rgb_when_ndvi_unavailable(self):
+        """#646 — navigating to a frame without NDVI must not leave the viewer broken."""
+        content = self.APP_SHELL.read_text()
+        assert "evidenceLayerMode === 'ndvi' && !activeFrame.ndvi" in content, (
+            "showEvidenceFrame must fall back from ndvi to rgb when the active frame "
+            "has no ndvi layer, so the viewer never shows a blank tile"
+        )
+
+    def test_layer_picker_stores_collection_label_per_frame(self):
+        """#646 — buildEvidenceFrames must record collectionLabel per entry."""
+        content = self.APP_SHELL.read_text()
+        assert "collectionLabel" in content, (
+            "buildEvidenceFrames must store a collectionLabel per map-layer entry "
+            "so updateLayerButtonLabels has per-frame context without re-reading the DOM"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Endpoint auth audit (#572) — ensure every non-anonymous endpoint is protected

--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -976,6 +976,29 @@ class TestEudrModeToggle:
         ), "requestEudrAssessment must send a real NDVI observation date, not only a display label"
 
 
+class TestEvidenceMapQualityGate:
+    """Ensure the evidence map respects frame-plan display quality metadata."""
+
+    APP_SHELL = WEBSITE / "js" / "app-shell.js"
+
+    def test_evidence_map_reads_frame_quality_metadata(self):
+        content = self.APP_SHELL.read_text()
+        assert "rgb_display_suitable" in content, (
+            "app-shell.js must read frame_plan.rgb_display_suitable "
+            "so coarse RGB frames can be demoted"
+        )
+        assert "preferred_layer" in content, (
+            "app-shell.js must read frame_plan.preferred_layer to choose RGB vs NDVI intelligently"
+        )
+
+    def test_evidence_map_chooses_default_layer_from_frame_plan(self):
+        content = self.APP_SHELL.read_text()
+        assert "pickEvidenceDefaultLayer" in content, (
+            "app-shell.js must define a helper that chooses the default evidence layer "
+            "from frame metadata"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Endpoint auth audit (#572) — ensure every non-anonymous endpoint is protected
 # ---------------------------------------------------------------------------

--- a/treesight/constants.py
+++ b/treesight/constants.py
@@ -31,6 +31,12 @@ DEFAULT_MAX_OFF_NADIR_DEG = 30.0
 MAX_OFF_NADIR_DEG_LIMIT = 45.0
 MIN_RESOLUTION_M = 0.01
 DEFAULT_PROVIDER = "planetary_computer"
+RGB_DISPLAY_MIN_PIXELS = 12
+COLLECTION_DISPLAY_GSD_M = {
+    "naip": 0.6,
+    "sentinel-2-l2a": 10.0,
+    "landsat-c2-l2": 30.0,
+}
 
 # --- Polling / batching ---
 DEFAULT_POLL_INTERVAL_SECONDS = 30

--- a/treesight/constants.py
+++ b/treesight/constants.py
@@ -33,10 +33,12 @@ MIN_RESOLUTION_M = 0.01
 DEFAULT_PROVIDER = "planetary_computer"
 RGB_DISPLAY_MIN_PIXELS = 12
 COLLECTION_DISPLAY_GSD_M = {
-    "naip": 0.6,
+    "naip": 0.6,  # post-2014 NAIP (0.6 m/px)
     "sentinel-2-l2a": 10.0,
     "landsat-c2-l2": 30.0,
 }
+NAIP_LEGACY_GSD_M = 1.0  # vintages ≤ 2014 were collected at 1 m/px
+NAIP_LEGACY_MAX_YEAR = 2014
 
 # --- Polling / batching ---
 DEFAULT_POLL_INTERVAL_SECONDS = 30

--- a/treesight/pipeline/enrichment/frames.py
+++ b/treesight/pipeline/enrichment/frames.py
@@ -1,10 +1,17 @@
-"""Frame planning — season/year matrix and NAIP detection."""
+"""Frame planning — season/year matrix, NAIP detection, and display suitability."""
 
 from __future__ import annotations
 
 import calendar
+import math
 from datetime import date, timedelta
 from typing import Any
+
+from treesight.constants import (
+    COLLECTION_DISPLAY_GSD_M,
+    METRES_PER_DEGREE_LATITUDE,
+    RGB_DISPLAY_MIN_PIXELS,
+)
 
 # Seasonal definitions matching the frontend
 SEASONS: list[dict[str, Any]] = [
@@ -32,6 +39,54 @@ NAIP_SUMMERS = {
     "2020-summer",
     "2022-summer",
 }
+
+
+def _max_aoi_span_m(coords: list[list[float]]) -> float:
+    """Approximate the larger AOI span in metres from lon/lat coordinates."""
+    if not coords:
+        return 0.0
+    lons = [c[0] for c in coords]
+    lats = [c[1] for c in coords]
+    mid_lat = (min(lats) + max(lats)) / 2.0
+    lat_span_m = (max(lats) - min(lats)) * METRES_PER_DEGREE_LATITUDE
+    lon_span_m = (
+        (max(lons) - min(lons)) * METRES_PER_DEGREE_LATITUDE * math.cos(math.radians(mid_lat))
+    )
+    return max(lat_span_m, lon_span_m)
+
+
+def _annotate_display_metadata(
+    frames: list[dict[str, Any]],
+    coords: list[list[float]],
+) -> list[dict[str, Any]]:
+    """Attach RGB suitability metadata used by the evidence viewer."""
+    max_span_m = _max_aoi_span_m(coords)
+    annotated: list[dict[str, Any]] = []
+
+    for frame in frames:
+        collection = str(frame["collection"])
+        display_gsd_m = float(COLLECTION_DISPLAY_GSD_M.get(collection, 10.0))
+        estimated_pixels = max_span_m / display_gsd_m if display_gsd_m > 0 else 0.0
+        rgb_display_suitable = estimated_pixels >= RGB_DISPLAY_MIN_PIXELS
+        warning = ""
+        if not rgb_display_suitable:
+            warning = (
+                f"{collection} imagery is {display_gsd_m:.1f} m/px; "
+                "RGB detail is limited at this AOI size. NDVI remains informative."
+            )
+
+        annotated.append(
+            {
+                **frame,
+                "display_resolution_m": display_gsd_m,
+                "estimated_display_pixels": round(estimated_pixels, 1),
+                "rgb_display_suitable": rgb_display_suitable,
+                "preferred_layer": "rgb" if rgb_display_suitable else "ndvi",
+                "rgb_display_warning": warning,
+            }
+        )
+
+    return annotated
 
 
 def _aoi_has_naip(coords: list[list[float]]) -> bool:
@@ -192,4 +247,4 @@ def build_frame_plan(
             and not (date_end and f["start"] > date_end)
         ]
 
-    return frames
+    return _annotate_display_metadata(frames, coords)

--- a/treesight/pipeline/enrichment/frames.py
+++ b/treesight/pipeline/enrichment/frames.py
@@ -10,6 +10,8 @@ from typing import Any
 from treesight.constants import (
     COLLECTION_DISPLAY_GSD_M,
     METRES_PER_DEGREE_LATITUDE,
+    NAIP_LEGACY_GSD_M,
+    NAIP_LEGACY_MAX_YEAR,
     RGB_DISPLAY_MIN_PIXELS,
 )
 
@@ -65,7 +67,11 @@ def _annotate_display_metadata(
 
     for frame in frames:
         collection = str(frame["collection"])
-        display_gsd_m = float(COLLECTION_DISPLAY_GSD_M.get(collection, 10.0))
+        # Older NAIP acquisitions (≤ 2014) were collected at 1 m/px, not 0.6 m/px.
+        if collection.startswith("naip") and int(frame.get("year", 9999)) <= NAIP_LEGACY_MAX_YEAR:
+            display_gsd_m = float(NAIP_LEGACY_GSD_M)
+        else:
+            display_gsd_m = float(COLLECTION_DISPLAY_GSD_M.get(collection, 10.0))
         estimated_pixels = max_span_m / display_gsd_m if display_gsd_m > 0 else 0.0
         rgb_display_suitable = estimated_pixels >= RGB_DISPLAY_MIN_PIXELS
         warning = ""

--- a/treesight/pipeline/enrichment/runner.py
+++ b/treesight/pipeline/enrichment/runner.py
@@ -235,7 +235,11 @@ def _run_mosaic_ndvi_phase(
                 sid = register_mosaic(f["collection"], f["start"], f["end"], bbox, extra, cl)
 
             nsid = sid
-            if sid is None and f["collection"] == "sentinel-2-l2a":
+            # When the RGB mosaic was skipped (unsuitable) or failed, register a
+            # Sentinel-2 mosaic for NDVI so the viewer has a vegetation tile to show.
+            # This covers sentinel-2-l2a (direct) and landsat-c2-l2 (cross-sensor) —
+            # previously Landsat frames were left with nsid=None here.
+            if sid is None and f["collection"] in {"sentinel-2-l2a", "landsat-c2-l2"}:
                 nsid = register_mosaic(
                     "sentinel-2-l2a",
                     f["start"],

--- a/treesight/pipeline/enrichment/runner.py
+++ b/treesight/pipeline/enrichment/runner.py
@@ -11,6 +11,7 @@ from typing import Any
 import httpx
 
 from treesight.constants import (
+    COLLECTION_DISPLAY_GSD_M,
     DEFAULT_ENRICHMENT_CONCURRENCY,
     DEFAULT_HTTP_TIMEOUT_SECONDS,
     EUDR_CUTOFF_DATE,
@@ -229,8 +230,20 @@ def _run_mosaic_ndvi_phase(
             else []
         )
         with httpx.Client(timeout=DEFAULT_HTTP_TIMEOUT_SECONDS) as cl:
-            sid = register_mosaic(f["collection"], f["start"], f["end"], bbox, extra, cl)
+            sid = None
+            if f.get("rgb_display_suitable", True):
+                sid = register_mosaic(f["collection"], f["start"], f["end"], bbox, extra, cl)
+
             nsid = sid
+            if sid is None and f["collection"] == "sentinel-2-l2a":
+                nsid = register_mosaic(
+                    "sentinel-2-l2a",
+                    f["start"],
+                    f["end"],
+                    bbox,
+                    [{"op": "<=", "args": [{"property": "eo:cloud_cover"}, 20]}],
+                    cl,
+                )
             if f["is_naip"]:
                 nsid = register_mosaic(
                     "sentinel-2-l2a",
@@ -346,6 +359,19 @@ def _run_mosaic_ndvi_phase(
             res = "10"
             src = "Sentinel-2 L2A"
         f["info"] = f"{src} | {res} m/px | {f['start']} → {f['end']}"
+        ndvi_stat = ndvi_stats[i] if i < len(ndvi_stats) else None
+        f["provenance"] = {
+            "collection": f.get("collection", ""),
+            "display_search_id": search_ids[i],
+            "ndvi_search_id": ndvi_search_ids[i],
+            "ndvi_scene_id": ndvi_stat.get("scene_id") if ndvi_stat else None,
+            "resolution_m": f.get("display_resolution_m")
+            or COLLECTION_DISPLAY_GSD_M.get(str(f.get("collection", ""))),
+            "cloud_cover_pct": ndvi_stat.get("cloud_cover") if ndvi_stat else None,
+            "acquired_at": ndvi_stat.get("datetime") if ndvi_stat else None,
+            "artifact_path": f.get("ndvi_raster_path"),
+            "label": f.get("label", ""),
+        }
 
     if acc:
         mosaic_count = sum(1 for s in search_ids if s)
@@ -811,9 +837,9 @@ def enrich_imagery(
         max_history_years=max_history_years,
     )
 
-    results: dict[str, Any] = {}
+    results: dict[str, Any] = {"frame_plan": frame_plan}
     if not frame_plan:
-        return results
+        return {}
 
     acc = ResourceAccumulator()
     _ndvi_stats, ndvi_raster_paths = _run_mosaic_ndvi_phase(
@@ -902,9 +928,10 @@ def enrich_finalize(
     the final manifest to blob storage.
     """
     # Merge: data_sources is the base, imagery overlays
-    ds_usage = data_sources.pop("resource_usage", None)
-    img_usage = imagery.pop("resource_usage", None)
+    ds_usage = data_sources.get("resource_usage")
+    img_usage = imagery.get("resource_usage")
     merged = {**data_sources, **imagery}
+    merged.pop("resource_usage", None)
 
     # Combine resource accumulators from parallel fan-out
     acc = ResourceAccumulator()

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -984,6 +984,56 @@
     });
   }
 
+  // #646 — update layer button aria-labels and titles with per-frame
+  // collection and resolution so the picker is self-documenting.
+  function updateLayerButtonLabels(frame) {
+    var btnRgb = document.getElementById('app-map-btn-rgb');
+    var btnNdvi = document.getElementById('app-map-btn-ndvi');
+    var expRgb = document.getElementById('app-map-expanded-btn-rgb');
+    var expNdvi = document.getElementById('app-map-expanded-btn-ndvi');
+    if (!frame) return;
+    var info = frame.collectionLabel
+      ? (frame.collectionLabel + (frame.resLabel || ''))
+      : '';
+    [btnRgb, expRgb].forEach(function(btn) {
+      if (!btn) return;
+      var base = info ? 'True-colour RGB — ' + info : 'True-colour RGB';
+      // Preserve quality warning set by syncEvidenceLayerButtons when disabled.
+      if (!btn.disabled) btn.title = base;
+      btn.setAttribute('aria-label', info ? 'RGB (' + info + ')' : 'RGB');
+    });
+    [btnNdvi, expNdvi].forEach(function(btn) {
+      if (!btn) return;
+      btn.title = info ? 'Vegetation index (NDVI) — ' + info : 'Vegetation index (NDVI)';
+      btn.setAttribute('aria-label', info ? 'NDVI (' + info + ')' : 'NDVI');
+    });
+  }
+
+  // #646 — update layer button aria-labels and titles with per-frame
+  // collection and resolution so the picker is self-documenting.
+  function updateLayerButtonLabels(frame) {
+    var btnRgb = document.getElementById('app-map-btn-rgb');
+    var btnNdvi = document.getElementById('app-map-btn-ndvi');
+    var expRgb = document.getElementById('app-map-expanded-btn-rgb');
+    var expNdvi = document.getElementById('app-map-expanded-btn-ndvi');
+    if (!frame) return;
+    var info = frame.collectionLabel
+      ? (frame.collectionLabel + (frame.resLabel || ''))
+      : '';
+    [btnRgb, expRgb].forEach(function(btn) {
+      if (!btn) return;
+      var base = info ? 'True-colour RGB \u2014 ' + info : 'True-colour RGB';
+      // Preserve any quality warning appended by syncEvidenceLayerButtons.
+      if (!btn.disabled) btn.title = base;
+      btn.setAttribute('aria-label', info ? 'RGB (' + info + ')' : 'RGB');
+    });
+    [btnNdvi, expNdvi].forEach(function(btn) {
+      if (!btn) return;
+      btn.title = info ? 'Vegetation index (NDVI) \u2014 ' + info : 'Vegetation index (NDVI)';
+      btn.setAttribute('aria-label', info ? 'NDVI (' + info + ')' : 'NDVI');
+    });
+  }
+
   function showEvidenceSurface(visible) {
     var surface = document.getElementById('app-evidence-surface');
     var phaseStatus = document.getElementById('app-content-phase-status');
@@ -1296,6 +1346,17 @@
         ndviLayer.addTo(evidenceMap);
       }
 
+      // #646 — store human-readable collection label and resolution suffix so
+      // updateLayerButtonLabels can build informative button titles per frame.
+      var collectionLabel = collection.indexOf('naip') >= 0 ? 'NAIP'
+        : collection.indexOf('sentinel') >= 0 ? 'Sentinel-2'
+        : collection.indexOf('landsat') >= 0 ? 'Landsat'
+        : collection;
+      var resolutionM = (frame.provenance && frame.provenance.resolution_m)
+        || frame.display_resolution_m
+        || null;
+      var resLabel = resolutionM ? (' \u00b7 ' + resolutionM + 'm') : '';
+
       evidenceMapLayers.push({
         rgb: rgbLayer,
         ndvi: ndviLayer,
@@ -1303,7 +1364,9 @@
         info: [collection, frame.start_date, frame.end_date].filter(Boolean).join(' | '),
         rgbDisplaySuitable: frame.rgb_display_suitable !== false,
         rgbDisplayWarning: frame.rgb_display_warning || '',
-        preferredLayer: frame.preferred_layer || 'rgb'
+        preferredLayer: frame.preferred_layer || 'rgb',
+        collectionLabel: collectionLabel,
+        resLabel: resLabel
       });
     });
 
@@ -1316,6 +1379,12 @@
     evidenceFrameIndex = idx;
     var activeFrame = evidenceMapLayers[idx];
 
+    // #646 — bidirectional mode adaptation:
+    // Fall back to rgb when the user is in ndvi mode but this frame has no ndvi layer.
+    if (evidenceLayerMode === 'ndvi' && !activeFrame.ndvi) {
+      evidenceLayerMode = 'rgb';
+    }
+    // Promote to ndvi for coarse frames where rgb is unsuitable (established in #645).
     if (activeFrame.rgbDisplaySuitable === false && activeFrame.ndvi) {
       evidenceLayerMode = 'ndvi';
     }
@@ -1337,6 +1406,7 @@
         (activeFrame.rgbDisplayWarning ? ' — ' + activeFrame.rgbDisplayWarning : '');
     }
     syncEvidenceLayerButtons(activeFrame);
+    updateLayerButtonLabels(activeFrame);
 
     // Sync expanded controls if open
     if (evidenceMapExpanded) syncExpandedControls();

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -947,10 +947,41 @@
     }
     if (counter) counter.textContent = (evidenceFrameIndex + 1) + '/' + evidenceMapLayers.length;
     if (label && evidenceMapLayers[evidenceFrameIndex]) {
-      label.textContent = evidenceMapLayers[evidenceFrameIndex].label + ' — ' + evidenceMapLayers[evidenceFrameIndex].info;
+      var expandedFrame = evidenceMapLayers[evidenceFrameIndex];
+      label.textContent = expandedFrame.label + ' — ' + expandedFrame.info +
+        (expandedFrame.rgbDisplayWarning ? ' — ' + expandedFrame.rgbDisplayWarning : '');
     }
+    syncEvidenceLayerButtons(evidenceMapLayers[evidenceFrameIndex]);
     if (rgbBtn) rgbBtn.classList.toggle('active', evidenceLayerMode === 'rgb');
     if (ndviBtn) ndviBtn.classList.toggle('active', evidenceLayerMode === 'ndvi');
+  }
+
+  function pickEvidenceDefaultLayer(frame) {
+    if (!frame) return 'rgb';
+    if (frame.preferredLayer === 'ndvi' || frame.preferred_layer === 'ndvi') return 'ndvi';
+    return 'rgb';
+  }
+
+  function syncEvidenceLayerButtons(frame) {
+    var rgbBtn = document.getElementById('app-map-btn-rgb');
+    var ndviBtn = document.getElementById('app-map-btn-ndvi');
+    var expandedRgbBtn = document.getElementById('app-map-expanded-btn-rgb');
+    var expandedNdviBtn = document.getElementById('app-map-expanded-btn-ndvi');
+    var rgbDisabled = !!(frame && frame.rgbDisplaySuitable === false);
+    var warning = frame && frame.rgbDisplayWarning ? frame.rgbDisplayWarning : '';
+
+    [rgbBtn, expandedRgbBtn].forEach(function(btn) {
+      if (!btn) return;
+      btn.disabled = rgbDisabled;
+      btn.title = rgbDisabled ? warning : '';
+      btn.classList.toggle('is-disabled', rgbDisabled);
+    });
+    [ndviBtn, expandedNdviBtn].forEach(function(btn) {
+      if (!btn) return;
+      btn.disabled = false;
+      btn.title = '';
+      btn.classList.remove('is-disabled');
+    });
   }
 
   function showEvidenceSurface(visible) {
@@ -1252,7 +1283,7 @@
       var sid = searchIds[idx];
       var ndviSid = ndviSearchIds[idx] || sid;
       var collection = frame.collection || 'sentinel-2-l2a';
-      var asset = collection.indexOf('naip') >= 0 ? 'image' : 'visual';
+      var asset = frame.asset || (collection.indexOf('naip') >= 0 ? 'image' : 'visual');
 
       var rgbLayer = null;
       var ndviLayer = null;
@@ -1269,16 +1300,25 @@
         rgb: rgbLayer,
         ndvi: ndviLayer,
         label: frame.label || ('Frame ' + (idx + 1)),
-        info: [collection, frame.start_date, frame.end_date].filter(Boolean).join(' | ')
+        info: [collection, frame.start_date, frame.end_date].filter(Boolean).join(' | '),
+        rgbDisplaySuitable: frame.rgb_display_suitable !== false,
+        rgbDisplayWarning: frame.rgb_display_warning || '',
+        preferredLayer: frame.preferred_layer || 'rgb'
       });
     });
 
+    evidenceLayerMode = pickEvidenceDefaultLayer(evidenceMapLayers[0]);
     showEvidenceFrame(0);
   }
 
   function showEvidenceFrame(idx) {
     if (idx < 0 || idx >= evidenceMapLayers.length) return;
     evidenceFrameIndex = idx;
+    var activeFrame = evidenceMapLayers[idx];
+
+    if (activeFrame.rgbDisplaySuitable === false && activeFrame.ndvi) {
+      evidenceLayerMode = 'ndvi';
+    }
 
     evidenceMapLayers.forEach(function(frame, i) {
       var showRgb = (i === idx && evidenceLayerMode === 'rgb');
@@ -1292,7 +1332,11 @@
     var label = document.getElementById('app-map-frame-label');
     if (slider) slider.value = idx;
     if (counter) counter.textContent = (idx + 1) + '/' + evidenceMapLayers.length;
-    if (label) label.textContent = evidenceMapLayers[idx].label + ' — ' + evidenceMapLayers[idx].info;
+    if (label) {
+      label.textContent = activeFrame.label + ' — ' + activeFrame.info +
+        (activeFrame.rgbDisplayWarning ? ' — ' + activeFrame.rgbDisplayWarning : '');
+    }
+    syncEvidenceLayerButtons(activeFrame);
 
     // Sync expanded controls if open
     if (evidenceMapExpanded) syncExpandedControls();

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -1009,6 +1009,22 @@
     });
   }
 
+  // Sync the active/inactive classes on all RGB and NDVI buttons (both inline
+  // panel and expanded modal) to match the current evidenceLayerMode.
+  // Called any time evidenceLayerMode is changed programmatically so the
+  // visual state is always consistent with what is rendered on the map.
+  function syncLayerModeButtons() {
+    var isRgb = evidenceLayerMode === 'rgb';
+    ['app-map-btn-rgb', 'app-map-expanded-btn-rgb'].forEach(function(id) {
+      var btn = document.getElementById(id);
+      if (btn) btn.classList.toggle('active', isRgb);
+    });
+    ['app-map-btn-ndvi', 'app-map-expanded-btn-ndvi'].forEach(function(id) {
+      var btn = document.getElementById(id);
+      if (btn) btn.classList.toggle('active', !isRgb);
+    });
+  }
+
   // #646 — update layer button aria-labels and titles with per-frame
   // collection and resolution so the picker is self-documenting.
   function updateLayerButtonLabels(frame) {
@@ -1371,6 +1387,7 @@
     });
 
     evidenceLayerMode = pickEvidenceDefaultLayer(evidenceMapLayers[0]);
+    syncLayerModeButtons();
     showEvidenceFrame(0);
   }
 
@@ -1388,6 +1405,8 @@
     if (activeFrame.rgbDisplaySuitable === false && activeFrame.ndvi) {
       evidenceLayerMode = 'ndvi';
     }
+    // Keep button active classes in sync after any programmatic mode change.
+    syncLayerModeButtons();
 
     evidenceMapLayers.forEach(function(frame, i) {
       var showRgb = (i === idx && evidenceLayerMode === 'rgb');


### PR DESCRIPTION
## Summary

First two Stage 3B evidence-quality issues: **#645** imagery quality gate and **#649** evidence provenance contract.

## Changes

### Imagery quality gate (#645)

`treesight/pipeline/enrichment/frames.py` — `build_frame_plan()` now annotates every frame with display suitability metadata:

- `display_resolution_m` — native GSD of the collection
- `estimated_display_pixels` — approximate AOI span / GSD
- `rgb_display_suitable` — `True` only when ≥ 12 display pixels
- `preferred_layer` — `"rgb"` or `"ndvi"` based on the above
- `rgb_display_warning` — human-readable explanation when unsuitable

`treesight/pipeline/enrichment/runner.py` — `_run_mosaic_ndvi_phase()` skips RGB mosaic registration for unsuitable frames; falls back to a Sentinel-2 NDVI-only search, avoiding unnecessary Planetary Computer wait time for frames where the RGB result would be unusable anyway.

`website/js/app-shell.js` — evidence viewer now:
- `pickEvidenceDefaultLayer()` reads `preferred_layer` from frame plan
- `syncEvidenceLayerButtons()` disables the RGB button (with tooltip) when unsuitable
- `showEvidenceFrame()` forces NDVI mode for coarse frames
- Frame labels append the quality warning text

### Evidence provenance contract (#649)

`treesight/pipeline/enrichment/runner.py` — each frame now carries a normalized `provenance` bundle after enrichment: `collection`, `display_search_id`, `ndvi_search_id`, `ndvi_scene_id`, `resolution_m`, `cloud_cover_pct`, `acquired_at`, `artifact_path`, `label`.

`blueprints/export.py`:
- **GeoJSON**: `provenance` dict nested under each frame feature's properties
- **CSV**: provenance fields flattened as explicit columns (`display_search_id`, `ndvi_search_id`, `ndvi_scene_id`, `resolution_m`, `cloud_cover_pct`, `acquired_at`, `artifact_path`) with fallbacks to legacy `ndvi_stats` fields for backwards compatibility

### Fan-out path fix (regression from this slice)

`enrich_imagery()` now returns the annotated `frame_plan` so `enrich_finalize()` receives provenance-annotated frames on the Durable Functions fan-out path. Previously the annotated plan was discarded before merge. `enrich_finalize()` merge is now non-destructive (uses `.get()` not `.pop()` for `resource_usage`).

### Roadmap

Corrected Stage 3B execution order to match the actual delivery sequence: `#645 → #649 → #646 → #647`.

## Validation

- 1520 passed, 28 skipped (`python -m pytest -x -q`) — full suite green
- `ruff check` + `ruff format --check` — clean
- All pre-commit hooks passed

## What's next

- **#646** Dynamic layer picker with canonical ordering and progressive disclosure (builds on frame quality metadata and provenance contract from this PR)
- **#647** Defensible PDF export with embedded imagery and provenance-backed captions