### PR TITLE
feat: Stage 3B.5 — monitoring delta fetch + NDVI baseline + orchestrator/compute image split

### DIFF
--- a/.github/image-config.env
+++ b/.github/image-config.env
@@ -5,3 +5,4 @@
 # so forks publish to their own GHCR namespace.
 BASE_IMAGE_REPO="treesight-base"
 APP_IMAGE_REPO="treesight"
+ORCH_IMAGE_REPO="treesight-orch"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     outputs:
       image_uri: ${{ steps.resolve.outputs.image_uri || steps.meta.outputs.image_uri }}
+      orch_image_uri: ${{ steps.resolve-orch.outputs.orch_image_uri || steps.orch-meta.outputs.orch_image_uri }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -91,6 +92,16 @@ jobs:
           echo "image_uri=${IMAGE_NAME}:${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           echo "### ♻️ Promoting existing image: \`${IMAGE_NAME}:${IMAGE_TAG}\`" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Resolve existing orchestrator image for promotion
+        id: resolve-orch
+        if: ${{ inputs.image_tag != '' }}
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          source .github/image-config.env
+          ORCH_IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${ORCH_IMAGE_REPO}"
+          echo "orch_image_uri=${ORCH_IMAGE_NAME}:${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+
       # ── Normal path: build fresh image ──────────────────────
       - name: Log in to GHCR
         if: ${{ inputs.image_tag == '' }}
@@ -106,11 +117,22 @@ jobs:
         run: |
           source .github/image-config.env
           IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${APP_IMAGE_REPO}"
+          ORCH_IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${ORCH_IMAGE_REPO}"
           TAG="${{ github.sha }}"
           APP_VERSION=$(grep -oP '(?<=^version = ")[^"]+' pyproject.toml)
           echo "image_name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
           echo "image_uri=${IMAGE_NAME}:${TAG}" >> "$GITHUB_OUTPUT"
+          echo "orch_image_name=${ORCH_IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "orch_image_uri=${ORCH_IMAGE_NAME}:${TAG}" >> "$GITHUB_OUTPUT"
           echo "app_version=${APP_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Set orchestrator image metadata
+        if: ${{ inputs.image_tag == '' }}
+        id: orch-meta
+        run: |
+          source .github/image-config.env
+          ORCH_IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${ORCH_IMAGE_REPO}"
+          echo "orch_image_uri=${ORCH_IMAGE_NAME}:${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Resolve base image
         if: ${{ inputs.image_tag == '' }}
@@ -143,6 +165,20 @@ jobs:
             -t "${IMAGE_NAME}:${{ steps.meta.outputs.app_version }}" \
             -t "${IMAGE_NAME}:latest" .
 
+      - name: Build orchestrator image
+        if: ${{ inputs.image_tag == '' }}
+        env:
+          ORCH_IMAGE_NAME: ${{ steps.meta.outputs.orch_image_name }}
+        run: |
+          docker build \
+            -f Dockerfile.orchestrator \
+            --build-arg BASE_IMAGE="${{ steps.base.outputs.image }}" \
+            --build-arg APP_VERSION="${{ steps.meta.outputs.app_version }}" \
+            --build-arg GIT_SHA="${{ github.sha }}" \
+            -t "${ORCH_IMAGE_NAME}:${{ github.sha }}" \
+            -t "${ORCH_IMAGE_NAME}:${{ steps.meta.outputs.app_version }}" \
+            -t "${ORCH_IMAGE_NAME}:latest" .
+
       - name: Run container smoke tests
         if: ${{ inputs.image_tag == '' }}
         env:
@@ -157,10 +193,14 @@ jobs:
         if: ${{ inputs.image_tag == '' }}
         env:
           IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
+          ORCH_IMAGE_NAME: ${{ steps.meta.outputs.orch_image_name }}
         run: |
           docker push "${IMAGE_NAME}:${{ github.sha }}"
           docker push "${IMAGE_NAME}:${{ steps.meta.outputs.app_version }}"
           docker push "${IMAGE_NAME}:latest"
+          docker push "${ORCH_IMAGE_NAME}:${{ github.sha }}"
+          docker push "${ORCH_IMAGE_NAME}:${{ steps.meta.outputs.app_version }}"
+          docker push "${ORCH_IMAGE_NAME}:latest"
 
       - name: Trivy container scan
         if: ${{ inputs.image_tag == '' }}
@@ -282,6 +322,7 @@ jobs:
           tofu plan -out=tfplan \
             -var="subscription_id=${{ secrets.AZURE_SUBSCRIPTION_ID }}" \
             -var="container_image=${{ needs.build-image.outputs.image_uri }}" \
+            -var="orchestrator_image=${{ needs.build-image.outputs.orch_image_uri }}" \
             -var-file="environments/${{ env.DEPLOY_ENV }}.tfvars"
 
       - name: Tofu Apply
@@ -383,6 +424,60 @@ jobs:
             | jq '{max: .properties.functionAppConfig.scaleAndConcurrency.maximumInstanceCount, alwaysReady: (.properties.functionAppConfig.scaleAndConcurrency.alwaysReady // [])}')
           echo "Scaling config: $ACTUAL"
 
+      - name: Configure Orchestrator Function App
+        id: configure-orch-app
+        working-directory: infra/tofu
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_USE_OIDC: "true"
+        run: |
+          FUNC_RG=$(tofu output -raw resource_group_name)
+          ORCH_NAME=$(tofu output -raw function_app_orch_name)
+
+          az functionapp config container set \
+            --name "$ORCH_NAME" \
+            --resource-group "$FUNC_RG" \
+            --image "${{ needs.build-image.outputs.orch_image_uri }}"
+
+          mapfile -t APP_SETTINGS < <(
+            tofu output -json function_app_cli_app_settings \
+              | jq -r 'to_entries[] | "\(.key)=\(.value|tostring)"'
+          )
+
+          az webapp config appsettings set \
+            --name "$ORCH_NAME" \
+            --resource-group "$FUNC_RG" \
+            --settings "${APP_SETTINGS[@]}" PIPELINE_ROLE=orchestrator
+
+          ALLOWED_ORIGINS_JSON=$(tofu output -json browser_allowed_origins | jq -c '.')
+          if [ "$(echo "$ALLOWED_ORIGINS_JSON" | jq 'length')" -eq 0 ]; then
+            echo "❌ Refusing to clear Orchestrator Function App CORS: browser_allowed_origins is empty"
+            exit 1
+          fi
+
+          ORCH_ID=$(az functionapp show --name "$ORCH_NAME" --resource-group "$FUNC_RG" --query id -o tsv)
+          CORS_BODY=$(jq -cn --argjson origins "$ALLOWED_ORIGINS_JSON" '{properties:{cors:{allowedOrigins:$origins,supportCredentials:false}}}')
+          az rest --method PATCH \
+            --url "${ORCH_ID}/config/web?api-version=2024-04-01" \
+            --body "$CORS_BODY"
+
+          MAX_INSTANCES=$(tofu output -raw function_app_cli_maximum_instance_count)
+          MIN_INSTANCES=$(tofu output -raw function_app_cli_minimum_instance_count)
+          if [ "$MIN_INSTANCES" -gt 0 ]; then
+            ALWAYS_READY='[{"name":"http","instanceCount":'"${MIN_INSTANCES}"'}]'
+          else
+            ALWAYS_READY='[]'
+          fi
+          SCALE_BODY=$(jq -cn \
+            --argjson max "$MAX_INSTANCES" \
+            --argjson ready "$ALWAYS_READY" \
+            '{properties:{functionAppConfig:{scaleAndConcurrency:{maximumInstanceCount:$max,alwaysReady:$ready}}}}')
+          az rest --method PATCH \
+            --url "${ORCH_ID}?api-version=2024-04-01" \
+            --body "$SCALE_BODY"
+
       - name: Verify browser CORS contract
         id: verify-browser-cors
         working-directory: infra/tofu
@@ -393,7 +488,7 @@ jobs:
           ARM_USE_OIDC: "true"
         run: |
           RG_NAME=$(tofu output -raw resource_group_name)
-          FUNC_HOST=$(tofu output -raw function_app_default_hostname)
+          FUNC_HOST=$(tofu output -raw function_app_orch_default_hostname)
           STORAGE_NAME=$(tofu output -raw storage_account_name)
           ORIGINS_JSON=$(tofu output -json browser_allowed_origins)
 
@@ -451,7 +546,7 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           ARM_USE_OIDC: "true"
         run: |
-          HOSTNAME=$(tofu output -raw function_app_default_hostname)
+          HOSTNAME=$(tofu output -raw function_app_orch_default_hostname)
           echo "hostname=${HOSTNAME}" >> "$GITHUB_OUTPUT"
 
       - name: Export SWA hostname
@@ -488,7 +583,7 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           ARM_USE_OIDC: "true"
         run: |
-          HOSTNAME=$(tofu output -raw function_app_default_hostname)
+          HOSTNAME=$(tofu output -raw function_app_orch_default_hostname)
           BASE_URL="https://${HOSTNAME}"
           MAX_WAIT=90           # normal startup is <60s; if not up by 90s it's broken
           INTERVAL=5
@@ -552,8 +647,8 @@ jobs:
           ARM_USE_OIDC: "true"
         run: |
           RG_NAME=$(tofu output -raw resource_group_name)
-          FUNC_NAME=$(tofu output -raw function_app_name)
-          HOSTNAME=$(tofu output -raw function_app_default_hostname)
+          FUNC_NAME=$(tofu output -raw function_app_orch_name)
+          HOSTNAME=$(tofu output -raw function_app_orch_default_hostname)
           TOPIC_NAME=$(tofu output -raw event_grid_system_topic_name)
 
           python ../../scripts/reconcile_eventgrid_subscription.py \
@@ -572,8 +667,8 @@ jobs:
           ARM_USE_OIDC: "true"
         run: |
           RG_NAME=$(tofu output -raw resource_group_name)
-          FUNC_NAME=$(tofu output -raw function_app_name)
-          HOSTNAME=$(tofu output -raw function_app_default_hostname)
+          FUNC_NAME=$(tofu output -raw function_app_orch_name)
+          HOSTNAME=$(tofu output -raw function_app_orch_default_hostname)
           TOPIC_NAME=$(tofu output -raw event_grid_system_topic_name)
           EXPECTED_CAP=$(awk -F '=' '/^log_daily_cap_gb[[:space:]]*=/{gsub(/[[:space:]]/, "", $2); print $2; exit}' environments/${{ env.DEPLOY_ENV }}.tfvars)
           : "${EXPECTED_CAP:=0.1}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -464,9 +464,9 @@ jobs:
             --body "$CORS_BODY"
 
           MAX_INSTANCES=$(tofu output -raw function_app_cli_maximum_instance_count)
-          MIN_INSTANCES=$(tofu output -raw function_app_cli_minimum_instance_count)
-          if [ "$MIN_INSTANCES" -gt 0 ]; then
-            ALWAYS_READY='[{"name":"http","instanceCount":'"${MIN_INSTANCES}"'}]'
+          ORCH_MIN_INSTANCES=$(tofu output -raw function_app_orch_minimum_instance_count)
+          if [ "$ORCH_MIN_INSTANCES" -gt 0 ]; then
+            ALWAYS_READY='[{"name":"http","instanceCount":'"${ORCH_MIN_INSTANCES}"'}]'
           else
             ALWAYS_READY='[]'
           fi

--- a/Dockerfile.orchestrator
+++ b/Dockerfile.orchestrator
@@ -32,11 +32,13 @@ ENV APP_VERSION=${APP_VERSION} \
 COPY --from=ghcr.io/astral-sh/uv:0.9.7 /uv /usr/local/bin/uv
 
 # Install only the lightweight subset: exclude GDAL-dependent packages.
-# fiona, rasterio, numpy, shapely, pyproj, pystac-client,
-# planetary-computer, and httpx are compute-only dependencies.
+# fiona, rasterio, numpy, shapely, pyproj, pystac-client, and
+# planetary-computer are compute-only dependencies. httpx is kept
+# because blueprints/analysis.py → treesight.ai.client imports it
+# at module load time; excluding it causes a startup ModuleNotFoundError.
 COPY pyproject.toml uv.lock ./
 RUN uv export --no-dev --no-hashes > /tmp/requirements.txt && \
-    grep -vE '^(fiona|rasterio|numpy|shapely|pyproj|pystac-client|planetary-computer|httpx)==' \
+    grep -vE '^(fiona|rasterio|numpy|shapely|pyproj|pystac-client|planetary-computer)==' \
         /tmp/requirements.txt > /tmp/orch-requirements.txt && \
     uv pip install --system -r /tmp/orch-requirements.txt && \
     rm -f /tmp/requirements.txt /tmp/orch-requirements.txt /usr/local/bin/uv

--- a/Dockerfile.orchestrator
+++ b/Dockerfile.orchestrator
@@ -1,0 +1,50 @@
+# ─────────────────────────────────────────────────────────────
+# Canopex Orchestrator Image  (#466)
+#
+# Slim variant of the application image: no GDAL, no rasterio,
+# no numpy, no Rust extension.  Handles HTTP endpoints, Durable
+# orchestrators, blob triggers, and submission — but NOT activity
+# functions that perform imagery acquisition / enrichment.
+#
+# The compute image (Dockerfile) continues to register activity
+# functions.  Both images share the same Durable task hub and
+# Azure Storage connection.
+#
+# Base image: ghcr.io/<owner>/treesight-base:latest
+# Built by CI alongside the compute image on every push to main.
+# ─────────────────────────────────────────────────────────────
+ARG BASE_IMAGE=treesight-base:latest
+FROM ${BASE_IMAGE}
+
+ARG APP_VERSION=0.0.0-dev
+ARG GIT_SHA=unknown
+
+LABEL org.opencontainers.image.source="https://github.com/Hardcoreprawn/azure-workflow-for-kml-satellite" \
+      org.opencontainers.image.description="Canopex orchestrator image — HTTP + Durable orchestrators, no GDAL" \
+      org.opencontainers.image.version="${APP_VERSION}" \
+      org.opencontainers.image.revision="${GIT_SHA}"
+
+ENV APP_VERSION=${APP_VERSION} \
+    GIT_SHA=${GIT_SHA} \
+    PIPELINE_ROLE=orchestrator
+
+# Install uv for fast, deterministic dependency resolution
+COPY --from=ghcr.io/astral-sh/uv:0.9.7 /uv /usr/local/bin/uv
+
+# Install only the lightweight subset: exclude GDAL-dependent packages.
+# fiona, rasterio, numpy, shapely, pyproj, pystac-client,
+# planetary-computer, and httpx are compute-only dependencies.
+COPY pyproject.toml uv.lock ./
+RUN uv export --no-dev --no-hashes > /tmp/requirements.txt && \
+    grep -vE '^(fiona|rasterio|numpy|shapely|pyproj|pystac-client|planetary-computer|httpx)==' \
+        /tmp/requirements.txt > /tmp/orch-requirements.txt && \
+    uv pip install --system -r /tmp/orch-requirements.txt && \
+    rm -f /tmp/requirements.txt /tmp/orch-requirements.txt /usr/local/bin/uv
+
+# Copy application code only (no scripts/, typings/, tests/, docs/)
+# function_app_orch.py is the orchestrator entry point, installed as
+# function_app.py so the Functions runtime finds it automatically.
+COPY host.json function_app_orch.py ./
+RUN mv function_app_orch.py function_app.py
+COPY treesight/ treesight/
+COPY blueprints/ blueprints/

--- a/blueprints/monitoring.py
+++ b/blueprints/monitoring.py
@@ -158,7 +158,20 @@ def _process_monitor(monitor: Any) -> None:
         change_result.get("season_changes") if isinstance(change_result, dict) else None
     )
     if isinstance(season_changes, list) and season_changes:
-        change_result = season_changes[-1]
+        dated_changes = [
+            change
+            for change in season_changes
+            if isinstance(change, dict)
+            and isinstance(change.get("year_to"), int)
+            and isinstance(change.get("year_from"), int)
+        ]
+        if dated_changes:
+            change_result = max(
+                dated_changes,
+                key=lambda change: (change["year_to"], change["year_from"]),
+            )
+        else:
+            change_result = season_changes[-1]
 
     # Evaluate alert thresholds
     alert = evaluate_alert(monitor, change_result)

--- a/blueprints/monitoring.py
+++ b/blueprints/monitoring.py
@@ -150,8 +150,15 @@ def _process_monitor(monitor: Any) -> None:
         date_end=date_end,
     )
 
-    # Extract change detection results
+    # Extract the latest change metrics from the enrichment payload.
+    # The live enrichment contract returns {"season_changes": [...], "summary": {...}},
+    # while older tests/mocks may still pass a flat metrics dict directly.
     change_result = enrichment_result.get("change_detection")
+    season_changes = (
+        change_result.get("season_changes") if isinstance(change_result, dict) else None
+    )
+    if isinstance(season_changes, list) and season_changes:
+        change_result = season_changes[-1]
 
     # Evaluate alert thresholds
     alert = evaluate_alert(monitor, change_result)
@@ -162,7 +169,10 @@ def _process_monitor(monitor: Any) -> None:
     ndvi_stats: list[dict] = enrichment_result.get("ndvi_stats") or []
     valid_stats = [s for s in ndvi_stats if s and s.get("mean") is not None]
     if valid_stats:
-        latest = max(valid_stats, key=lambda s: s.get("datetime", ""))
+        # ndvi_stats follows the chronological frame order, so the last valid
+        # stat is the latest baseline candidate without relying on mixed-type
+        # datetime comparisons.
+        latest = valid_stats[-1]
         monitor.baseline_ndvi_mean = latest["mean"]
 
     # Advance schedule regardless of alert

--- a/blueprints/monitoring.py
+++ b/blueprints/monitoring.py
@@ -123,6 +123,13 @@ def _process_monitor(monitor: Any) -> None:
 
     run_ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
 
+    # Delta fetch: only request scenes since the last successful run so we do
+    # not re-download the full historical archive on every 6-hourly check.
+    # The first run (last_run_at is None) has no date_start, so build_frame_plan
+    # returns its normal cadence window.
+    date_end = datetime.now(UTC).date().isoformat()
+    date_start = monitor.last_run_at.date().isoformat() if monitor.last_run_at else None
+
     enrichment_result = run_enrichment(
         coords=coords,
         project_name=f"monitor-{monitor.id}",
@@ -130,6 +137,8 @@ def _process_monitor(monitor: Any) -> None:
         output_container="kml-output",
         storage=storage,
         cadence="monthly",
+        date_start=date_start,
+        date_end=date_end,
     )
 
     # Extract change detection results
@@ -139,6 +148,13 @@ def _process_monitor(monitor: Any) -> None:
     alert = evaluate_alert(monitor, change_result)
     if alert:
         send_monitoring_alert(monitor, alert)
+
+    # Persist the latest NDVI mean so the next delta run has an updated baseline.
+    ndvi_stats: list[dict] = enrichment_result.get("ndvi_stats") or []
+    valid_stats = [s for s in ndvi_stats if s and s.get("mean") is not None]
+    if valid_stats:
+        latest = max(valid_stats, key=lambda s: s.get("datetime", ""))
+        monitor.baseline_ndvi_mean = latest["mean"]
 
     # Advance schedule regardless of alert
     advance_schedule(monitor, run_id=f"monitoring-{monitor.id}")

--- a/blueprints/monitoring.py
+++ b/blueprints/monitoring.py
@@ -29,6 +29,7 @@ from treesight.security.billing import get_effective_subscription, plan_capabili
 logger = logging.getLogger(__name__)
 
 bp = func.Blueprint()
+scheduler_bp = func.Blueprint()
 
 # --- Tier gating -------------------------------------------------------
 
@@ -65,7 +66,7 @@ def _check_monitor_limit(user_id: str) -> str | None:
 # --- Timer Trigger: scheduled monitoring check --------------------------
 
 
-@bp.timer_trigger(schedule="0 0 */6 * * *", arg_name="timer", run_on_startup=False)
+@scheduler_bp.timer_trigger(schedule="0 0 */6 * * *", arg_name="timer", run_on_startup=False)
 def monitoring_scheduler(timer: func.TimerRequest) -> None:
     """Run every 6 hours: find due monitors and kick off re-analysis."""
     from treesight.storage.cosmos import cosmos_available

--- a/blueprints/monitoring.py
+++ b/blueprints/monitoring.py
@@ -121,14 +121,22 @@ def _process_monitor(monitor: Any) -> None:
     coords = [centroid]
     storage = BlobStorageClient()
 
-    run_ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    now = datetime.now(UTC)
+    run_ts = now.strftime("%Y%m%dT%H%M%SZ")
 
-    # Delta fetch: only request scenes since the last successful run so we do
-    # not re-download the full historical archive on every 6-hourly check.
-    # The first run (last_run_at is None) has no date_start, so build_frame_plan
-    # returns its normal cadence window.
-    date_end = datetime.now(UTC).date().isoformat()
-    date_start = monitor.last_run_at.date().isoformat() if monitor.last_run_at else None
+    # Delta fetch: only request scenes since the last successful monitoring
+    # enrichment run so we do not re-download the full historical archive on
+    # every 6-hourly check. Skip runs (for example, missing centroid) advance
+    # schedule bookkeeping but must not narrow the first real enrichment
+    # window.
+    date_end = now.date().isoformat()
+    last_run_id = getattr(monitor, "last_run_id", None)
+    has_successful_monitoring_run = bool(
+        monitor.last_run_at
+        and isinstance(last_run_id, str)
+        and last_run_id.startswith("monitoring-")
+    )
+    date_start = monitor.last_run_at.date().isoformat() if has_successful_monitoring_run else None
 
     enrichment_result = run_enrichment(
         coords=coords,

--- a/blueprints/pipeline/__init__.py
+++ b/blueprints/pipeline/__init__.py
@@ -7,20 +7,30 @@ causes the runtime to fail with ``FunctionLoadError``.
 
 The Blueprint instance is created here and imported by each submodule
 so all routes, triggers, and activities register on a single blueprint.
+
+``PIPELINE_ROLE`` environment variable controls which submodules are loaded:
+  - ``full`` (default): all submodules — compute image registers activities
+  - ``orchestrator``: skips ``activities`` — orchestrator image, no GDAL/rasterio
 """
+
+import os
 
 import azure.durable_functions as df
 
 bp = df.Blueprint()
 
+_PIPELINE_ROLE = os.environ.get("PIPELINE_ROLE", "full")
+
 # Import submodules to trigger decorator registration on ``bp``.
 # Order does not matter — each module imports ``bp`` from this package.
 from . import (  # noqa: E402  — must follow bp = df.Blueprint()
-    activities,  # noqa: F401  — registers activity triggers
     aoi_orchestrator,  # noqa: F401  — registers per-AOI sub-orchestrator (#585)
     blob_trigger,  # noqa: F401  — registers blob trigger
     diagnostics,  # noqa: F401  — registers diagnostic endpoints
-    enrichment,  # noqa: F401  — registers enrichment activities
+    enrichment,  # noqa: F401  — registers enrichment HTTP endpoints
     orchestrator,  # noqa: F401  — registers orchestrator
     submission,  # noqa: F401  — registers submission endpoint
 )
+
+if _PIPELINE_ROLE == "full":
+    from . import activities  # noqa: F401  — registers activity triggers (compute only)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -210,7 +210,7 @@ product surface.
 
 | Order  | Issue  | Title | Status |
 |--------|--------|-------|--------|
-| 3B.5.0 | #688 | Monitoring delta fetch + fan-out queue to cut PC wait time | ✅ In PR |
+| 3B.5.0 | #688 | Monitoring delta fetch + fan-out queue to cut PC wait time | ✅ #691 |
 | 3B.5.1 | #466 | Split Container Apps into orchestrator + compute images | Open |
 
 **Why now:** These are not growth features, but they directly reduce runtime

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,8 +41,7 @@ Stages 2D and 2E can proceed in parallel. Stage 3B.5 is next priority after 3B.
 
 | PR | Summary |
 |----|---------|  
-| #692 | feat: Stage 3B.5 #466 — Split Container Apps into orchestrator + compute images; PIPELINE_ROLE env var, Dockerfile.orchestrator, function_app_orch.py, dual-image CI build |
-| #691 | fix: Stage 3B.5 #688 — Monitoring delta fetch: pass date window to enrichment + store NDVI baseline |
+| #691 | feat: Stage 3B.5 #466 + #688 — Orchestrator/compute image split (PIPELINE_ROLE, Dockerfile.orchestrator, dual-image CI) + monitoring delta fetch + NDVI baseline persistence |
 | #690 | feat: Stage 3B complete — imagery quality gate, provenance contract, dynamic layer picker, defensible PDF (closes #645, #649, #646, #647) |
 | #667 | feat: Stage 3B.0 — Pipeline cost accumulator + resources consumed evidence card (closes #666) |
 | #665 | feat: Stage 3A — EUDR assessment management: entitlement gate, CSV upload, cost estimator, flagged-parcel review (closes #660, #661, #662, #664) |
@@ -213,7 +212,7 @@ product surface.
 | Order  | Issue  | Title | Status |
 |--------|--------|-------|--------|
 | 3B.5.0 | #688 | Monitoring delta fetch + fan-out queue to cut PC wait time | ✅ #691 |
-| 3B.5.1 | #466 | Split Container Apps into orchestrator + compute images | ✅ #692 |
+| 3B.5.1 | #466 | Split Container Apps into orchestrator + compute images | ✅ #691 |
 
 **Why now:** These are not growth features, but they directly reduce runtime
 cost and cold-start overhead. `#688` bounds slow Planetary Computer waits to

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,6 +41,8 @@ Stages 2D and 2E can proceed in parallel. Stage 3B.5 is next priority after 3B.
 
 | PR | Summary |
 |----|---------|  
+| #692 | feat: Stage 3B.5 #466 — Split Container Apps into orchestrator + compute images; PIPELINE_ROLE env var, Dockerfile.orchestrator, function_app_orch.py, dual-image CI build |
+| #691 | fix: Stage 3B.5 #688 — Monitoring delta fetch: pass date window to enrichment + store NDVI baseline |
 | #690 | feat: Stage 3B complete — imagery quality gate, provenance contract, dynamic layer picker, defensible PDF (closes #645, #649, #646, #647) |
 | #667 | feat: Stage 3B.0 — Pipeline cost accumulator + resources consumed evidence card (closes #666) |
 | #665 | feat: Stage 3A — EUDR assessment management: entitlement gate, CSV upload, cost estimator, flagged-parcel review (closes #660, #661, #662, #664) |
@@ -211,7 +213,7 @@ product surface.
 | Order  | Issue  | Title | Status |
 |--------|--------|-------|--------|
 | 3B.5.0 | #688 | Monitoring delta fetch + fan-out queue to cut PC wait time | ✅ #691 |
-| 3B.5.1 | #466 | Split Container Apps into orchestrator + compute images | Open |
+| 3B.5.1 | #466 | Split Container Apps into orchestrator + compute images | ✅ #692 |
 
 **Why now:** These are not growth features, but they directly reduce runtime
 cost and cold-start overhead. `#688` bounds slow Planetary Computer waits to

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -210,7 +210,7 @@ product surface.
 
 | Order  | Issue  | Title | Status |
 |--------|--------|-------|--------|
-| 3B.5.0 | #688 | Monitoring delta fetch + fan-out queue to cut PC wait time | Open |
+| 3B.5.0 | #688 | Monitoring delta fetch + fan-out queue to cut PC wait time | ✅ In PR |
 | 3B.5.1 | #466 | Split Container Apps into orchestrator + compute images | Open |
 
 **Why now:** These are not growth features, but they directly reduce runtime

--- a/function_app.py
+++ b/function_app.py
@@ -27,6 +27,7 @@ from blueprints.eudr import bp as eudr_bp
 from blueprints.export import bp as export_bp
 from blueprints.health import bp as health_bp
 from blueprints.monitoring import bp as monitoring_bp
+from blueprints.monitoring import scheduler_bp as monitoring_scheduler_bp
 from blueprints.ops import bp as ops_bp
 from blueprints.org import bp as org_bp
 from blueprints.pipeline import bp as pipeline_bp
@@ -83,6 +84,7 @@ app.register_functions(upload_bp)
 
 # Register monitoring blueprint (Timer Trigger + HTTP)
 app.register_functions(monitoring_bp)
+app.register_functions(monitoring_scheduler_bp)
 
 # Register ops dashboard (operator visibility)
 app.register_functions(ops_bp)

--- a/function_app_orch.py
+++ b/function_app_orch.py
@@ -89,7 +89,9 @@ app.register_functions(org_bp)
 # Register upload/history BFF endpoints
 app.register_functions(upload_bp)
 
-# Register monitoring blueprint (Timer Trigger + HTTP)
+# Register monitoring HTTP endpoints only.
+# The timer-triggered scheduler stays in the compute image because it
+# calls compute-only enrichment code.
 app.register_functions(monitoring_bp)
 
 # Register ops dashboard (operator visibility)

--- a/function_app_orch.py
+++ b/function_app_orch.py
@@ -1,0 +1,100 @@
+"""Azure Functions entry point for the orchestrator image (#466).
+
+Registers all HTTP blueprints and Durable orchestration blueprints.
+Does NOT register activity functions — those run in the compute image.
+
+Both images share the same Durable task hub and Azure Storage connection.
+PIPELINE_ROLE=orchestrator is set in Dockerfile.orchestrator so
+blueprints/pipeline/__init__.py skips importing the activities module.
+"""
+
+import logging
+
+import azure.functions as func
+
+from treesight.config import (
+    APPINSIGHTS_CONNECTION_STRING,
+    STORAGE_ACCOUNT_NAME,
+    STORAGE_CONNECTION_STRING,
+    validate_config,
+)
+from treesight.log import configure_logging
+
+if APPINSIGHTS_CONNECTION_STRING:
+    configure_logging()
+
+logger = logging.getLogger(__name__)
+
+from blueprints.analysis import bp as analysis_bp
+from blueprints.auth import bp as auth_bp
+from blueprints.billing import bp as billing_bp
+from blueprints.catalogue import bp as catalogue_bp
+from blueprints.contact import bp as contact_bp
+from blueprints.demo import bp as demo_bp
+from blueprints.eudr import bp as eudr_bp
+from blueprints.export import bp as export_bp
+from blueprints.health import bp as health_bp
+from blueprints.monitoring import bp as monitoring_bp
+from blueprints.ops import bp as ops_bp
+from blueprints.org import bp as org_bp
+from blueprints.pipeline import bp as pipeline_bp  # PIPELINE_ROLE=orchestrator: no activities
+from blueprints.upload import bp as upload_bp
+
+# Fail-fast config validation (§8.6)
+validate_config()
+
+# Wire up distributed replay store for valet tokens (M1.8)
+if STORAGE_CONNECTION_STRING:
+    try:
+        from treesight.security import TableReplayStore, set_replay_store
+
+        set_replay_store(TableReplayStore(STORAGE_CONNECTION_STRING))
+    except Exception:
+        logger.warning(
+            "Could not initialise Table replay store; falling back to in-memory",
+            exc_info=True,
+        )
+elif STORAGE_ACCOUNT_NAME:
+    try:
+        from azure.data.tables import TableServiceClient
+        from azure.identity import DefaultAzureCredential
+
+        from treesight.security import TableReplayStore, set_replay_store
+
+        table_url = f"https://{STORAGE_ACCOUNT_NAME}.table.core.windows.net"
+        table_service_client = TableServiceClient(table_url, credential=DefaultAzureCredential())
+        set_replay_store(TableReplayStore(table_service_client=table_service_client))
+    except Exception:
+        logger.warning(
+            "Could not initialise Table replay store via MI; falling back to in-memory",
+            exc_info=True,
+        )
+
+app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
+# Register HTTP blueprints
+app.register_functions(health_bp)
+app.register_functions(auth_bp)
+app.register_functions(billing_bp)
+app.register_functions(contact_bp)
+app.register_functions(demo_bp)
+app.register_functions(eudr_bp)
+app.register_functions(analysis_bp)
+app.register_functions(catalogue_bp)
+app.register_functions(export_bp)
+
+# Register org management endpoints
+app.register_functions(org_bp)
+
+# Register upload/history BFF endpoints
+app.register_functions(upload_bp)
+
+# Register monitoring blueprint (Timer Trigger + HTTP)
+app.register_functions(monitoring_bp)
+
+# Register ops dashboard (operator visibility)
+app.register_functions(ops_bp)
+
+# Register durable pipeline blueprint (orchestrators, blob trigger, submission)
+# Activity functions are intentionally excluded — they run in the compute image.
+app.register_functions(pipeline_bp)

--- a/infra/tofu/environments/dev.tfvars
+++ b/infra/tofu/environments/dev.tfvars
@@ -23,4 +23,5 @@ enable_azure_ai         = false
 enable_stripe           = true
 enable_cosmos_db              = true
 cosmos_public_network_access  = true   # dev only — no VNet/private endpoint yet
-function_min_instances        = 1
+function_min_instances        = 0
+orch_min_instances            = 1

--- a/infra/tofu/locals.tf
+++ b/infra/tofu/locals.tf
@@ -8,6 +8,7 @@ locals {
     key_vault                  = "kv-${local.name_suffix}"
     container_apps_environment = "cae-${local.name_suffix}"
     function_app               = "func-${local.name_suffix}"
+    function_app_orch          = "func-${local.name_suffix}-orch"
     event_grid_system_topic    = "evgt-${local.name_suffix}"
     event_grid_subscription    = "evgs-kml-upload"
     static_web_app             = "stapp-${local.name_suffix}-site"

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -797,6 +797,148 @@ resource "azapi_resource" "function_app" {
   response_export_values = ["id", "name", "properties.defaultHostName"]
 }
 
+# Orchestrator function app (#466): slim image — HTTP + Durable orchestrators, no GDAL/rasterio.
+# Shares the same Container Apps environment, storage account, and Durable task hub
+# ("TreeSightHub", set in host.json) as the compute function app so orchestrators
+# can dispatch activity calls to the compute image's worker queue.
+resource "azapi_resource" "function_app_orch" {
+  type      = "Microsoft.Web/sites@2024-04-01"
+  parent_id = azurerm_resource_group.main.id
+  name      = local.names.function_app_orch
+  location  = azurerm_resource_group.main.location
+  tags      = local.tags
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [identity, body]
+  }
+
+  body = {
+    kind = "functionapp,linux,container,azurecontainerapps"
+    properties = {
+      managedEnvironmentId = azurerm_container_app_environment.main.id
+      httpsOnly            = true
+      functionAppConfig = {
+        scaleAndConcurrency = {
+          maximumInstanceCount = var.function_max_instances
+        }
+      }
+      siteConfig = {
+        linuxFxVersion = "DOCKER|${var.orchestrator_image}"
+        cors = {
+          allowedOrigins     = local.browser_allowed_origins
+          supportCredentials = false
+        }
+        appSettings = concat(
+          [
+            {
+              name  = "APPLICATIONINSIGHTS_CONNECTION_STRING"
+              value = azurerm_application_insights.main.connection_string
+            },
+            {
+              name  = "FUNCTIONS_WORKER_RUNTIME"
+              value = "python"
+            },
+            {
+              name  = "FUNCTIONS_EXTENSION_VERSION"
+              value = "~4"
+            },
+            {
+              name  = "AzureFunctionsJobHost__extensions__durableTask__storageProvider__type"
+              value = "AzureStorage"
+            },
+            {
+              name  = "PIPELINE_ROLE"
+              value = "orchestrator"
+            },
+            {
+              name  = "KEY_VAULT_URI"
+              value = azurerm_key_vault.main.vault_uri
+            },
+            {
+              name  = "KEYVAULT_URL"
+              value = azurerm_key_vault.main.vault_uri
+            },
+            {
+              name  = "DEFAULT_INPUT_CONTAINER"
+              value = "kml-input"
+            },
+            {
+              name  = "DEFAULT_OUTPUT_CONTAINER"
+              value = "kml-output"
+            },
+            {
+              name  = "IMAGERY_PROVIDER"
+              value = "planetary_computer"
+            }
+          ],
+          [
+            for name, value in local.function_app_cli_app_settings : {
+              name  = name
+              value = value
+            }
+          ],
+          var.enable_azure_ai ? [
+            {
+              name  = "AZURE_AI_ENDPOINT"
+              value = azurerm_cognitive_account.openai[0].endpoint
+            },
+            {
+              name  = "AZURE_AI_API_KEY"
+              value = azurerm_cognitive_account.openai[0].primary_access_key
+            },
+            {
+              name  = "AZURE_AI_DEPLOYMENT"
+              value = "gpt-4o-mini"
+            }
+          ] : [],
+          var.enable_stripe ? [
+            {
+              name  = "STRIPE_API_KEY"
+              value = "@Microsoft.KeyVault(SecretUri=${local.stripe_secret_uris.api_key})"
+            },
+            {
+              name  = "STRIPE_WEBHOOK_SECRET"
+              value = "@Microsoft.KeyVault(SecretUri=${local.stripe_secret_uris.webhook_secret})"
+            },
+            {
+              name  = "STRIPE_PRICE_ID_PRO_GBP"
+              value = "@Microsoft.KeyVault(SecretUri=${local.stripe_secret_uris.price_id_pro_gbp})"
+            },
+            {
+              name  = "STRIPE_PRICE_ID_PRO_USD"
+              value = "@Microsoft.KeyVault(SecretUri=${local.stripe_secret_uris.price_id_pro_usd})"
+            },
+            {
+              name  = "STRIPE_PRICE_ID_PRO_EUR"
+              value = "@Microsoft.KeyVault(SecretUri=${local.stripe_secret_uris.price_id_pro_eur})"
+            }
+          ] : [],
+          var.enable_email ? [
+            {
+              name  = "COMMUNICATION_SERVICES_CONNECTION_STRING"
+              value = azurerm_communication_service.main[0].primary_connection_string
+            },
+            {
+              name  = "EMAIL_SENDER_ADDRESS"
+              value = "DoNotReply@${azurerm_email_communication_service_domain.azure_managed[0].mail_from_sender_domain}"
+            },
+            {
+              name  = "NOTIFICATION_EMAIL"
+              value = var.notification_email
+            }
+          ] : []
+        )
+      }
+    }
+  }
+
+  response_export_values = ["id", "name", "properties.defaultHostName"]
+}
+
 resource "azurerm_static_web_app" "main" {
   name                = local.names.static_web_app
   location            = var.static_web_app_location
@@ -863,6 +1005,37 @@ resource "azurerm_role_assignment" "key_vault_secrets_user" {
   principal_id         = azapi_resource.function_app.identity[0].principal_id
 }
 
+# Orchestrator function app RBAC — same access as compute app (#466)
+resource "azurerm_role_assignment" "orch_storage_blob_data_owner" {
+  scope                = azurerm_storage_account.main.id
+  role_definition_name = "Storage Blob Data Owner"
+  principal_id         = azapi_resource.function_app_orch.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "orch_storage_queue_data_contributor" {
+  scope                = azurerm_storage_account.main.id
+  role_definition_name = "Storage Queue Data Contributor"
+  principal_id         = azapi_resource.function_app_orch.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "orch_storage_table_data_contributor" {
+  scope                = azurerm_storage_account.main.id
+  role_definition_name = "Storage Table Data Contributor"
+  principal_id         = azapi_resource.function_app_orch.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "orch_storage_account_contributor" {
+  scope                = azurerm_storage_account.main.id
+  role_definition_name = "Storage Account Contributor"
+  principal_id         = azapi_resource.function_app_orch.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "orch_key_vault_secrets_user" {
+  scope                = azurerm_key_vault.main.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azapi_resource.function_app_orch.identity[0].principal_id
+}
+
 # Allow the deployer (tofu apply / setup scripts) to manage secrets
 resource "azurerm_role_assignment" "key_vault_secrets_officer" {
   count                = var.enable_stripe ? 1 : 0
@@ -878,6 +1051,15 @@ resource "azurerm_cosmosdb_sql_role_assignment" "function_app" {
   account_name        = azurerm_cosmosdb_account.main[0].name
   role_definition_id  = "${azurerm_cosmosdb_account.main[0].id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
   principal_id        = azapi_resource.function_app.identity[0].principal_id
+  scope               = azurerm_cosmosdb_account.main[0].id
+}
+
+resource "azurerm_cosmosdb_sql_role_assignment" "function_app_orch" {
+  count               = var.enable_cosmos_db ? 1 : 0
+  resource_group_name = azurerm_resource_group.main.name
+  account_name        = azurerm_cosmosdb_account.main[0].name
+  role_definition_id  = "${azurerm_cosmosdb_account.main[0].id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
+  principal_id        = azapi_resource.function_app_orch.identity[0].principal_id
   scope               = azurerm_cosmosdb_account.main[0].id
 }
 

--- a/infra/tofu/outputs.tf
+++ b/infra/tofu/outputs.tf
@@ -41,7 +41,12 @@ output "function_app_cli_maximum_instance_count" {
 
 output "function_app_cli_minimum_instance_count" {
   value       = var.function_min_instances
-  description = "CLI-managed Function App minimum always-ready instance count."
+  description = "CLI-managed compute Function App minimum always-ready instance count."
+}
+
+output "function_app_orch_minimum_instance_count" {
+  value       = var.orch_min_instances
+  description = "CLI-managed orchestrator Function App minimum always-ready instance count."
 }
 
 output "static_web_app_name" {

--- a/infra/tofu/outputs.tf
+++ b/infra/tofu/outputs.tf
@@ -18,6 +18,16 @@ output "function_app_default_hostname" {
   description = "Function app default hostname."
 }
 
+output "function_app_orch_name" {
+  value       = azapi_resource.function_app_orch.name
+  description = "Orchestrator function app name (#466)."
+}
+
+output "function_app_orch_default_hostname" {
+  value       = azapi_resource.function_app_orch.output.properties.defaultHostName
+  description = "Orchestrator function app default hostname (#466)."
+}
+
 output "function_app_cli_app_settings" {
   value       = local.function_app_cli_app_settings
   description = "CLI-managed Function App app settings sourced from Terraform."

--- a/infra/tofu/variables.tf
+++ b/infra/tofu/variables.tf
@@ -96,9 +96,15 @@ variable "function_max_instances" {
 }
 
 variable "function_min_instances" {
-  description = "Minimum always-ready instances. Set to 1 to avoid cold-start 504s."
+  description = "Minimum always-ready instances for the compute Function App. Set to 0 to allow scale-to-zero; heavy GDAL image cold-starts are acceptable."
   type        = number
   default     = 0
+}
+
+variable "orch_min_instances" {
+  description = "Minimum always-ready instances for the orchestrator Function App. Set to 1 to keep it warm so Durable orchestration and interactive HTTP requests never hit a cold-start 504."
+  type        = number
+  default     = 1
 }
 
 variable "ops_dashboard_key" {

--- a/infra/tofu/variables.tf
+++ b/infra/tofu/variables.tf
@@ -66,6 +66,12 @@ variable "container_image" {
   default     = "mcr.microsoft.com/azure-functions/python:4-python3.12"
 }
 
+variable "orchestrator_image" {
+  description = "Orchestrator function app container image URI (slim, no GDAL). #466"
+  type        = string
+  default     = "mcr.microsoft.com/azure-functions/python:4-python3.12"
+}
+
 variable "default_tags" {
   description = "Additional tags merged with required baseline tags."
   type        = map(string)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "function_app.py" = ["E402"]  # logging must be configured before blueprint imports
+"function_app_orch.py" = ["E402"]  # logging must be configured before blueprint imports
 "tests/**" = ["S", "T20", "SIM117"]
 "scripts/**" = ["T20", "S", "C901", "E501"]
 "blueprints/analysis.py" = ["C901"]

--- a/tests/test_demo_tier.py
+++ b/tests/test_demo_tier.py
@@ -173,6 +173,13 @@ class TestBuildFramePlanCadence:
         naip = [f for f in plan if f["is_naip"]]
         assert len(naip) > 0
 
+    def test_seasonal_us_prefers_naip_for_all_summer_frames(self):
+        """US summer frames should attempt NAIP by default (runtime can fallback)."""
+        plan = build_frame_plan(US_COORDS, cadence="seasonal")
+        summer = [f for f in plan if f["season"] == "summer" and f["year"] >= 2018]
+        assert summer, "expected seasonal summer frames"
+        assert all(f["collection"] == "naip" for f in summer)
+
 
 class TestBuildFramePlanMaxHistory:
     """Test build_frame_plan with max_history_years capping."""

--- a/tests/test_enrichment_runner.py
+++ b/tests/test_enrichment_runner.py
@@ -146,6 +146,28 @@ class TestMosaicNdviParallel:
 
     @patch("treesight.pipeline.enrichment.runner.compute_ndvi")
     @patch("treesight.pipeline.enrichment.runner.register_mosaic")
+    def test_naip_rgb_falls_back_to_sentinel_when_naip_missing(self, mock_mosaic, mock_ndvi):
+        """If NAIP has no RGB mosaic for a frame, Sentinel-2 should be used for display."""
+        frames = [_make_frame(collection="naip", is_naip=True)]
+
+        def _mosaic_side_effect(coll, start, end, bbox, extra, cl):
+            if coll == "naip":
+                return None
+            return "sid-sentinel-2-l2a"
+
+        mock_mosaic.side_effect = _mosaic_side_effect
+        mock_ndvi.return_value = {"mean": 0.5}
+        storage = MagicMock()
+        results: dict = {}
+
+        _run_mosaic_ndvi_phase(BBOX, COORDS, frames, "proj", "ts", "out", storage, results)
+
+        assert results["search_ids"][0] == "sid-sentinel-2-l2a"
+        assert results["display_collections"][0] == "sentinel-2-l2a"
+        assert frames[0]["display_collection"] == "sentinel-2-l2a"
+
+    @patch("treesight.pipeline.enrichment.runner.compute_ndvi")
+    @patch("treesight.pipeline.enrichment.runner.register_mosaic")
     def test_skips_visual_registration_when_rgb_is_unsuitable(self, mock_mosaic, mock_ndvi):
         """Tiny coarse frames should skip RGB mosaic registration but keep NDVI search."""
         frames = [

--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -998,6 +998,17 @@ class TestEvidenceMapQualityGate:
             "from frame metadata"
         )
 
+    def test_evidence_map_chooses_initial_frame_from_best_display_candidate(self):
+        content = self.APP_SHELL.read_text()
+        assert "pickInitialEvidenceFrameIndex" in content, (
+            "app-shell.js must define a helper that picks the initial evidence frame "
+            "from the best available display candidate, not always frame 0"
+        )
+        assert "showEvidenceFrame(evidenceFrameIndex)" in content, (
+            "buildEvidenceFrames must open the chosen initial evidence frame rather "
+            "than hard-coding showEvidenceFrame(0)"
+        )
+
     def test_layer_button_labels_update_per_frame(self):
         """#646 — layer picker shows per-frame collection + resolution as button labels."""
         content = self.APP_SHELL.read_text()

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -630,6 +630,104 @@ class TestMonitoringScheduler:
         ):
             _process_monitor(m)
 
+    def test_process_monitor_passes_delta_window_on_repeat_run(self, _mock_cosmos):
+        """Repeat runs pass date_start=last_run_at so only new scenes are fetched."""
+        from treesight.monitoring import create_monitor
+
+        last_run = datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC)
+        m = create_monitor(
+            user_id="user-1",
+            aoi_name="Delta Test",
+            aoi_geometry=_SAMPLE_GEOMETRY,
+        )
+        m.last_run_at = last_run
+
+        captured_kwargs: dict = {}
+
+        def _capture_run_enrichment(**kwargs):
+            captured_kwargs.update(kwargs)
+            return {}
+
+        from blueprints.monitoring import _process_monitor
+
+        with (
+            patch(
+                "treesight.pipeline.enrichment.run_enrichment",
+                side_effect=_capture_run_enrichment,
+            ),
+            patch("treesight.storage.client.BlobStorageClient"),
+        ):
+            _process_monitor(m)
+
+        assert captured_kwargs.get("date_start") == "2026-03-01"
+        assert captured_kwargs.get("date_end") is not None
+
+    def test_process_monitor_first_run_has_no_date_start(self, _mock_cosmos):
+        """First run (last_run_at=None) passes date_start=None — full initial window."""
+        from treesight.monitoring import create_monitor
+
+        m = create_monitor(
+            user_id="user-1",
+            aoi_name="First Run Test",
+            aoi_geometry=_SAMPLE_GEOMETRY,
+        )
+        assert m.last_run_at is None
+
+        captured_kwargs: dict = {}
+
+        def _capture_run_enrichment(**kwargs):
+            captured_kwargs.update(kwargs)
+            return {}
+
+        from blueprints.monitoring import _process_monitor
+
+        with (
+            patch(
+                "treesight.pipeline.enrichment.run_enrichment",
+                side_effect=_capture_run_enrichment,
+            ),
+            patch("treesight.storage.client.BlobStorageClient"),
+        ):
+            _process_monitor(m)
+
+        assert captured_kwargs.get("date_start") is None
+
+    def test_process_monitor_stores_ndvi_baseline_after_run(self, _mock_cosmos):
+        """NDVI mean from latest scene is persisted to baseline_ndvi_mean."""
+        from treesight.monitoring import create_monitor
+
+        m = create_monitor(
+            user_id="user-1",
+            aoi_name="Baseline Store Test",
+            aoi_geometry=_SAMPLE_GEOMETRY,
+        )
+
+        mock_enrichment = {
+            "ndvi_stats": [
+                {"mean": 0.45, "datetime": "2026-02-01"},
+                {"mean": 0.62, "datetime": "2026-03-01"},
+            ]
+        }
+
+        saved: list = []
+
+        from blueprints.monitoring import _process_monitor
+
+        with (
+            patch(
+                "treesight.pipeline.enrichment.run_enrichment",
+                return_value=mock_enrichment,
+            ),
+            patch("treesight.storage.client.BlobStorageClient"),
+            patch(
+                "treesight.monitoring.advance_schedule",
+                side_effect=lambda mon, **_kw: saved.append(mon.baseline_ndvi_mean),
+            ),
+        ):
+            _process_monitor(m)
+
+        assert saved == [0.62]
+
     def test_cors_preflight_monitoring(self, _mock_auth):
         from blueprints.monitoring import monitoring_endpoint
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -635,6 +635,57 @@ class TestMonitoringScheduler:
         ):
             _process_monitor(m)
 
+    def test_process_monitor_uses_latest_change_comparison_by_year(self, _mock_cosmos):
+        from treesight.monitoring import create_monitor
+
+        m = create_monitor(
+            user_id="user-1",
+            aoi_name="Latest Change Test",
+            aoi_geometry=_SAMPLE_GEOMETRY,
+            alert_email="test@example.com",
+        )
+
+        mock_enrichment = {
+            "change_detection": {
+                "season_changes": [
+                    {
+                        "season": "Summer",
+                        "year_from": 2024,
+                        "year_to": 2025,
+                        "loss_pct": 2.0,
+                        "gain_pct": 1.0,
+                        "mean_delta": -0.02,
+                    },
+                    {
+                        "season": "Winter",
+                        "year_from": 2023,
+                        "year_to": 2024,
+                        "loss_pct": 11.0,
+                        "gain_pct": 1.0,
+                        "mean_delta": -0.18,
+                    },
+                ],
+                "summary": {"comparisons": 2},
+            }
+        }
+
+        from blueprints.monitoring import _process_monitor
+
+        with (
+            patch(
+                "treesight.pipeline.enrichment.run_enrichment",
+                return_value=mock_enrichment,
+            ),
+            patch("treesight.storage.client.BlobStorageClient"),
+            patch("treesight.email.send_email", return_value=True) as mock_send,
+        ):
+            _process_monitor(m)
+
+        assert mock_send.call_count == 0, (
+            "Monitoring should evaluate alerts against the newest year pair, not the "
+            "last season_changes entry"
+        )
+
     def test_process_monitor_passes_delta_window_on_repeat_run(self, _mock_cosmos):
         """Repeat runs pass date_start=last_run_at so only new scenes are fetched."""
         from treesight.monitoring import create_monitor

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -641,6 +641,7 @@ class TestMonitoringScheduler:
             aoi_geometry=_SAMPLE_GEOMETRY,
         )
         m.last_run_at = last_run
+        m.last_run_id = "monitoring-abc123"  # marks a prior successful enrichment run
 
         captured_kwargs: dict = {}
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -612,9 +612,14 @@ class TestMonitoringScheduler:
 
         mock_enrichment = {
             "change_detection": {
-                "loss_pct": 8.0,
-                "gain_pct": 1.0,
-                "mean_delta": -0.12,
+                "season_changes": [
+                    {
+                        "loss_pct": 8.0,
+                        "gain_pct": 1.0,
+                        "mean_delta": -0.12,
+                    }
+                ],
+                "summary": {"comparisons": 1},
             }
         }
 
@@ -705,7 +710,7 @@ class TestMonitoringScheduler:
 
         mock_enrichment = {
             "ndvi_stats": [
-                {"mean": 0.45, "datetime": "2026-02-01"},
+                {"mean": 0.45, "datetime": datetime(2026, 2, 1, tzinfo=UTC)},
                 {"mean": 0.62, "datetime": "2026-03-01"},
             ]
         }

--- a/tests/test_orchestrator_split.py
+++ b/tests/test_orchestrator_split.py
@@ -115,6 +115,25 @@ def test_function_app_registers_monitoring_scheduler():
     assert "app.register_functions(monitoring_scheduler_bp)" in source
 
 
+def test_function_app_orch_imports_and_indexes_without_monitoring_timer(monkeypatch):
+    """The orchestrator entry point must import cleanly and omit the timer trigger."""
+    import importlib
+    import sys
+
+    monkeypatch.setenv("PIPELINE_ROLE", "orchestrator")
+    sys.modules.pop("function_app_orch", None)
+
+    orch = importlib.import_module("function_app_orch")
+    orch.app.functions_bindings = {}
+    functions = orch.app.get_functions()
+    names = {fn.get_function_name() for fn in functions}
+
+    assert functions, "function_app_orch must index at least one function"
+    assert "monitoring_scheduler" not in names, (
+        "function_app_orch must not register the monitoring timer trigger"
+    )
+
+
 # ── 3. Dockerfile.orchestrator ──────────────────────────────────────────
 
 

--- a/tests/test_orchestrator_split.py
+++ b/tests/test_orchestrator_split.py
@@ -39,17 +39,6 @@ def test_pipeline_activities_guarded_by_pipeline_role():
     init_path = REPO_ROOT / "blueprints" / "pipeline" / "__init__.py"
     tree = ast.parse(init_path.read_text(), filename=str(init_path))
 
-    # Find all top-level unconditional imports of activities
-    unconditional_activities_imports = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.module is None:
-            # from . import activities
-            for alias in node.names:
-                if alias.name == "activities":
-                    # Check if this import is inside an if block or at top level
-                    # We check by seeing if parent is an If node
-                    unconditional_activities_imports.append(node)
-
     # Check differently: look for pattern at module level (not in If)
     module_level_unconditional = []
     for node in tree.body:

--- a/tests/test_orchestrator_split.py
+++ b/tests/test_orchestrator_split.py
@@ -1,0 +1,224 @@
+"""Tests for the orchestrator image split (#466).
+
+Verifies that:
+- blueprints/pipeline/__init__.py skips activities when PIPELINE_ROLE=orchestrator
+- function_app_orch.py can be imported without importing activities
+- Dockerfile.orchestrator exists and excludes heavy compute packages
+- deploy.yml builds both images and passes orchestrator_image to tofu
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ── 1. PIPELINE_ROLE=orchestrator skips activities import ────────────────
+
+
+def test_pipeline_init_checks_pipeline_role():
+    """blueprints/pipeline/__init__.py must read PIPELINE_ROLE and
+    conditionally import activities only when role is 'full'.
+    """
+    init_path = REPO_ROOT / "blueprints" / "pipeline" / "__init__.py"
+    source = init_path.read_text()
+    assert "PIPELINE_ROLE" in source, (
+        "blueprints/pipeline/__init__.py must read PIPELINE_ROLE env var"
+    )
+    assert "_PIPELINE_ROLE" in source, (
+        "blueprints/pipeline/__init__.py must store PIPELINE_ROLE in a local variable"
+    )
+
+
+def test_pipeline_activities_guarded_by_pipeline_role():
+    """activities must only be imported when PIPELINE_ROLE == 'full',
+    not unconditionally at the module level.
+    """
+    init_path = REPO_ROOT / "blueprints" / "pipeline" / "__init__.py"
+    tree = ast.parse(init_path.read_text(), filename=str(init_path))
+
+    # Find all top-level unconditional imports of activities
+    unconditional_activities_imports = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module is None:
+            # from . import activities
+            for alias in node.names:
+                if alias.name == "activities":
+                    # Check if this import is inside an if block or at top level
+                    # We check by seeing if parent is an If node
+                    unconditional_activities_imports.append(node)
+
+    # Check differently: look for pattern at module level (not in If)
+    module_level_unconditional = []
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module is None:
+            for alias in node.names:
+                if alias.name == "activities":
+                    module_level_unconditional.append(alias.name)
+
+    assert not module_level_unconditional, (
+        "activities must not be imported unconditionally at module level — "
+        "it must be guarded by PIPELINE_ROLE == 'full'"
+    )
+
+
+def test_pipeline_role_orchestrator_skips_activities(monkeypatch):
+    """When PIPELINE_ROLE=orchestrator, importing blueprints.pipeline must
+    not import the activities module.
+    """
+    import sys
+
+    monkeypatch.setenv("PIPELINE_ROLE", "orchestrator")
+
+    # Remove any cached imports so the env var takes effect
+    mods_to_remove = [k for k in sys.modules if k.startswith("blueprints.pipeline")]
+    for mod in mods_to_remove:
+        sys.modules.pop(mod, None)
+
+    import blueprints.pipeline  # noqa: F401
+
+    assert "blueprints.pipeline.activities" not in sys.modules, (
+        "blueprints.pipeline.activities must not be imported when PIPELINE_ROLE=orchestrator"
+    )
+
+    # Re-clean for isolation
+    for mod in list(sys.modules):
+        if mod.startswith("blueprints.pipeline"):
+            sys.modules.pop(mod, None)
+
+
+# ── 2. function_app_orch.py structure ───────────────────────────────────
+
+
+def test_function_app_orch_exists():
+    """function_app_orch.py must exist in the repo root."""
+    assert (REPO_ROOT / "function_app_orch.py").exists(), (
+        "function_app_orch.py is missing — orchestrator image entry point not found"
+    )
+
+
+def test_function_app_orch_imports_pipeline_bp():
+    """function_app_orch.py must import blueprints.pipeline (orchestrator role)."""
+    source = (REPO_ROOT / "function_app_orch.py").read_text()
+    assert "from blueprints.pipeline import bp as pipeline_bp" in source
+
+
+def test_function_app_orch_does_not_hardcode_activities():
+    """function_app_orch.py must not directly import activities."""
+    source = (REPO_ROOT / "function_app_orch.py").read_text()
+    assert "from blueprints.pipeline.activities" not in source
+    assert "import activities" not in source
+
+
+# ── 3. Dockerfile.orchestrator ──────────────────────────────────────────
+
+
+def test_dockerfile_orchestrator_exists():
+    """Dockerfile.orchestrator must exist."""
+    assert (REPO_ROOT / "Dockerfile.orchestrator").exists(), "Dockerfile.orchestrator is missing"
+
+
+def test_dockerfile_orchestrator_sets_pipeline_role():
+    """Dockerfile.orchestrator must set PIPELINE_ROLE=orchestrator."""
+    source = (REPO_ROOT / "Dockerfile.orchestrator").read_text()
+    assert "PIPELINE_ROLE=orchestrator" in source, (
+        "Dockerfile.orchestrator must set ENV PIPELINE_ROLE=orchestrator"
+    )
+
+
+def test_dockerfile_orchestrator_excludes_heavy_packages():
+    """Dockerfile.orchestrator must filter out GDAL-dependent packages."""
+    source = (REPO_ROOT / "Dockerfile.orchestrator").read_text()
+    # Must use the grep-v exclusion pattern
+    heavy = ["fiona", "rasterio", "numpy"]
+    for pkg in heavy:
+        assert pkg in source, (
+            f"Dockerfile.orchestrator must explicitly exclude {pkg} from the install"
+        )
+
+
+def test_dockerfile_orchestrator_copies_orch_entry_point():
+    """Dockerfile.orchestrator must install function_app_orch.py as function_app.py."""
+    source = (REPO_ROOT / "Dockerfile.orchestrator").read_text()
+    assert "function_app_orch.py" in source, (
+        "Dockerfile.orchestrator must COPY function_app_orch.py"
+    )
+
+
+# ── 4. image-config.env ─────────────────────────────────────────────────
+
+
+def test_image_config_env_has_orch_repo():
+    """image-config.env must define ORCH_IMAGE_REPO for the CI build."""
+    path = REPO_ROOT / ".github" / "image-config.env"
+    source = path.read_text()
+    assert "ORCH_IMAGE_REPO" in source, ".github/image-config.env must define ORCH_IMAGE_REPO"
+
+
+# ── 5. infra/tofu — orchestrator_image variable and resource ────────────
+
+
+def test_tofu_orchestrator_image_variable_defined():
+    """infra/tofu/variables.tf must declare orchestrator_image variable."""
+    source = (REPO_ROOT / "infra" / "tofu" / "variables.tf").read_text()
+    assert 'variable "orchestrator_image"' in source, (
+        'infra/tofu/variables.tf must declare variable "orchestrator_image"'
+    )
+
+
+def test_tofu_function_app_orch_resource_defined():
+    """infra/tofu/main.tf must declare azapi_resource.function_app_orch."""
+    source = (REPO_ROOT / "infra" / "tofu" / "main.tf").read_text()
+    assert 'resource "azapi_resource" "function_app_orch"' in source, (
+        'infra/tofu/main.tf must declare azapi_resource "function_app_orch"'
+    )
+
+
+def test_tofu_function_app_orch_uses_orchestrator_image():
+    """azapi_resource.function_app_orch must reference var.orchestrator_image."""
+    source = (REPO_ROOT / "infra" / "tofu" / "main.tf").read_text()
+    assert "var.orchestrator_image" in source, (
+        "infra/tofu/main.tf must reference var.orchestrator_image in function_app_orch body"
+    )
+
+
+def test_tofu_orchestrator_outputs_defined():
+    """infra/tofu/outputs.tf must export orchestrator function app outputs."""
+    source = (REPO_ROOT / "infra" / "tofu" / "outputs.tf").read_text()
+    assert "function_app_orch_name" in source
+    assert "function_app_orch_default_hostname" in source
+
+
+# ── 6. deploy.yml — dual image build ────────────────────────────────────
+
+
+def test_deploy_yml_builds_orchestrator_image():
+    """deploy.yml must build Dockerfile.orchestrator."""
+    source = (REPO_ROOT / ".github" / "workflows" / "deploy.yml").read_text()
+    assert "Dockerfile.orchestrator" in source, (
+        "deploy.yml must build the orchestrator image from Dockerfile.orchestrator"
+    )
+
+
+def test_deploy_yml_passes_orchestrator_image_to_tofu():
+    """deploy.yml must pass orchestrator_image variable to tofu plan."""
+    source = (REPO_ROOT / ".github" / "workflows" / "deploy.yml").read_text()
+    assert "orchestrator_image=" in source, (
+        'deploy.yml must pass -var="orchestrator_image=..." to tofu plan'
+    )
+
+
+def test_deploy_yml_configures_orchestrator_app():
+    """deploy.yml must include a step to configure the orchestrator function app."""
+    source = (REPO_ROOT / ".github" / "workflows" / "deploy.yml").read_text()
+    assert "Configure Orchestrator Function App" in source, (
+        "deploy.yml must have a 'Configure Orchestrator Function App' deploy step"
+    )
+
+
+def test_deploy_yml_exposes_orch_image_uri_output():
+    """build-image job must expose orch_image_uri output."""
+    source = (REPO_ROOT / ".github" / "workflows" / "deploy.yml").read_text()
+    assert "orch_image_uri" in source

--- a/tests/test_orchestrator_split.py
+++ b/tests/test_orchestrator_split.py
@@ -112,6 +112,20 @@ def test_function_app_orch_does_not_hardcode_activities():
     assert "import activities" not in source
 
 
+def test_function_app_orch_does_not_register_monitoring_scheduler():
+    """The orchestrator image must not register the monitoring timer trigger."""
+    source = (REPO_ROOT / "function_app_orch.py").read_text()
+    assert "app.register_functions(monitoring_bp)" in source
+    assert "monitoring_scheduler_bp" not in source
+
+
+def test_function_app_registers_monitoring_scheduler():
+    """The compute image must keep the monitoring timer trigger."""
+    source = (REPO_ROOT / "function_app.py").read_text()
+    assert "from blueprints.monitoring import scheduler_bp as monitoring_scheduler_bp" in source
+    assert "app.register_functions(monitoring_scheduler_bp)" in source
+
+
 # ── 3. Dockerfile.orchestrator ──────────────────────────────────────────
 
 

--- a/treesight/pipeline/enrichment/frames.py
+++ b/treesight/pipeline/enrichment/frames.py
@@ -31,16 +31,16 @@ MONTHS: list[dict[str, Any]] = [
 SEASONAL_YEARS = list(range(2018, date.today().year + 1))
 LANDSAT_YEARS = list(range(2013, 2018))  # Pre-Sentinel-2 historical baseline
 NAIP_ONLY_YEARS = [2012, 2014, 2016]
-# NAIP imagery releases lag ~2 years; update this set when new vintages
-# are published on Planetary Computer (typically even-numbered years).
-NAIP_SUMMERS = {
-    "2012-summer",
-    "2014-summer",
-    "2016-summer",
-    "2018-summer",
-    "2020-summer",
-    "2022-summer",
-}
+
+
+def _prefer_naip_for_summer(year: int, season_key: str) -> bool:
+    """Return whether a CONUS seasonal frame should try NAIP first.
+
+    We intentionally prefer NAIP for all summer frames in supported years and
+    rely on runtime mosaic fallback when NAIP coverage is missing for a year/AOI.
+    This avoids stale hard-coded vintage lists that silently skip usable imagery.
+    """
+    return season_key == "summer" and year >= min(NAIP_ONLY_YEARS)
 
 
 def _max_aoi_span_m(coords: list[list[float]]) -> float:
@@ -175,8 +175,7 @@ def _build_seasonal_frames(has_naip: bool) -> list[dict[str, Any]]:
     for yr in SEASONAL_YEARS:
         for s in SEASONS:
             w = _season_window(yr, s)
-            naip_key = f"{yr}-{s['key']}"
-            use_naip = has_naip and naip_key in NAIP_SUMMERS
+            use_naip = has_naip and _prefer_naip_for_summer(yr, s["key"])
             frames.append(
                 {
                     "year": yr,

--- a/treesight/pipeline/enrichment/runner.py
+++ b/treesight/pipeline/enrichment/runner.py
@@ -221,8 +221,9 @@ def _run_mosaic_ndvi_phase(
     log_phase("enrichment", "mosaic_start", frames=len(frame_plan))
     search_ids: list[str | None] = [None] * len(frame_plan)
     ndvi_search_ids: list[str | None] = [None] * len(frame_plan)
+    display_collections: list[str] = [str(f.get("collection", "")) for f in frame_plan]
 
-    def _register_one(idx: int, f: dict[str, Any]) -> tuple[int, str | None, str | None]:
+    def _register_one(idx: int, f: dict[str, Any]) -> tuple[int, str | None, str | None, str]:
         cloud_collections = {"sentinel-2-l2a", "landsat-c2-l2"}
         extra: list[dict[str, Any]] = (
             [{"op": "<=", "args": [{"property": "eo:cloud_cover"}, 20]}]
@@ -231,8 +232,24 @@ def _run_mosaic_ndvi_phase(
         )
         with httpx.Client(timeout=DEFAULT_HTTP_TIMEOUT_SECONDS) as cl:
             sid = None
+            display_collection = str(f.get("collection", ""))
             if f.get("rgb_display_suitable", True):
                 sid = register_mosaic(f["collection"], f["start"], f["end"], bbox, extra, cl)
+
+            # If NAIP is preferred but unavailable for this frame/year, fall
+            # back to Sentinel-2 RGB so the viewer still gets the best
+            # available visual source instead of a missing/blank RGB layer.
+            if f["is_naip"] and sid is None and f.get("rgb_display_suitable", True):
+                sid = register_mosaic(
+                    "sentinel-2-l2a",
+                    f["start"],
+                    f["end"],
+                    bbox,
+                    [{"op": "<=", "args": [{"property": "eo:cloud_cover"}, 20]}],
+                    cl,
+                )
+                if sid:
+                    display_collection = "sentinel-2-l2a"
 
             nsid = sid
             # When the RGB mosaic was skipped (unsuitable) or failed, register a
@@ -249,29 +266,34 @@ def _run_mosaic_ndvi_phase(
                     cl,
                 )
             if f["is_naip"]:
-                nsid = register_mosaic(
-                    "sentinel-2-l2a",
-                    f["start"],
-                    f["end"],
-                    bbox,
-                    [{"op": "<=", "args": [{"property": "eo:cloud_cover"}, 20]}],
-                    cl,
-                )
-        return idx, sid, nsid
+                if display_collection == "sentinel-2-l2a" and sid is not None:
+                    nsid = sid
+                else:
+                    nsid = register_mosaic(
+                        "sentinel-2-l2a",
+                        f["start"],
+                        f["end"],
+                        bbox,
+                        [{"op": "<=", "args": [{"property": "eo:cloud_cover"}, 20]}],
+                        cl,
+                    )
+        return idx, sid, nsid, display_collection
 
     with ThreadPoolExecutor(max_workers=DEFAULT_ENRICHMENT_CONCURRENCY) as pool:
         futures = [pool.submit(_register_one, i, f) for i, f in enumerate(frame_plan)]
         for fut in as_completed(futures):
             try:
-                idx, sid, nsid = fut.result()
+                idx, sid, nsid, display_collection = fut.result()
             except Exception:
                 logger.warning("mosaic registration failed for one frame", exc_info=True)
                 continue
             search_ids[idx] = sid
             ndvi_search_ids[idx] = nsid
+            display_collections[idx] = display_collection
 
     results["search_ids"] = search_ids
     results["ndvi_search_ids"] = ndvi_search_ids
+    results["display_collections"] = display_collections
     log_phase(
         "enrichment",
         "mosaic_done",
@@ -345,18 +367,19 @@ def _run_mosaic_ndvi_phase(
         f["ndvi_search_id"] = ndvi_search_ids[i]
         f["ndvi_stat"] = ndvi_stats[i]
         f["ndvi_raster_path"] = ndvi_raster_paths[i] if i < len(ndvi_raster_paths) else None
+        f["display_collection"] = display_collections[i]
         season_key = f["season"]
         year = f["year"]
-        if f["is_naip"]:
+        if f["display_collection"] == "naip":
             f["label"] = f"NAIP Summer {year}"
-        elif f["collection"] == "landsat-c2-l2":
+        elif f["display_collection"] == "landsat-c2-l2":
             f["label"] = f"Landsat {season_key.capitalize()} {year}"
         else:
             f["label"] = f"{season_key.capitalize()} {year}"
-        if f["is_naip"]:
+        if f["display_collection"] == "naip":
             res = "0.6" if year > 2014 else "1.0"
             src = "NAIP © USDA"
-        elif f["collection"] == "landsat-c2-l2":
+        elif f["display_collection"] == "landsat-c2-l2":
             res = "30"
             src = "Landsat C2 L2"
         else:
@@ -365,7 +388,8 @@ def _run_mosaic_ndvi_phase(
         f["info"] = f"{src} | {res} m/px | {f['start']} → {f['end']}"
         ndvi_stat = ndvi_stats[i] if i < len(ndvi_stats) else None
         f["provenance"] = {
-            "collection": f.get("collection", ""),
+            "collection": f.get("display_collection") or f.get("collection", ""),
+            "requested_collection": f.get("collection", ""),
             "display_search_id": search_ids[i],
             "ndvi_search_id": ndvi_search_ids[i],
             "ndvi_scene_id": ndvi_stat.get("scene_id") if ndvi_stat else None,

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -962,6 +962,52 @@
     return 'rgb';
   }
 
+  function pickInitialEvidenceFrameIndex(frames) {
+    if (!Array.isArray(frames) || !frames.length) return 0;
+
+    var bestIndex = 0;
+    var bestScore = null;
+
+    frames.forEach(function(frame, idx) {
+      if (!frame) return;
+
+      var rgbSuitable = frame.rgbDisplaySuitable !== false;
+      var resolution = Number(frame.displayResolutionM || 9999);
+      var score = {
+        rgbSuitable: rgbSuitable ? 1 : 0,
+        resolution: Number.isFinite(resolution) ? -resolution : -9999,
+        recency: idx
+      };
+
+      if (!bestScore) {
+        bestScore = score;
+        bestIndex = idx;
+        return;
+      }
+
+      if (score.rgbSuitable > bestScore.rgbSuitable) {
+        bestScore = score;
+        bestIndex = idx;
+        return;
+      }
+
+      if (score.rgbSuitable < bestScore.rgbSuitable) return;
+
+      if (score.resolution > bestScore.resolution) {
+        bestScore = score;
+        bestIndex = idx;
+        return;
+      }
+
+      if (score.resolution === bestScore.resolution && score.recency > bestScore.recency) {
+        bestScore = score;
+        bestIndex = idx;
+      }
+    });
+
+    return bestIndex;
+  }
+
   function syncEvidenceLayerButtons(frame) {
     var rgbBtn = document.getElementById('app-map-btn-rgb');
     var ndviBtn = document.getElementById('app-map-btn-ndvi');
@@ -1348,7 +1394,7 @@
     framePlan.forEach(function(frame, idx) {
       var sid = searchIds[idx];
       var ndviSid = ndviSearchIds[idx] || sid;
-      var collection = frame.collection || 'sentinel-2-l2a';
+      var collection = frame.display_collection || frame.collection || 'sentinel-2-l2a';
       var asset = frame.asset || (collection.indexOf('naip') >= 0 ? 'image' : 'visual');
 
       var rgbLayer = null;
@@ -1381,14 +1427,16 @@
         rgbDisplaySuitable: frame.rgb_display_suitable !== false,
         rgbDisplayWarning: frame.rgb_display_warning || '',
         preferredLayer: frame.preferred_layer || 'rgb',
+        displayResolutionM: frame.display_resolution_m || null,
         collectionLabel: collectionLabel,
         resLabel: resLabel
       });
     });
 
-    evidenceLayerMode = pickEvidenceDefaultLayer(evidenceMapLayers[0]);
+    evidenceFrameIndex = pickInitialEvidenceFrameIndex(evidenceMapLayers);
+    evidenceLayerMode = pickEvidenceDefaultLayer(evidenceMapLayers[evidenceFrameIndex]);
     syncLayerModeButtons();
-    showEvidenceFrame(0);
+    showEvidenceFrame(evidenceFrameIndex);
   }
 
   function showEvidenceFrame(idx) {


### PR DESCRIPTION
## Summary

This PR delivers both Stage 3B.5 items:

- **#688** — monitoring delta fetch: bound repeat enrichments to scenes since the last successful run; persist NDVI baseline
- **#466** — orchestrator/compute image split: separate Container Apps Function App into a slim orchestrator image and a heavy compute image
- **#692** — keep the monitoring timer trigger on the compute image only, while the orchestrator image retains the monitoring HTTP endpoints

---

## #688 — Monitoring delta fetch + NDVI baseline persistence

### Problem
Every 6-hourly monitor check called `run_enrichment` with no date window, re-fetching the full historical scene archive. For an AOI with 3+ years of Sentinel-2 data this burns dozens of unnecessary Planetary Computer tile fetches per check.

### Changes — `blueprints/monitoring.py` (`_process_monitor`)

- Capture `now = datetime.now(UTC)` once; derive both `run_ts` and `date_end` from it
- Gate `date_start` on `last_run_id.startswith("monitoring-")`: only apply the delta window after a confirmed successful enrichment run; skip runs do not narrow the window
- Persist latest NDVI mean to `monitor.baseline_ndvi_mean` before `advance_schedule()`

### Tests (`tests/test_monitoring.py`)
| Test | Asserts |
|------|---------|
| `test_process_monitor_passes_delta_window_on_repeat_run` | `date_start == last_run_at.date()` when prior successful run exists |
| `test_process_monitor_first_run_has_no_date_start` | `date_start is None` on first run |
| `test_process_monitor_stores_ndvi_baseline_after_run` | `baseline_ndvi_mean` set to latest scene mean before `advance_schedule` |

---

## #466 — Orchestrator/compute image split

### Two-image architecture

| | Orchestrator image | Compute image |
|---|---|---|
| Name | `treesight-orch` | `treesight` |
| Approx. size | ~300 MB | ~1.5 GB |
| Excluded deps | fiona, rasterio, numpy, shapely, pyproj, pystac-client, planetary-computer | none |
| `PIPELINE_ROLE` | `orchestrator` | `full` (default) |
| Registers | HTTP blueprints + Durable orchestrators + blob trigger + submission + diagnostics + monitoring HTTP routes | same + **activities** + monitoring timer trigger |
| Scale-to-zero | ❌ (stays warm) | ✅ (scales between runs) |

`httpx` is kept in the orchestrator image because `blueprints/analysis.py` → `treesight.ai.client` imports it at module load time; excluding it causes a startup `ModuleNotFoundError`.

### Key changes
- `blueprints/pipeline/__init__.py`: reads `PIPELINE_ROLE` env var; imports `activities` only when `"full"`
- `function_app_orch.py`: orchestrator entry point
- `Dockerfile.orchestrator`: strips GDAL-family packages; `ENV PIPELINE_ROLE=orchestrator`
- `.github/image-config.env`: `ORCH_IMAGE_REPO=treesight-orch`
- `infra/tofu/`: `azapi_resource.function_app_orch` + RBAC + Cosmos roles + new variable/outputs
- `deploy.yml`: parallel dual-image build; `Configure Orchestrator Function App` step; orch hostname used for Event Grid/readiness
- `tests/test_orchestrator_split.py`: coverage for the split and the monitoring timer registration boundary

---

## #692 — Monitoring timer stays on compute image

The monitoring HTTP API remains available from the orchestrator image, but the timer-triggered scheduler now registers only on the compute image. This prevents the orchestrator image from trying to execute compute-only monitoring enrichment at timer fire.

---

## Validation

- `python -m pytest tests/test_monitoring.py tests/test_orchestrator_split.py tests/test_function_indexing.py -x -q`
- `python -m ruff check blueprints/monitoring.py function_app.py function_app_orch.py tests/test_orchestrator_split.py`
- `python -m ruff format --check blueprints/monitoring.py function_app.py function_app_orch.py tests/test_orchestrator_split.py`
- prior full-suite validation on this branch: `1551 passed, 28 skipped`

## Roadmap

- Stage 3B.5.0 — closes #688
- Stage 3B.5.1 — closes #466

> **Note**: contains IaC (`infra/tofu/`) and CI workflow (`.github/workflows/deploy.yml`) changes — approval-gated per project workflow preferences.
