### PR TITLE
fix: keep monitoring timer on compute image only (#692)

### DIFF
--- a/blueprints/monitoring.py
+++ b/blueprints/monitoring.py
@@ -29,6 +29,7 @@ from treesight.security.billing import get_effective_subscription, plan_capabili
 logger = logging.getLogger(__name__)
 
 bp = func.Blueprint()
+scheduler_bp = func.Blueprint()
 
 # --- Tier gating -------------------------------------------------------
 
@@ -65,7 +66,7 @@ def _check_monitor_limit(user_id: str) -> str | None:
 # --- Timer Trigger: scheduled monitoring check --------------------------
 
 
-@bp.timer_trigger(schedule="0 0 */6 * * *", arg_name="timer", run_on_startup=False)
+@scheduler_bp.timer_trigger(schedule="0 0 */6 * * *", arg_name="timer", run_on_startup=False)
 def monitoring_scheduler(timer: func.TimerRequest) -> None:
     """Run every 6 hours: find due monitors and kick off re-analysis."""
     from treesight.storage.cosmos import cosmos_available

--- a/function_app.py
+++ b/function_app.py
@@ -27,6 +27,7 @@ from blueprints.eudr import bp as eudr_bp
 from blueprints.export import bp as export_bp
 from blueprints.health import bp as health_bp
 from blueprints.monitoring import bp as monitoring_bp
+from blueprints.monitoring import scheduler_bp as monitoring_scheduler_bp
 from blueprints.ops import bp as ops_bp
 from blueprints.org import bp as org_bp
 from blueprints.pipeline import bp as pipeline_bp
@@ -83,6 +84,7 @@ app.register_functions(upload_bp)
 
 # Register monitoring blueprint (Timer Trigger + HTTP)
 app.register_functions(monitoring_bp)
+app.register_functions(monitoring_scheduler_bp)
 
 # Register ops dashboard (operator visibility)
 app.register_functions(ops_bp)

--- a/function_app_orch.py
+++ b/function_app_orch.py
@@ -89,7 +89,9 @@ app.register_functions(org_bp)
 # Register upload/history BFF endpoints
 app.register_functions(upload_bp)
 
-# Register monitoring blueprint (Timer Trigger + HTTP)
+# Register monitoring HTTP endpoints only.
+# The timer-triggered scheduler stays in the compute image because it
+# calls compute-only enrichment code.
 app.register_functions(monitoring_bp)
 
 # Register ops dashboard (operator visibility)

--- a/tests/test_orchestrator_split.py
+++ b/tests/test_orchestrator_split.py
@@ -112,6 +112,20 @@ def test_function_app_orch_does_not_hardcode_activities():
     assert "import activities" not in source
 
 
+def test_function_app_orch_does_not_register_monitoring_scheduler():
+    """The orchestrator image must not register the monitoring timer trigger."""
+    source = (REPO_ROOT / "function_app_orch.py").read_text()
+    assert "app.register_functions(monitoring_bp)" in source
+    assert "monitoring_scheduler_bp" not in source
+
+
+def test_function_app_registers_monitoring_scheduler():
+    """The compute image must keep the monitoring timer trigger."""
+    source = (REPO_ROOT / "function_app.py").read_text()
+    assert "from blueprints.monitoring import scheduler_bp as monitoring_scheduler_bp" in source
+    assert "app.register_functions(monitoring_scheduler_bp)" in source
+
+
 # ── 3. Dockerfile.orchestrator ──────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Fixes #692 as a stacked PR on top of #691.

#466 split the app into orchestrator + compute images, but both images were still registering the monitoring blueprint. That left the timer-triggered scheduler active in the orchestrator image even though `_process_monitor()` still calls compute-only enrichment code.

This PR keeps the monitoring HTTP routes available in the orchestrator image, but moves the timer trigger registration to the compute image only.

## Changes

- `blueprints/monitoring.py`
  - exports `scheduler_bp` for the timer trigger
  - keeps HTTP monitoring routes on `bp`
- `function_app.py`
  - registers both `monitoring_bp` and `monitoring_scheduler_bp`
- `function_app_orch.py`
  - registers `monitoring_bp` only
- `tests/test_orchestrator_split.py`
  - adds coverage for compute/orchestrator monitoring registration split

## Why this slice

This is the smallest safe fix that prevents the orchestrator image from running compute-only monitoring work at timer fire, without reopening the broader runtime-cost PR.

## Validation

- `python -m pytest tests/test_monitoring.py tests/test_orchestrator_split.py tests/test_function_indexing.py -x -q`
- `python -m ruff check blueprints/monitoring.py function_app.py function_app_orch.py tests/test_orchestrator_split.py`
- `python -m ruff format --check blueprints/monitoring.py function_app.py function_app_orch.py tests/test_orchestrator_split.py`

## Stacking

- Base branch: `eudr/stage-3b5-runtime-cost` (PR #691)
- After #691 merges, retarget this PR to `main`
