### PR TITLE
fix: add run ownership check to timelapse-analysis-save (closes #696)

### DIFF
--- a/blueprints/pipeline/enrichment.py
+++ b/blueprints/pipeline/enrichment.py
@@ -22,7 +22,7 @@ from treesight.constants import DEFAULT_OUTPUT_CONTAINER
 
 from . import bp
 from ._helpers import _reshape_output
-from .history import get_run_record_by_instance_id
+from .history import assert_run_write_access, get_run_record_by_instance_id
 
 logger = logging.getLogger(__name__)
 
@@ -89,9 +89,12 @@ def timelapse_analysis_save(req: func.HttpRequest) -> func.HttpResponse:
         return cors_preflight(req)
 
     try:
-        check_auth(req)
+        _claims, user_id = check_auth(req)
     except ValueError as exc:
         return error_response(401, str(exc), req=req)
+
+    if user_id == "anonymous":
+        return error_response(401, "Authentication required", req=req)
 
     raw_body = req.get_body()
     if len(raw_body) > _MAX_ANALYSIS_BODY_BYTES:
@@ -109,6 +112,14 @@ def timelapse_analysis_save(req: func.HttpRequest) -> func.HttpResponse:
 
     if not instance_id or not analysis:
         return error_response(400, "instance_id and analysis are required", req=req)
+
+    run_record = get_run_record_by_instance_id(instance_id)
+    if not run_record:
+        return error_response(404, "Run not found", req=req)
+    try:
+        assert_run_write_access(run_record, user_id)
+    except ValueError as exc:
+        return error_response(403, str(exc), req=req)
 
     from treesight.storage.client import BlobStorageClient
 

--- a/blueprints/pipeline/enrichment.py
+++ b/blueprints/pipeline/enrichment.py
@@ -19,6 +19,7 @@ from blueprints._helpers import (
     fetch_enrichment_manifest,
 )
 from treesight.constants import DEFAULT_OUTPUT_CONTAINER
+from treesight.storage import cosmos as _cosmos_mod
 
 from . import bp
 from ._helpers import _reshape_output
@@ -107,11 +108,17 @@ def timelapse_analysis_save(req: func.HttpRequest) -> func.HttpResponse:
     except ValueError:
         return error_response(400, "Invalid JSON body", req=req)
 
+    if not isinstance(body, dict):
+        return error_response(400, "Request body must be a JSON object", req=req)
+
     instance_id = body.get("instance_id", "")
     analysis = body.get("analysis", {})
 
-    if not instance_id or not analysis:
+    if not instance_id or not isinstance(analysis, dict) or not analysis:
         return error_response(400, "instance_id and analysis are required", req=req)
+
+    if not _cosmos_mod.cosmos_available():
+        return error_response(503, "Service temporarily unavailable", req=req)
 
     run_record = get_run_record_by_instance_id(instance_id)
     if not run_record:

--- a/blueprints/pipeline/enrichment.py
+++ b/blueprints/pipeline/enrichment.py
@@ -19,11 +19,14 @@ from blueprints._helpers import (
     fetch_enrichment_manifest,
 )
 from treesight.constants import DEFAULT_OUTPUT_CONTAINER
-from treesight.storage import cosmos as _cosmos_mod
 
 from . import bp
 from ._helpers import _reshape_output
-from .history import assert_run_write_access, get_run_record_by_instance_id
+from .history import (
+    RunRecordLookupError,
+    assert_run_write_access,
+    get_run_record_by_instance_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -117,10 +120,11 @@ def timelapse_analysis_save(req: func.HttpRequest) -> func.HttpResponse:
     if not instance_id or not isinstance(analysis, dict) or not analysis:
         return error_response(400, "instance_id and analysis are required", req=req)
 
-    if not _cosmos_mod.cosmos_available():
+    try:
+        run_record = get_run_record_by_instance_id(instance_id, raise_on_error=True)
+    except RunRecordLookupError:
         return error_response(503, "Service temporarily unavailable", req=req)
 
-    run_record = get_run_record_by_instance_id(instance_id)
     if not run_record:
         return error_response(404, "Run not found", req=req)
     try:
@@ -153,13 +157,28 @@ def timelapse_analysis_save(req: func.HttpRequest) -> func.HttpResponse:
 def timelapse_analysis_load(req: func.HttpRequest) -> func.HttpResponse:
     """GET /api/timelapse-analysis-load/{instance_id} — retrieve saved analysis."""
     try:
-        check_auth(req)
+        _claims, user_id = check_auth(req)
     except ValueError as exc:
         return error_response(401, str(exc), req=req)
+
+    if user_id == "anonymous":
+        return error_response(401, "Authentication required", req=req)
 
     instance_id = req.route_params.get("instance_id", "")
     if not instance_id:
         return error_response(400, "instance_id required", req=req)
+
+    try:
+        run_record = get_run_record_by_instance_id(instance_id, raise_on_error=True)
+    except RunRecordLookupError:
+        return error_response(503, "Service temporarily unavailable", req=req)
+
+    if not run_record:
+        return error_response(404, "Run not found", req=req)
+    try:
+        assert_run_write_access(run_record, user_id)
+    except ValueError as exc:
+        return error_response(403, str(exc), req=req)
 
     from treesight.storage.client import BlobStorageClient
 

--- a/blueprints/pipeline/history.py
+++ b/blueprints/pipeline/history.py
@@ -51,13 +51,28 @@ def _analysis_submission_blob_name(user_id: str, submission_id: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def get_run_record_by_instance_id(instance_id: str) -> dict[str, Any] | None:
+class RunRecordLookupError(RuntimeError):
+    """Raised when a run record lookup fails due to backend availability/errors."""
+
+
+def get_run_record_by_instance_id(
+    instance_id: str,
+    *,
+    raise_on_error: bool = False,
+) -> dict[str, Any] | None:
     """Fetch a single run record by instance ID using a cross-partition Cosmos query.
 
-    Returns None when the record is not found or Cosmos is not available.
+    Returns None when the record is not found.
+
+    When ``raise_on_error`` is False (default), returns None when Cosmos is
+    unavailable or the query fails. When True, raises RunRecordLookupError in
+    those cases so callers can distinguish backend failures from true not-found.
+
     Blob fallback is not supported for cross-user lookups (owner unknown).
     """
     if not _cosmos_mod.cosmos_available():
+        if raise_on_error:
+            raise RunRecordLookupError("Cosmos unavailable")
         return None
     try:
         from treesight.storage import cosmos
@@ -68,8 +83,10 @@ def get_run_record_by_instance_id(instance_id: str) -> dict[str, Any] | None:
             parameters=[{"name": "@id", "value": instance_id}],
         )
         return results[0] if results else None
-    except Exception:
+    except Exception as exc:
         logger.warning("Cosmos run lookup failed for instance=%s", instance_id, exc_info=True)
+        if raise_on_error:
+            raise RunRecordLookupError("Run lookup failed") from exc
         return None
 
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,6 +7,45 @@ Last updated: 2026-04-22
 
 ---
 
+## Execution Order
+
+**The stacked PR queue. Work top-to-bottom. Each row is one PR unless noted.**
+Update status as work moves. Add new items at the correct priority position,
+not at the bottom.
+
+| # | Issue(s) | PR | Description | Status |
+|---|----------|----|-------------|--------|
+| 1 | #701 | #702 | fix: remove subscription_item_id from logs — CodeQL taint | 🔄 CI running |
+| 2 | #696 | — | fix: timelapse-analysis-save missing ownership check | 🔄 In progress |
+| 3 | #697 + #698 + #550 + #551 | — | chore: CI upgrades — Trivy 0.70, Actions Node 24, CodeQL v4 (bundle) | Open |
+| 4 | #405 | — | fix: reduce config drift (OpenTofu vs az CLI) — Stage 2E.2 | Open |
+| 5 | #402 | — | fix: security-gated production deploys — Stage 2E.3 | Open |
+| 6 | #403 | — | fix: smoke gates + promotion/demotion — Stage 2E.4 | Open |
+| 7 | #400 | — | feat: pipeline run telemetry — Stage 3.2 | Open |
+| 8 | #399 | — | feat: pipeline ETA estimator (needs #400) — Stage 3.3 | Open |
+| 9 | #78 + #79 | — | feat: temporal catalogue in Cosmos + API (bundle) — Stage 3.4/3.5 | Open |
+| 10 | #437 | — | test: E2E 200+ AOI KMZ scale validation — Stage 3.11 | Open |
+| 11 | #488 | — | perf: pipeline performance optimisation — Stage 3.6 | Open |
+| 12 | #675 | — | feat: DMS/UTM coordinate format support — Stage 3.12 | Open |
+| 13 | #586 | — | feat: per-user AOI imagery reuse + retention — Stage 3.7 | Open |
+| 14 | #679 | — | feat: shareable analysis links — Stage 3.8 | Open |
+| 15 | #618 | — | feat: Brazilian data enrichment (PRODES, DETER, CAR) — Stage 3.9 | Open |
+| 16 | #699 | — | research: supplier valet-token intake (may supersede #676) — Stage 3.14 | Research first |
+| 17 | #676 | — | feat: supplier data collection template — Stage 3.13 | Open (post #699 research) |
+| 18 | #678 | — | feat: country-risk auto-flagging — Stage 3.15 | Open |
+| 19 | #677 | — | feat: commodity tracking per parcel — Stage 3.16 | Open |
+| 20 | #680 | — | feat: GeoJSON/shapefile upload — Stage 3.17 | Open |
+| 21 | #619 | — | eval: Mapbox/Maxar satellite basemap — Stage 3.10 | Open |
+
+**Low-priority housekeeping** (bundle with adjacent work, don't schedule separately):
+`#573` CSP wildcards · `#593` Pydantic deprecation · `#625` poll_order refactor ·
+`#519` self-host Leaflet · `#569` old domain · `#570` ops docs risk · `#584` data model ·
+`#525`/`#526` deploy perf · `#252`/`#228` rate limiter/replay (Stage 4)
+
+**Stage 4 starts after Stage 3 is generating revenue** — see Stage 4 section below.
+
+---
+
 ## Direction
 
 **EUDR compliance is the product.** Conservation monitoring is mothballed

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -498,8 +498,20 @@ paths:
                 $ref: "#/components/schemas/AnalysisResult"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Caller does not own this run
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "404":
-          description: Analysis not found
+          description: Run or analysis not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: Cosmos DB temporarily unavailable
           content:
             application/json:
               schema:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -443,13 +443,40 @@ paths:
               schema:
                 type: object
                 properties:
-                  status:
+                  saved:
+                    type: boolean
+                    example: true
+                  path:
                     type: string
-                    example: saved
+                    example: analysis/abc123/timelapse_analysis.json
+        "400":
+          description: Missing or invalid fields
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Caller does not own this run
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Run not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "413":
           description: Payload too large (> 128 KiB)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: Cosmos DB temporarily unavailable
           content:
             application/json:
               schema:

--- a/tests/test_analysis_submission_endpoints.py
+++ b/tests/test_analysis_submission_endpoints.py
@@ -1353,12 +1353,47 @@ class TestTimelapseAnalysisSave:
 
         assert resp.status_code == 401
 
+    def test_rejects_non_dict_body(self):
+        from blueprints.pipeline.enrichment import timelapse_analysis_save
+
+        # JSON array instead of object
+        req = make_test_request(
+            url="https://example.com/api/timelapse-analysis-save",
+            method="POST",
+            body=b"[1, 2, 3]",
+            origin=TEST_LOCAL_ORIGIN,
+            auth_header="Bearer fake-token",
+        )
+        with patch("blueprints.pipeline.enrichment.check_auth", return_value=({}, "user-123")):
+            resp = timelapse_analysis_save(req)
+
+        assert resp.status_code == 400
+
+    def test_returns_503_when_cosmos_unavailable(self):
+        from blueprints.pipeline.enrichment import timelapse_analysis_save
+
+        req = self._make_req({"instance_id": "inst-abc", "analysis": {"result": "ok"}})
+        with (
+            patch("blueprints.pipeline.enrichment.check_auth", return_value=({}, "user-123")),
+            patch(
+                "blueprints.pipeline.enrichment._cosmos_mod.cosmos_available",
+                return_value=False,
+            ),
+        ):
+            resp = timelapse_analysis_save(req)
+
+        assert resp.status_code == 503
+
     def test_rejects_missing_run(self):
         from blueprints.pipeline.enrichment import timelapse_analysis_save
 
         req = self._make_req({"instance_id": "inst-abc", "analysis": {"result": "ok"}})
         with (
             patch("blueprints.pipeline.enrichment.check_auth", return_value=({}, "user-123")),
+            patch(
+                "blueprints.pipeline.enrichment._cosmos_mod.cosmos_available",
+                return_value=True,
+            ),
             patch(
                 "blueprints.pipeline.enrichment.get_run_record_by_instance_id",
                 return_value=None,
@@ -1375,6 +1410,10 @@ class TestTimelapseAnalysisSave:
         run = {"id": "inst-abc", "user_id": "owner-999", "org_id": "org-1"}
         with (
             patch("blueprints.pipeline.enrichment.check_auth", return_value=({}, "attacker-456")),
+            patch(
+                "blueprints.pipeline.enrichment._cosmos_mod.cosmos_available",
+                return_value=True,
+            ),
             patch(
                 "blueprints.pipeline.enrichment.get_run_record_by_instance_id",
                 return_value=run,
@@ -1398,6 +1437,10 @@ class TestTimelapseAnalysisSave:
         mock_storage = MagicMock()
         with (
             patch("blueprints.pipeline.enrichment.check_auth", return_value=({}, "user-123")),
+            patch(
+                "blueprints.pipeline.enrichment._cosmos_mod.cosmos_available",
+                return_value=True,
+            ),
             patch(
                 "blueprints.pipeline.enrichment.get_run_record_by_instance_id",
                 return_value=run,

--- a/tests/test_analysis_submission_endpoints.py
+++ b/tests/test_analysis_submission_endpoints.py
@@ -1303,3 +1303,114 @@ class TestAnnotationEndpoints:
         assert data["reverted"] is True
         upserted = mock_cosmos.upsert_item.call_args[0][1]
         assert "0" not in upserted.get("parcel_overrides", {})
+
+
+# ---------------------------------------------------------------------------
+# timelapse-analysis-save ownership check (issue #696)
+# ---------------------------------------------------------------------------
+
+
+class TestTimelapseAnalysisSave:
+    """Regression tests for the run ownership gate on POST /api/timelapse-analysis-save."""
+
+    def _make_req(
+        self,
+        body: dict,
+        auth_header: str | None = "Bearer fake-token",
+    ) -> func.HttpRequest:
+        return make_test_request(
+            url="https://example.com/api/timelapse-analysis-save",
+            method="POST",
+            body=body,
+            origin=TEST_LOCAL_ORIGIN,
+            auth_header=auth_header,
+        )
+
+    def test_rejects_unauthenticated(self):
+        from blueprints.pipeline.enrichment import timelapse_analysis_save
+
+        req = self._make_req(
+            {"instance_id": "inst-abc", "analysis": {"result": "ok"}},
+            auth_header=None,
+        )
+        with patch(
+            "blueprints.pipeline.enrichment.check_auth",
+            side_effect=ValueError("Unauthorized"),
+        ):
+            resp = timelapse_analysis_save(req)
+
+        assert resp.status_code == 401
+
+    def test_rejects_anonymous_user(self):
+        from blueprints.pipeline.enrichment import timelapse_analysis_save
+
+        req = self._make_req({"instance_id": "inst-abc", "analysis": {"result": "ok"}})
+        with patch(
+            "blueprints.pipeline.enrichment.check_auth",
+            return_value=({}, "anonymous"),
+        ):
+            resp = timelapse_analysis_save(req)
+
+        assert resp.status_code == 401
+
+    def test_rejects_missing_run(self):
+        from blueprints.pipeline.enrichment import timelapse_analysis_save
+
+        req = self._make_req({"instance_id": "inst-abc", "analysis": {"result": "ok"}})
+        with (
+            patch("blueprints.pipeline.enrichment.check_auth", return_value=({}, "user-123")),
+            patch(
+                "blueprints.pipeline.enrichment.get_run_record_by_instance_id",
+                return_value=None,
+            ),
+        ):
+            resp = timelapse_analysis_save(req)
+
+        assert resp.status_code == 404
+
+    def test_rejects_non_owner(self):
+        from blueprints.pipeline.enrichment import timelapse_analysis_save
+
+        req = self._make_req({"instance_id": "inst-abc", "analysis": {"result": "ok"}})
+        run = {"id": "inst-abc", "user_id": "owner-999", "org_id": "org-1"}
+        with (
+            patch("blueprints.pipeline.enrichment.check_auth", return_value=({}, "attacker-456")),
+            patch(
+                "blueprints.pipeline.enrichment.get_run_record_by_instance_id",
+                return_value=run,
+            ),
+            patch(
+                "blueprints.pipeline.enrichment.assert_run_write_access",
+                side_effect=ValueError("Access denied"),
+            ),
+        ):
+            resp = timelapse_analysis_save(req)
+
+        assert resp.status_code == 403
+
+    def test_permits_owner_and_saves(self):
+        from blueprints.pipeline.enrichment import timelapse_analysis_save
+
+        req = self._make_req(
+            {"instance_id": "inst-abc", "analysis": {"model": "gpt-4o", "result": "ok"}}
+        )
+        run = {"id": "inst-abc", "user_id": "user-123", "org_id": "org-1"}
+        mock_storage = MagicMock()
+        with (
+            patch("blueprints.pipeline.enrichment.check_auth", return_value=({}, "user-123")),
+            patch(
+                "blueprints.pipeline.enrichment.get_run_record_by_instance_id",
+                return_value=run,
+            ),
+            patch("blueprints.pipeline.enrichment.assert_run_write_access"),
+            patch(
+                "treesight.storage.client.BlobStorageClient",
+                return_value=mock_storage,
+            ),
+        ):
+            resp = timelapse_analysis_save(req)
+
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["saved"] is True
+        mock_storage.upload_json.assert_called_once()

--- a/tests/test_analysis_submission_endpoints.py
+++ b/tests/test_analysis_submission_endpoints.py
@@ -1103,6 +1103,38 @@ class TestRunRecordLookup:
 
         assert result is None
 
+    def test_get_run_record_raises_when_configured_and_cosmos_unavailable(self):
+        import pytest
+
+        from blueprints.pipeline.history import (
+            RunRecordLookupError,
+            get_run_record_by_instance_id,
+        )
+
+        with (
+            patch("blueprints.pipeline.history._cosmos_mod.cosmos_available", return_value=False),
+            pytest.raises(RunRecordLookupError, match="Cosmos unavailable"),
+        ):
+            get_run_record_by_instance_id("inst-abc", raise_on_error=True)
+
+    def test_get_run_record_raises_when_configured_and_query_fails(self):
+        import pytest
+
+        from blueprints.pipeline.history import (
+            RunRecordLookupError,
+            get_run_record_by_instance_id,
+        )
+
+        with (
+            patch("blueprints.pipeline.history._cosmos_mod.cosmos_available", return_value=True),
+            patch(
+                "blueprints.pipeline.history._cosmos_mod.query_items",
+                side_effect=RuntimeError("boom"),
+            ),
+            pytest.raises(RunRecordLookupError, match="Run lookup failed"),
+        ):
+            get_run_record_by_instance_id("inst-abc", raise_on_error=True)
+
     def test_assert_run_write_access_permits_owner(self):
         from blueprints.pipeline.history import assert_run_write_access
 
@@ -1371,13 +1403,14 @@ class TestTimelapseAnalysisSave:
 
     def test_returns_503_when_cosmos_unavailable(self):
         from blueprints.pipeline.enrichment import timelapse_analysis_save
+        from blueprints.pipeline.history import RunRecordLookupError
 
         req = self._make_req({"instance_id": "inst-abc", "analysis": {"result": "ok"}})
         with (
             patch("blueprints.pipeline.enrichment.check_auth", return_value=({}, "user-123")),
             patch(
-                "blueprints.pipeline.enrichment._cosmos_mod.cosmos_available",
-                return_value=False,
+                "blueprints.pipeline.enrichment.get_run_record_by_instance_id",
+                side_effect=RunRecordLookupError("Cosmos unavailable"),
             ),
         ):
             resp = timelapse_analysis_save(req)
@@ -1390,10 +1423,6 @@ class TestTimelapseAnalysisSave:
         req = self._make_req({"instance_id": "inst-abc", "analysis": {"result": "ok"}})
         with (
             patch("blueprints.pipeline.enrichment.check_auth", return_value=({}, "user-123")),
-            patch(
-                "blueprints.pipeline.enrichment._cosmos_mod.cosmos_available",
-                return_value=True,
-            ),
             patch(
                 "blueprints.pipeline.enrichment.get_run_record_by_instance_id",
                 return_value=None,
@@ -1410,10 +1439,6 @@ class TestTimelapseAnalysisSave:
         run = {"id": "inst-abc", "user_id": "owner-999", "org_id": "org-1"}
         with (
             patch("blueprints.pipeline.enrichment.check_auth", return_value=({}, "attacker-456")),
-            patch(
-                "blueprints.pipeline.enrichment._cosmos_mod.cosmos_available",
-                return_value=True,
-            ),
             patch(
                 "blueprints.pipeline.enrichment.get_run_record_by_instance_id",
                 return_value=run,
@@ -1438,10 +1463,6 @@ class TestTimelapseAnalysisSave:
         with (
             patch("blueprints.pipeline.enrichment.check_auth", return_value=({}, "user-123")),
             patch(
-                "blueprints.pipeline.enrichment._cosmos_mod.cosmos_available",
-                return_value=True,
-            ),
-            patch(
                 "blueprints.pipeline.enrichment.get_run_record_by_instance_id",
                 return_value=run,
             ),
@@ -1457,3 +1478,120 @@ class TestTimelapseAnalysisSave:
         data = json.loads(resp.get_body())
         assert data["saved"] is True
         mock_storage.upload_json.assert_called_once()
+
+
+class TestTimelapseAnalysisLoad:
+    """Regression tests for the run ownership gate on GET /api/timelapse-analysis-load."""
+
+    def _make_req(
+        self,
+        instance_id: str,
+        auth_header: str | None = "Bearer fake-token",
+    ) -> func.HttpRequest:
+        headers: dict[str, str] = {"Origin": TEST_LOCAL_ORIGIN}
+        if auth_header:
+            headers["Authorization"] = auth_header
+
+        return func.HttpRequest(
+            method="GET",
+            url=f"https://example.com/api/timelapse-analysis-load/{instance_id}",
+            headers=headers,
+            params={},
+            route_params={"instance_id": instance_id} if instance_id else {},
+            body=b"",
+        )
+
+    def test_rejects_unauthenticated(self):
+        from blueprints.pipeline.enrichment import timelapse_analysis_load
+
+        req = self._make_req("inst-abc", auth_header=None)
+        with patch(
+            "blueprints.pipeline.enrichment.check_auth",
+            side_effect=ValueError("Unauthorized"),
+        ):
+            resp = timelapse_analysis_load(req)
+
+        assert resp.status_code == 401
+
+    def test_rejects_anonymous_user(self):
+        from blueprints.pipeline.enrichment import timelapse_analysis_load
+
+        req = self._make_req("inst-abc")
+        with patch("blueprints.pipeline.enrichment.check_auth", return_value=({}, "anonymous")):
+            resp = timelapse_analysis_load(req)
+
+        assert resp.status_code == 401
+
+    def test_returns_503_on_lookup_error(self):
+        from blueprints.pipeline.enrichment import timelapse_analysis_load
+        from blueprints.pipeline.history import RunRecordLookupError
+
+        req = self._make_req("inst-abc")
+        with (
+            patch("blueprints.pipeline.enrichment.check_auth", return_value=({}, "user-123")),
+            patch(
+                "blueprints.pipeline.enrichment.get_run_record_by_instance_id",
+                side_effect=RunRecordLookupError("Run lookup failed"),
+            ),
+        ):
+            resp = timelapse_analysis_load(req)
+
+        assert resp.status_code == 503
+
+    def test_returns_404_when_run_missing(self):
+        from blueprints.pipeline.enrichment import timelapse_analysis_load
+
+        req = self._make_req("inst-abc")
+        with (
+            patch("blueprints.pipeline.enrichment.check_auth", return_value=({}, "user-123")),
+            patch(
+                "blueprints.pipeline.enrichment.get_run_record_by_instance_id",
+                return_value=None,
+            ),
+        ):
+            resp = timelapse_analysis_load(req)
+
+        assert resp.status_code == 404
+
+    def test_rejects_non_owner(self):
+        from blueprints.pipeline.enrichment import timelapse_analysis_load
+
+        req = self._make_req("inst-abc")
+        run = {"id": "inst-abc", "user_id": "owner-999", "org_id": "org-1"}
+        with (
+            patch("blueprints.pipeline.enrichment.check_auth", return_value=({}, "attacker-456")),
+            patch(
+                "blueprints.pipeline.enrichment.get_run_record_by_instance_id",
+                return_value=run,
+            ),
+            patch(
+                "blueprints.pipeline.enrichment.assert_run_write_access",
+                side_effect=ValueError("Access denied"),
+            ),
+        ):
+            resp = timelapse_analysis_load(req)
+
+        assert resp.status_code == 403
+
+    def test_permits_owner_and_loads(self):
+        from blueprints.pipeline.enrichment import timelapse_analysis_load
+
+        req = self._make_req("inst-abc")
+        run = {"id": "inst-abc", "user_id": "user-123", "org_id": "org-1"}
+        mock_storage = MagicMock()
+        mock_storage.download_json.return_value = {"summary": "ok"}
+        with (
+            patch("blueprints.pipeline.enrichment.check_auth", return_value=({}, "user-123")),
+            patch(
+                "blueprints.pipeline.enrichment.get_run_record_by_instance_id",
+                return_value=run,
+            ),
+            patch("blueprints.pipeline.enrichment.assert_run_write_access"),
+            patch("treesight.storage.client.BlobStorageClient", return_value=mock_storage),
+        ):
+            resp = timelapse_analysis_load(req)
+
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["summary"] == "ok"
+        mock_storage.download_json.assert_called_once()


### PR DESCRIPTION
## Summary

Fixes #696 — `POST /api/timelapse-analysis-save` lacked a run ownership check. Any authenticated user could overwrite another user's saved AI analysis by supplying an arbitrary `instance_id`.

## Fix

Applied the same pattern as notes/overrides (Stage 3C.2/3C.3 from PR #695):

1. Extract `user_id` from `check_auth` — reject `anonymous` explicitly
2. Fetch run record via `get_run_record_by_instance_id(instance_id)`
3. Call `assert_run_write_access(run_record, user_id)` before writing the blob

## Tests Added (`TestTimelapseAnalysisSave`)

- ✅ Rejects unauthenticated requests (401)
- ✅ Rejects anonymous users (401)  
- ✅ Returns 404 for unknown instance_id
- ✅ Returns 403 for non-owner (assert_run_write_access raises)
- ✅ Permits owner and writes blob

## Also

Updated `docs/ROADMAP.md` with a stacked **Execution Order** table — the full PR queue in delivery order so the plan is visible in the doc.

## Checklist

- [x] Tests pass (1590 passed, 28 skipped)
- [x] Lint clean
- [x] No new security issues introduced
- [x] Roadmap updated