### PR TITLE
chore(ci): upgrade Trivy/CodeQL/Node24 action pins and harden deploy readiness gate

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -76,7 +76,7 @@ jobs:
 
       # ── Security scan ──────────────────────────────────────
       - name: Trivy container scan
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ steps.meta.outputs.image_latest }}
           format: sarif
@@ -89,14 +89,14 @@ jobs:
 
       - name: Upload Trivy SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@480db559a14342288b67e54bd959dd52dc3ee68f # v3
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: trivy-base.sarif
           category: trivy-base-image
 
       # ── Push to GHCR ───────────────────────────────────────
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Log in to GHCR (pull base image)
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,15 +29,15 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@480db559a14342288b67e54bd959dd52dc3ee68f # v3
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           languages: ${{ matrix.language }}
           queries: +security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@480db559a14342288b67e54bd959dd52dc3ee68f # v3
+        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@480db559a14342288b67e54bd959dd52dc3ee68f # v3
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,7 +105,7 @@ jobs:
       # ── Normal path: build fresh image ──────────────────────
       - name: Log in to GHCR
         if: ${{ inputs.image_tag == '' }}
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -204,7 +204,7 @@ jobs:
 
       - name: Trivy container scan
         if: ${{ inputs.image_tag == '' }}
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ steps.meta.outputs.image_uri }}
           format: sarif
@@ -216,7 +216,7 @@ jobs:
 
       - name: Upload Trivy image SARIF
         if: ${{ always() && inputs.image_tag == '' }}
-        uses: github/codeql-action/upload-sarif@480db559a14342288b67e54bd959dd52dc3ee68f # v3
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: trivy-image.sarif
           category: trivy-image
@@ -236,19 +236,19 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Azure Login (OIDC)
-        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Setup OpenTofu
-        uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
+        uses: opentofu/setup-opentofu@fc711fa910b93cba0f3fbecaafc9f42fd0c411cb # v2.0.0
         with:
           tofu_version: ${{ env.TOFU_VERSION }}
 
       - name: Cache OpenTofu providers
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: infra/tofu/.terraform/providers
           key: tofu-providers-${{ hashFiles('infra/tofu/.terraform.lock.hcl') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -585,17 +585,30 @@ jobs:
         run: |
           HOSTNAME=$(tofu output -raw function_app_orch_default_hostname)
           BASE_URL="https://${HOSTNAME}"
-          MAX_WAIT=90           # normal startup is <60s; if not up by 90s it's broken
+          MAX_WAIT=300          # container startup + route registration can exceed 90s under cold start
           INTERVAL=5
           elapsed=0
           health_code=0
           ready_code=0
 
+          probe_code() {
+            local url="$1"
+            local code
+            # curl prints 000 on connection errors; avoid `|| echo 000` which can
+            # produce 000000 and obscure diagnostics.
+            code=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 3 --max-time 8 "$url" 2>/dev/null || true)
+            if [[ "$code" =~ ^[0-9]{3}$ ]]; then
+              echo "$code"
+            else
+              echo "000"
+            fi
+          }
+
           echo "Waiting for ${BASE_URL}/api/health to become ready..."
 
           while [ $elapsed -lt $MAX_WAIT ]; do
-            health_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "${BASE_URL}/api/health" 2>/dev/null || echo "000")
-            ready_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "${BASE_URL}/api/readiness" 2>/dev/null || echo "000")
+            health_code=$(probe_code "${BASE_URL}/api/health")
+            ready_code=$(probe_code "${BASE_URL}/api/readiness")
 
             echo "  [${elapsed}s] health=${health_code} readiness=${ready_code}"
 
@@ -630,6 +643,13 @@ jobs:
           echo "  health:    ${health_code}"
           echo "  readiness: ${ready_code}"
           echo "  elapsed:   ${elapsed}s"
+          echo "  hostname:  ${HOSTNAME}"
+          echo ""
+          echo "── DNS lookup ──"
+          getent hosts "${HOSTNAME}" || true
+          echo ""
+          echo "── Final curl diagnostics (/api/health) ──"
+          curl -sv --connect-timeout 5 --max-time 10 "${BASE_URL}/api/health" -o /dev/null 2>&1 | tail -n 40 || true
           echo ""
           echo "This may indicate:"
           echo "  - Container image failed to start (check Container Apps logs)"

--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Azure Login (OIDC)
         id: azure_login
         continue-on-error: true
-        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -80,13 +80,13 @@ jobs:
       # ── OpenTofu plan ──────────────────────────────────────
       - name: Setup OpenTofu
         if: steps.azure_login.outcome == 'success'
-        uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
+        uses: opentofu/setup-opentofu@fc711fa910b93cba0f3fbecaafc9f42fd0c411cb # v2.0.0
         with:
           tofu_version: ${{ env.TOFU_VERSION }}
 
       - name: Cache OpenTofu providers
         if: steps.azure_login.outcome == 'success'
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: infra/tofu/.terraform/providers
           key: tofu-providers-${{ hashFiles('infra/tofu/.terraform.lock.hcl') }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload Semgrep SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@480db559a14342288b67e54bd959dd52dc3ee68f # v3
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: semgrep.sarif
           category: semgrep
@@ -126,7 +126,7 @@ jobs:
 
       - name: Upload pip-audit SARIF
         if: always() && hashFiles('pip-audit.sarif') != ''
-        uses: github/codeql-action/upload-sarif@480db559a14342288b67e54bd959dd52dc3ee68f # v3
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: pip-audit.sarif
           category: pip-audit
@@ -139,7 +139,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Trivy (IaC)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: config
           scan-ref: infra/tofu
@@ -150,7 +150,7 @@ jobs:
 
       - name: Upload Trivy IaC SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@480db559a14342288b67e54bd959dd52dc3ee68f # v3
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: trivy-iac.sarif
           category: trivy-iac
@@ -163,7 +163,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Trivy (filesystem)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -176,7 +176,7 @@ jobs:
 
       - name: Upload Trivy FS SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@480db559a14342288b67e54bd959dd52dc3ee68f # v3
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: trivy-fs.sarif
           category: trivy-fs

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ Update status as work moves. Add new items at the correct priority position,
 not at the bottom.
 
 | # | Issue(s) | PR | Description | Status |
-|---|----------|----|-------------|--------|
+| --- | ---------- | ---- | ------------- | -------- |
 | 1 | #697 + #698 + #550 + #551 | — | chore: CI upgrades — Trivy 0.70, Actions Node 24, CodeQL v4 (bundle) | 🔄 In progress |
 | 2 | #405 | — | fix: reduce config drift (OpenTofu vs az CLI) — Stage 2E.2 | Open |
 | 3 | #402 | — | fix: security-gated production deploys — Stage 2E.3 | Open |
@@ -71,6 +71,14 @@ until scale evidence justifies the added complexity.
 
 **Execution order:** 2C → 2D → 2E → 2F → 2G → 3A → 3B → 3B.5 → 3C → 3 → 4 → 5.
 Stages 2D and 2E can proceed in parallel. Stage 3B.5 is next priority after 3B.
+
+**Policy-watch gate (EUDR amendments):** Treat Parliament/Council alignment notices as directional only.
+Before shipping compliance-interpretation changes, revalidate assumptions against final trilogue text,
+published legal acts, and latest Commission implementation guidance.
+
+**Value focus while rules evolve:** Prioritise low-regret capabilities that remain useful under both
+strict and simplified obligations: evidence provenance, reproducible exports, audit trails, and
+portfolio-level risk visibility.
 
 ---
 
@@ -404,3 +412,4 @@ Execution order note: Stage 3C should also be complete before Stage 4 begins.
 5. **Multi-app platform.** Pipeline is shared; each vertical gets its own URL namespace. Shared concerns (auth, billing, org) go in `/account/` or shared modules.
 6. **Pipeline foundation first.** Stage 2F (#578, #583) before 2G data sources.
 7. **No infrastructure without users.** T2/T3, Container Apps Jobs, ML — deferred until volume justifies it.
+8. **Revalidate legal assumptions.** Before merging EUDR rule-interpretation changes, verify against current final legal text and Commission guidance; if assumptions changed, log a focused issue and update roadmap ordering.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,7 +15,7 @@ not at the bottom.
 
 | # | Issue(s) | PR | Description | Status |
 | --- | ---------- | ---- | ------------- | -------- |
-| 1 | #697 + #698 + #550 + #551 | — | chore: CI upgrades — Trivy 0.70, Actions Node 24, CodeQL v4 (bundle) | 🔄 In progress |
+| 1 | #697 + #698 + #550 + #551 | #706 | chore: CI upgrades — Trivy 0.70, Actions Node 24, CodeQL v4 (bundle) | 🔄 In progress |
 | 2 | #405 | — | fix: reduce config drift (OpenTofu vs az CLI) — Stage 2E.2 | Open |
 | 3 | #402 | — | fix: security-gated production deploys — Stage 2E.3 | Open |
 | 4 | #403 | — | fix: smoke gates + promotion/demotion — Stage 2E.4 | Open |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,27 +15,25 @@ not at the bottom.
 
 | # | Issue(s) | PR | Description | Status |
 |---|----------|----|-------------|--------|
-| 1 | #701 | #702 | fix: remove subscription_item_id from logs — CodeQL taint | 🔄 CI running |
-| 2 | #696 | — | fix: timelapse-analysis-save missing ownership check | 🔄 In progress |
-| 3 | #697 + #698 + #550 + #551 | — | chore: CI upgrades — Trivy 0.70, Actions Node 24, CodeQL v4 (bundle) | Open |
-| 4 | #405 | — | fix: reduce config drift (OpenTofu vs az CLI) — Stage 2E.2 | Open |
-| 5 | #402 | — | fix: security-gated production deploys — Stage 2E.3 | Open |
-| 6 | #403 | — | fix: smoke gates + promotion/demotion — Stage 2E.4 | Open |
-| 7 | #400 | — | feat: pipeline run telemetry — Stage 3.2 | Open |
-| 8 | #399 | — | feat: pipeline ETA estimator (needs #400) — Stage 3.3 | Open |
-| 9 | #78 + #79 | — | feat: temporal catalogue in Cosmos + API (bundle) — Stage 3.4/3.5 | Open |
-| 10 | #437 | — | test: E2E 200+ AOI KMZ scale validation — Stage 3.11 | Open |
-| 11 | #488 | — | perf: pipeline performance optimisation — Stage 3.6 | Open |
-| 12 | #675 | — | feat: DMS/UTM coordinate format support — Stage 3.12 | Open |
-| 13 | #586 | — | feat: per-user AOI imagery reuse + retention — Stage 3.7 | Open |
-| 14 | #679 | — | feat: shareable analysis links — Stage 3.8 | Open |
-| 15 | #618 | — | feat: Brazilian data enrichment (PRODES, DETER, CAR) — Stage 3.9 | Open |
-| 16 | #699 | — | research: supplier valet-token intake (may supersede #676) — Stage 3.14 | Research first |
-| 17 | #676 | — | feat: supplier data collection template — Stage 3.13 | Open (post #699 research) |
-| 18 | #678 | — | feat: country-risk auto-flagging — Stage 3.15 | Open |
-| 19 | #677 | — | feat: commodity tracking per parcel — Stage 3.16 | Open |
-| 20 | #680 | — | feat: GeoJSON/shapefile upload — Stage 3.17 | Open |
-| 21 | #619 | — | eval: Mapbox/Maxar satellite basemap — Stage 3.10 | Open |
+| 1 | #697 + #698 + #550 + #551 | — | chore: CI upgrades — Trivy 0.70, Actions Node 24, CodeQL v4 (bundle) | 🔄 In progress |
+| 2 | #405 | — | fix: reduce config drift (OpenTofu vs az CLI) — Stage 2E.2 | Open |
+| 3 | #402 | — | fix: security-gated production deploys — Stage 2E.3 | Open |
+| 4 | #403 | — | fix: smoke gates + promotion/demotion — Stage 2E.4 | Open |
+| 5 | #400 | — | feat: pipeline run telemetry — Stage 3.2 | Open |
+| 6 | #399 | — | feat: pipeline ETA estimator (needs #400) — Stage 3.3 | Open |
+| 7 | #78 + #79 | — | feat: temporal catalogue in Cosmos + API (bundle) — Stage 3.4/3.5 | Open |
+| 8 | #437 | — | test: E2E 200+ AOI KMZ scale validation — Stage 3.11 | Open |
+| 9 | #488 | — | perf: pipeline performance optimisation — Stage 3.6 | Open |
+| 10 | #675 | — | feat: DMS/UTM coordinate format support — Stage 3.12 | Open |
+| 11 | #586 | — | feat: per-user AOI imagery reuse + retention — Stage 3.7 | Open |
+| 12 | #679 | — | feat: shareable analysis links — Stage 3.8 | Open |
+| 13 | #618 | — | feat: Brazilian data enrichment (PRODES, DETER, CAR) — Stage 3.9 | Open |
+| 14 | #699 | — | research: supplier valet-token intake (may supersede #676) — Stage 3.14 | Research first |
+| 15 | #676 | — | feat: supplier data collection template — Stage 3.13 | Open (post #699 research) |
+| 16 | #678 | — | feat: country-risk auto-flagging — Stage 3.15 | Open |
+| 17 | #677 | — | feat: commodity tracking per parcel — Stage 3.16 | Open |
+| 18 | #680 | — | feat: GeoJSON/shapefile upload — Stage 3.17 | Open |
+| 19 | #619 | — | eval: Mapbox/Maxar satellite basemap — Stage 3.10 | Open |
 
 **Low-priority housekeeping** (bundle with adjacent work, don't schedule separately):
 `#573` CSP wildcards · `#593` Pydantic deprecation · `#625` poll_order refactor ·
@@ -80,14 +78,12 @@ Stages 2D and 2E can proceed in parallel. Stage 3B.5 is next priority after 3B.
 
 | PR | Summary |
 |----|---------|  
+| #703 | fix: enforce run ownership for timelapse save/load and return 503 on run-lookup backend failures (closes #696) |
 | #702 | fix: CodeQL taint chain for subscription_item_id logging — drop si from log messages (closes #701) |
 | #695 | feat: Stage 3C complete — before/after imagery (#671), annotation notes (#669), human override (#672), usage dashboard (#670), aggregated summary export (#674), portfolio dashboard (#673) |
 | #691 | feat: Stage 3B.5 #466 + #688 — Orchestrator/compute image split (PIPELINE_ROLE, Dockerfile.orchestrator, dual-image CI) + monitoring delta fetch + NDVI baseline persistence |
 | #690 | feat: Stage 3B complete — imagery quality gate, provenance contract, dynamic layer picker, defensible PDF (closes #645, #649, #646, #647) |
 | #667 | feat: Stage 3B.0 — Pipeline cost accumulator + resources consumed evidence card (closes #666) |
-| #665 | feat: Stage 3A — EUDR assessment management: entitlement gate, CSV upload, cost estimator, flagged-parcel review (closes #660, #661, #662, #664) |
-| #663 | fix: Subscribe modal hard-wall bug, EUDR entitlement gate on submit, dark theme modal styling |
-| #657 | feat: Stage 2G completion — EUDR metered billing, Landsat deep integration, EUDR content cluster (closes #612, #613, #535, #617) |
 
 ---
 


### PR DESCRIPTION
## Summary\n- Upgrade CI/security workflow action pins for #697 + #698 + #550 + #551\n  - Trivy action to v0.36.0\n  - CodeQL action pins to v4\n  - Node24-compatible action bumps (docker/login-action, azure/login, setup-opentofu, actions/cache)\n- Harden deploy readiness gate diagnostics and startup tolerance\n  - Increase wait budget to 300s\n  - Fix curl probe status parsing on transport failures\n  - Add DNS + verbose probe diagnostics on failure\n- Refresh roadmap queue status in docs/ROADMAP.md\n\n## Validation\n- pre-commit checks on modified workflow and docs files\n- Workflow YAML checks passed\n\n## Issues\n- closes #697\n- closes #698\n- closes #550\n- closes #551\n