### PR TITLE
fix: reduce OpenTofu/CLI config drift contract for Function App (#405)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -478,6 +478,78 @@ jobs:
             --url "${ORCH_ID}?api-version=2024-04-01" \
             --body "$SCALE_BODY"
 
+      - name: Verify Function App config contract
+        id: verify-config-contract
+        working-directory: infra/tofu
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_USE_OIDC: "true"
+        run: |
+          set -euo pipefail
+
+          FUNC_RG=$(tofu output -raw resource_group_name)
+          FUNC_NAME=$(tofu output -raw function_app_name)
+          ORCH_NAME=$(tofu output -raw function_app_orch_name)
+
+          DESIRED_SETTINGS=$(tofu output -json function_app_cli_app_settings)
+
+          verify_settings_subset() {
+            local app_name="$1"
+            local expected_json="$2"
+
+            ACTUAL_SETTINGS_JSON=$(az webapp config appsettings list \
+              --name "$app_name" \
+              --resource-group "$FUNC_RG" \
+              | jq 'map({(.name): .value}) | add')
+
+            MISMATCHES=$(jq -n \
+              --argjson expected "$expected_json" \
+              --argjson actual "$ACTUAL_SETTINGS_JSON" \
+              '[
+                $expected
+                | to_entries[]
+                | select(($actual[.key] // null) != .value)
+                | {key: .key, expected: .value, actual: ($actual[.key] // "<missing>")}
+              ]')
+
+            if [ "$(echo "$MISMATCHES" | jq 'length')" -gt 0 ]; then
+              echo "❌ App settings drift detected for $app_name"
+              echo "$MISMATCHES" | jq '.'
+              exit 1
+            fi
+
+            echo "✅ App settings contract verified for $app_name"
+          }
+
+          verify_container_image() {
+            local app_name="$1"
+            local expected_image="$2"
+
+            ACTUAL_IMAGE=$(az functionapp config container show \
+              --name "$app_name" \
+              --resource-group "$FUNC_RG" \
+              --query '[?name==`DOCKER_CUSTOM_IMAGE_NAME`].value' -o tsv)
+
+            if [ "$ACTUAL_IMAGE" != "$expected_image" ]; then
+              echo "❌ Container image drift for $app_name: expected=$expected_image actual=$ACTUAL_IMAGE"
+              exit 1
+            fi
+
+            echo "✅ Container image contract verified for $app_name"
+          }
+
+          ORCH_SETTINGS=$(jq -n \
+            --argjson base "$DESIRED_SETTINGS" \
+            '$base + {"PIPELINE_ROLE":"orchestrator"}')
+
+          verify_settings_subset "$FUNC_NAME" "$DESIRED_SETTINGS"
+          verify_settings_subset "$ORCH_NAME" "$ORCH_SETTINGS"
+
+          verify_container_image "$FUNC_NAME" "${{ needs.build-image.outputs.image_uri }}"
+          verify_container_image "$ORCH_NAME" "${{ needs.build-image.outputs.orch_image_uri }}"
+
       - name: Verify browser CORS contract
         id: verify-browser-cors
         working-directory: infra/tofu

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -511,11 +511,15 @@ jobs:
                 $expected
                 | to_entries[]
                 | select(($actual[.key] // null) != .value)
-                | {key: .key, expected: .value, actual: ($actual[.key] // "<missing>")}
+                | {
+                    key: .key,
+                    status: (if ($actual[.key] // null) == null then "missing" else "different" end)
+                  }
               ]')
 
             if [ "$(echo "$MISMATCHES" | jq 'length')" -gt 0 ]; then
               echo "❌ App settings drift detected for $app_name"
+              echo "Drifted keys (values redacted):"
               echo "$MISMATCHES" | jq '.'
               exit 1
             fi
@@ -526,14 +530,20 @@ jobs:
           verify_container_image() {
             local app_name="$1"
             local expected_image="$2"
+            local actual_linux_fx_version
+            local normalized_actual_image
+            local normalized_expected_image
 
-            ACTUAL_IMAGE=$(az functionapp config container show \
+            actual_linux_fx_version=$(az functionapp show \
               --name "$app_name" \
               --resource-group "$FUNC_RG" \
-              --query '[?name==`DOCKER_CUSTOM_IMAGE_NAME`].value' -o tsv)
+              --query 'siteConfig.linuxFxVersion' -o tsv)
 
-            if [ "$ACTUAL_IMAGE" != "$expected_image" ]; then
-              echo "❌ Container image drift for $app_name: expected=$expected_image actual=$ACTUAL_IMAGE"
+            normalized_actual_image="${actual_linux_fx_version#DOCKER|}"
+            normalized_expected_image="${expected_image#DOCKER|}"
+
+            if [ "$normalized_actual_image" != "$normalized_expected_image" ]; then
+              echo "❌ Container image drift for $app_name: expected=$expected_image actual=$actual_linux_fx_version"
               exit 1
             fi
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -133,7 +133,7 @@ Build once, promote dev → prod.
 | Order | Issue | Title | Status |
 |-------|-------|-------|--------|
 | 2E.1 | #401 | Separate dev and prod deployment flows | ✅ Closed |
-| 2E.2 | #405 | Reduce config drift (OpenTofu vs az CLI) | Open |
+| 2E.2 | #405 | Reduce config drift (OpenTofu vs az CLI) | 🔄 In progress |
 | 2E.3 | #402 | Security-gated production deploys | Open |
 | 2E.4 | #403 | Smoke gates, promotion/demotion | Open |
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,25 +15,24 @@ not at the bottom.
 
 | # | Issue(s) | PR | Description | Status |
 | --- | ---------- | ---- | ------------- | -------- |
-| 1 | #697 + #698 + #550 + #551 | #706 | chore: CI upgrades — Trivy 0.70, Actions Node 24, CodeQL v4 (bundle) | 🔄 In progress |
-| 2 | #405 | — | fix: reduce config drift (OpenTofu vs az CLI) — Stage 2E.2 | Open |
-| 3 | #402 | — | fix: security-gated production deploys — Stage 2E.3 | Open |
-| 4 | #403 | — | fix: smoke gates + promotion/demotion — Stage 2E.4 | Open |
-| 5 | #400 | — | feat: pipeline run telemetry — Stage 3.2 | Open |
-| 6 | #399 | — | feat: pipeline ETA estimator (needs #400) — Stage 3.3 | Open |
-| 7 | #78 + #79 | — | feat: temporal catalogue in Cosmos + API (bundle) — Stage 3.4/3.5 | Open |
-| 8 | #437 | — | test: E2E 200+ AOI KMZ scale validation — Stage 3.11 | Open |
-| 9 | #488 | — | perf: pipeline performance optimisation — Stage 3.6 | Open |
-| 10 | #675 | — | feat: DMS/UTM coordinate format support — Stage 3.12 | Open |
-| 11 | #586 | — | feat: per-user AOI imagery reuse + retention — Stage 3.7 | Open |
-| 12 | #679 | — | feat: shareable analysis links — Stage 3.8 | Open |
-| 13 | #618 | — | feat: Brazilian data enrichment (PRODES, DETER, CAR) — Stage 3.9 | Open |
-| 14 | #699 | — | research: supplier valet-token intake (may supersede #676) — Stage 3.14 | Research first |
-| 15 | #676 | — | feat: supplier data collection template — Stage 3.13 | Open (post #699 research) |
-| 16 | #678 | — | feat: country-risk auto-flagging — Stage 3.15 | Open |
-| 17 | #677 | — | feat: commodity tracking per parcel — Stage 3.16 | Open |
-| 18 | #680 | — | feat: GeoJSON/shapefile upload — Stage 3.17 | Open |
-| 19 | #619 | — | eval: Mapbox/Maxar satellite basemap — Stage 3.10 | Open |
+| 1 | #405 | — | fix: reduce config drift (OpenTofu vs az CLI) — Stage 2E.2 | 🔄 In progress |
+| 2 | #402 | — | fix: security-gated production deploys — Stage 2E.3 | Open |
+| 3 | #403 | — | fix: smoke gates + promotion/demotion — Stage 2E.4 | Open |
+| 4 | #400 | — | feat: pipeline run telemetry — Stage 3.2 | Open |
+| 5 | #399 | — | feat: pipeline ETA estimator (needs #400) — Stage 3.3 | Open |
+| 6 | #78 + #79 | — | feat: temporal catalogue in Cosmos + API (bundle) — Stage 3.4/3.5 | Open |
+| 7 | #437 | — | test: E2E 200+ AOI KMZ scale validation — Stage 3.11 | Open |
+| 8 | #488 | — | perf: pipeline performance optimisation — Stage 3.6 | Open |
+| 9 | #675 | — | feat: DMS/UTM coordinate format support — Stage 3.12 | Open |
+| 10 | #586 | — | feat: per-user AOI imagery reuse + retention — Stage 3.7 | Open |
+| 11 | #679 | — | feat: shareable analysis links — Stage 3.8 | Open |
+| 12 | #618 | — | feat: Brazilian data enrichment (PRODES, DETER, CAR) — Stage 3.9 | Open |
+| 13 | #699 | — | research: supplier valet-token intake (may supersede #676) — Stage 3.14 | Research first |
+| 14 | #676 | — | feat: supplier data collection template — Stage 3.13 | Open (post #699 research) |
+| 15 | #678 | — | feat: country-risk auto-flagging — Stage 3.15 | Open |
+| 16 | #677 | — | feat: commodity tracking per parcel — Stage 3.16 | Open |
+| 17 | #680 | — | feat: GeoJSON/shapefile upload — Stage 3.17 | Open |
+| 18 | #619 | — | eval: Mapbox/Maxar satellite basemap — Stage 3.10 | Open |
 
 **Low-priority housekeeping** (bundle with adjacent work, don't schedule separately):
 `#573` CSP wildcards · `#593` Pydantic deprecation · `#625` poll_order refactor ·
@@ -86,12 +85,12 @@ portfolio-level risk visibility.
 
 | PR | Summary |
 |----|---------|  
+| #706 | chore: CI/security release-safety hardening — action pin upgrades (Trivy, CodeQL v4, Node24-compatible actions) + deploy readiness gate diagnostics/timeout hardening (closes #697, #698, #550, #551) |
 | #703 | fix: enforce run ownership for timelapse save/load and return 503 on run-lookup backend failures (closes #696) |
 | #702 | fix: CodeQL taint chain for subscription_item_id logging — drop si from log messages (closes #701) |
 | #695 | feat: Stage 3C complete — before/after imagery (#671), annotation notes (#669), human override (#672), usage dashboard (#670), aggregated summary export (#674), portfolio dashboard (#673) |
 | #691 | feat: Stage 3B.5 #466 + #688 — Orchestrator/compute image split (PIPELINE_ROLE, Dockerfile.orchestrator, dual-image CI) + monitoring delta fetch + NDVI baseline persistence |
 | #690 | feat: Stage 3B complete — imagery quality gate, provenance contract, dynamic layer picker, defensible PDF (closes #645, #649, #646, #647) |
-| #667 | feat: Stage 3B.0 — Pipeline cost accumulator + resources consumed evidence card (closes #666) |
 
 ---
 

--- a/infra/tofu/README.md
+++ b/infra/tofu/README.md
@@ -79,6 +79,7 @@ Supporting helpers:
 
 - Function App on Container Apps and the Event Grid system topic are created via `azapi` resources for parity with current ARM/Bicep behavior.
 - While the azapi identity-update bug remains, mutable Function App settings are applied via CLI from Terraform outputs so `infra/tofu` stays the single source of truth instead of the workflow reparsing tfvars.
+- The deploy workflow verifies the live Function App contract after CLI mutation (app settings + container image) against OpenTofu outputs and fails fast on mismatch to surface drift in CI/review.
 - The deploy workflow owns Event Grid webhook subscription reconciliation because it can verify host readiness, trigger indexing, and current webhook keys before making the subscription live.
 - `enable_event_grid_subscription` defaults to `false` to avoid OpenTofu racing runtime indexing or publishing a stale webhook key.
 - OpenTofu references Stripe secrets by stable Key Vault secret names only. The actual Stripe values are bootstrap/operator-managed by the setup scripts and must not be passed through tfvars or Terraform variables.


### PR DESCRIPTION
## Summary
Implements a concrete Stage 2E.2 slice for #405 by tightening the ownership contract between OpenTofu outputs and deploy-time CLI patching.

### Changes
- Deploy workflow: add explicit post-mutation config contract verification for both compute and orchestrator Function Apps:
  - app settings subset must match tofu output JSON for CLI-managed settings (plus PIPELINE_ROLE=orchestrator for orchestrator app)
  - container image must match expected image URIs from build job outputs
  - fail fast when drift is detected
- Infra docs: document deploy-time contract verification in infra/tofu/README.md.
- Roadmap: mark #706 as landed and advance #405 to in progress at top of execution queue.

## Why
This reduces split-brain risk while azapi body updates remain ignored due the identity bug. It keeps OpenTofu as source-of-truth and makes drift detectable in CI/review instead of only at runtime.

## Validation
- pre-commit hooks passed for modified files
- workflow lint and yaml checks passed

Closes #405
