### PR TITLE
infra: remediate Trivy AZU-0060 with Storage CMK (Key Vault)

### DIFF
--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -34,6 +34,21 @@ resource "azurerm_storage_account" "main" {
       max_age_in_seconds = 3600
     }
   }
+
+  identity {
+    type         = "SystemAssigned, UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.storage_cmk.id]
+  }
+
+  customer_managed_key {
+    key_vault_key_id          = azurerm_key_vault_key.storage_cmk.id
+    user_assigned_identity_id = azurerm_user_assigned_identity.storage_cmk.id
+  }
+
+  depends_on = [
+    azurerm_role_assignment.storage_cmk_kv_crypto_user,
+  ]
+
   tags = local.tags
 }
 
@@ -326,6 +341,35 @@ resource "azurerm_key_vault" "main" {
   tags                          = local.tags
 }
 
+resource "azurerm_user_assigned_identity" "storage_cmk" {
+  name                = "id-${local.name_suffix}-storage-cmk"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  tags                = local.tags
+}
+
+resource "azurerm_key_vault_key" "storage_cmk" {
+  name         = "cmk-storage-${local.name_suffix}"
+  key_vault_id = azurerm_key_vault.main.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+  tags = local.tags
+}
+
+resource "azurerm_role_assignment" "storage_cmk_kv_crypto_user" {
+  scope                = azurerm_key_vault.main.id
+  role_definition_name = "Key Vault Crypto Service Encryption User"
+  principal_id         = azurerm_user_assigned_identity.storage_cmk.principal_id
+}
+
 # --- Azure Communication Services Email ---
 
 resource "azurerm_communication_service" "main" {
@@ -431,7 +475,7 @@ resource "azurerm_cosmosdb_account" "main" {
   # Container Apps has no static egress IPs / VNet integration yet.
   # Add VNet + private endpoint when user volume justifies the cost.
   local_authentication_disabled         = true
-  public_network_access_enabled         = var.cosmos_public_network_access  # fixes #640
+  public_network_access_enabled         = var.cosmos_public_network_access # fixes #640
   minimal_tls_version                   = "Tls12"
   network_acl_bypass_for_azure_services = true
 }

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -36,12 +36,12 @@ resource "azurerm_storage_account" "main" {
   }
 
   identity {
-    type         = "SystemAssigned, UserAssigned"
+    type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.storage_cmk.id]
   }
 
   customer_managed_key {
-    key_vault_key_id          = azurerm_key_vault_key.storage_cmk.id
+    key_vault_key_id          = azurerm_key_vault_key.storage_cmk.versionless_id
     user_assigned_identity_id = azurerm_user_assigned_identity.storage_cmk.id
   }
 
@@ -354,18 +354,14 @@ resource "azurerm_key_vault_key" "storage_cmk" {
   key_type     = "RSA"
   key_size     = 2048
   key_opts = [
-    "decrypt",
-    "encrypt",
-    "sign",
     "unwrapKey",
-    "verify",
     "wrapKey",
   ]
   tags = local.tags
 }
 
 resource "azurerm_role_assignment" "storage_cmk_kv_crypto_user" {
-  scope                = azurerm_key_vault.main.id
+  scope                = azurerm_key_vault_key.storage_cmk.resource_versionless_id
   role_definition_name = "Key Vault Crypto Service Encryption User"
   principal_id         = azurerm_user_assigned_identity.storage_cmk.principal_id
 }


### PR DESCRIPTION
## Summary
- enable customer-managed key encryption for azurerm_storage_account.main
- add a dedicated user-assigned identity for storage CMK operations
- add Key Vault key and grant Key Vault Crypto Service Encryption User role to that identity
- wire storage account customer_managed_key to Key Vault key and identity

## Why
- addresses GitHub code scanning Trivy alert #2890 (AZU-0060: Storage account should use customer-managed keys for encryption)

## Validation
- tofu fmt -check ✅
- tofu validate ✅
- trivy config infra/tofu --include-non-failures reports AZU-0060 PASS ✅
- ruff check . ✅
- ruff format --check . ✅
- make test ✅ (1620 passed, 1 skipped, 27 deselected)

## Risk
- storage account change is in-place on plan (~ update in-place)
- additive resources: user-assigned identity, key vault key, role assignment
