### PR TITLE
security(trivy): handle CVE-2026-40894 host finding

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -28,6 +28,7 @@ AVD-AZU-0061 # exp:2026-07-09 false positive — attribute already set
 CVE-2026-25679 # exp:2026-05-09 Go stdlib in Functions host — tracking upstream
 CVE-2026-27139 # exp:2026-05-09 Go stdlib in Functions host — tracking upstream
 CVE-2026-27142 # exp:2026-05-09 Go stdlib in Functions host — tracking upstream
+CVE-2026-40894 # exp:2026-05-24 OpenTelemetry.Api in Functions host — fixed upstream in 1.15.3
 
 # libpng16-16: fix version 1.6.39-2+deb12u4 not yet in Debian bookworm mirrors.
 # apt-get upgrade cannot pull what the mirror doesn't have yet.


### PR DESCRIPTION
## Summary
- add temporary .trivyignore entry for CVE-2026-40894

## Why
Deploy started failing on Trivy image scan for a new host-level vulnerability in Azure Functions host dependencies (OpenTelemetry.Api 1.12.0, fixed upstream in 1.15.3). This is in the Microsoft Functions host layer, not app code.

## Safety
- strict Trivy blocking remains enabled
- this is a single time-boxed exception with expiry
- remove once upstream base/host image includes patched dependency
