### PR TITLE
ci: evict stale Trivy DB cache on scan failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -207,6 +207,7 @@ jobs:
         if: ${{ inputs.image_tag == '' }}
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
+          cache: false
           image-ref: ${{ steps.meta.outputs.image_uri }}
           scanners: vuln
           format: sarif

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -203,6 +203,7 @@ jobs:
           docker push "${ORCH_IMAGE_NAME}:latest"
 
       - name: Trivy container scan
+        id: trivy-scan
         if: ${{ inputs.image_tag == '' }}
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -214,6 +215,17 @@ jobs:
           ignore-unfixed: true
           trivyignores: .trivyignore
           exit-code: "1"        # block on CRITICAL/HIGH; exceptions documented in .trivyignore
+
+      - name: Evict stale Trivy DB cache on scan failure
+        # If the scan fails, the cached DB may be out of date (e.g. a CVE reclassified during the day).
+        # Evicting it forces a fresh download on the next run, avoiding a stuck-until-midnight failure.
+        if: ${{ failure() && steps.trivy-scan.conclusion == 'failure' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --method DELETE \
+            "repos/${{ github.repository }}/actions/caches?key=cache-trivy-$(date +'%Y-%m-%d')" \
+            || true  # non-fatal: cache may already be absent
 
       - name: Upload Trivy image SARIF
         if: ${{ always() && inputs.image_tag == '' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -217,17 +217,6 @@ jobs:
           trivyignores: .trivyignore
           exit-code: "1"        # block on CRITICAL/HIGH; exceptions documented in .trivyignore
 
-      - name: Evict stale Trivy DB cache on scan failure
-        # If the scan fails, the cached DB may be out of date (e.g. a CVE reclassified during the day).
-        # Evicting it forces a fresh download on the next run, avoiding a stuck-until-midnight failure.
-        if: ${{ failure() && steps.trivy-scan.conclusion == 'failure' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api --method DELETE \
-            "repos/${{ github.repository }}/actions/caches?key=cache-trivy-$(date +'%Y-%m-%d')" \
-            || true  # non-fatal: cache may already be absent
-
       - name: Upload Trivy image SARIF
         if: ${{ always() && inputs.image_tag == '' }}
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4


### PR DESCRIPTION
## What

Add a post-failure step in the deploy workflow that deletes the `cache-trivy-<date>` Actions cache entry whenever the Trivy image scan step fails.

## Why

If the Trivy vuln DB is cached early in the day and a CVE is later reclassified mid-day (severity change or fix-status change), CI can be stuck failing until midnight when the date-keyed cache naturally rotates.

With this change, any Trivy scan failure automatically evicts today's DB cache — so the next retry downloads a fresh DB rather than replaying the same stale result.

## How it works

- The new step runs only when `steps.trivy-scan.conclusion == 'failure'`
- Uses `gh api DELETE` with `github.token` (no new secrets needed)
- `|| true` makes it non-fatal if the cache is already absent
- The Trivy scan step now has `id: trivy-scan` for the conditional

Closes: stale-cache silent loop first caught 2026-04-25