### PR TITLE
fix(infra): pin CMK key management to deploy principal

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -256,6 +256,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-image
     environment: ${{ github.event.inputs.environment || 'dev' }}
+    env:
+      TF_VAR_deploy_principal_client_id: ${{ secrets.AZURE_CLIENT_ID }}
     outputs:
       function_app_hostname: ${{ steps.hostname.outputs.hostname }}
       appinsights_connection_string: ${{ steps.appinsights.outputs.connection_string }}

--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -39,6 +39,8 @@ jobs:
     name: Cost Estimate
     runs-on: ubuntu-latest
     environment: dev
+    env:
+      TF_VAR_deploy_principal_client_id: ${{ secrets.AZURE_CLIENT_ID }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -101,11 +103,24 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           ARM_USE_OIDC: "true"
         run: |
-          tofu init \
-            -backend-config="resource_group_name=${{ secrets.TF_STATE_RESOURCE_GROUP }}" \
-            -backend-config="storage_account_name=${{ secrets.TF_STATE_STORAGE_ACCOUNT }}" \
-            -backend-config="container_name=${{ secrets.TF_STATE_CONTAINER_DEV }}" \
-            -backend-config="key=${{ secrets.TF_STATE_KEY_DEV }}"
+          MAX_RETRIES=3
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            echo "tofu init attempt ${attempt}/${MAX_RETRIES}"
+            if tofu init \
+              -backend-config="resource_group_name=${{ secrets.TF_STATE_RESOURCE_GROUP }}" \
+              -backend-config="storage_account_name=${{ secrets.TF_STATE_STORAGE_ACCOUNT }}" \
+              -backend-config="container_name=${{ secrets.TF_STATE_CONTAINER_DEV }}" \
+              -backend-config="key=${{ secrets.TF_STATE_KEY_DEV }}"; then
+              echo "✅ tofu init succeeded on attempt ${attempt}"
+              exit 0
+            fi
+            if [ "$attempt" -lt "$MAX_RETRIES" ]; then
+              echo "⚠️ tofu init failed, retrying in 10s..."
+              sleep 10
+            fi
+          done
+          echo "❌ tofu init failed after ${MAX_RETRIES} attempts"
+          exit 1
 
       - name: Tofu Plan (JSON)
         if: steps.azure_login.outcome == 'success'
@@ -118,6 +133,7 @@ jobs:
         run: |
           tofu plan -out=tfplan \
             -var="subscription_id=${{ secrets.AZURE_SUBSCRIPTION_ID }}" \
+            -var="deploy_principal_client_id=${{ secrets.AZURE_CLIENT_ID }}" \
             -var-file="environments/dev.tfvars"
           tofu show -json tfplan > plan.json
 

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -29,6 +29,12 @@ Issue: #18
 7. `/api/analysis/submit` must reject unauthenticated callers before any upload or orchestration work begins.
 8. For direct `analysis/` uploads created by `/api/analysis/submit`, rely on the HTTP submission path as the authoritative orchestration start; BlobCreated automation should only start storage-native uploads outside that prefix.
 
+CMK deploy note (dev and prod):
+
+- Storage Account CMK rollout requires the configured GitHub Actions OIDC deploy principal to hold `Key Vault Crypto Officer` on the vault so OpenTofu can manage the CMK key lifecycle.
+- CMK authoring is pinned to that explicit deploy principal; local applies must authenticate as the same principal instead of relying on the caller's personal identity.
+- The infra stack assigns that role and waits for RBAC propagation before managing the key to avoid `ForbiddenByRbac` failures during `tofu apply`.
+
 Reference: .github/workflows/deploy.yml and infra/tofu/README.md.
 
 ## Access Model

--- a/infra/tofu/.terraform.lock.hcl
+++ b/infra/tofu/.terraform.lock.hcl
@@ -61,3 +61,21 @@ provider "registry.opentofu.org/hashicorp/random" {
     "zh:f56e26e6977f755d7ae56fa6320af96ecf4bb09580d47cb481efbf27f1c5afff",
   ]
 }
+
+provider "registry.opentofu.org/hashicorp/time" {
+  version     = "0.13.1"
+  constraints = "~> 0.13"
+  hashes = [
+    "h1:ueilLAoXlZPufdJYuPFeqznwP39ZwLsRcQtqow+NUiI=",
+    "zh:10f32af8b544a039f19abd546e345d056a55cb7bdd69d5bbd7322cbc86883848",
+    "zh:35dd5beb34a9f73de8d0fed332814c69acae69397c9c065ce63ccd8315442bef",
+    "zh:56545d1dd5f2e7262e0c0c124264974229ec9cc234d0d7a0e36e14b869590f4a",
+    "zh:8d7259c3f819fd3470ff933c904b6a549502a8351feb1b5c040a4560decaf7e0",
+    "zh:a40f26878826b142e26fe193f7e3e14fc97f615cd6af140e88ce5bc25f3fcf50",
+    "zh:b2e82f25fecff172a9a9e24ea37d37e4fc630ee9245617cb40b10e66a6b979c8",
+    "zh:d4b699850a40ed07ef83c6b827605d24050b2732646ee017bda278e4ddf01c91",
+    "zh:e4e6a5e5614b6a54557400aabb748ebd57e947cdbd21ad1c7602c51368a80559",
+    "zh:eb78fb97bca22931e730487a20a90f5a6221ddfb3138aaf070737ea2b7c9c885",
+    "zh:faba366a1352ee679bba2a5b09c073c6854721db94b191d49b620b60946a065f",
+  ]
+}

--- a/infra/tofu/README.md
+++ b/infra/tofu/README.md
@@ -37,6 +37,8 @@ The script creates:
 - Entra app registration + service principal
 - federated credentials for `dev` and `prd` GitHub environments
 
+Use that same GitHub Actions app registration client ID as `deploy_principal_client_id` whenever OpenTofu needs to manage CMK-backed storage resources.
+
 ## Required GitHub Environment Secrets
 
 Configure for each environment (`dev`, `prd`):
@@ -58,8 +60,8 @@ tofu init \
   -backend-config="container_name=<TF_STATE_CONTAINER>" \
   -backend-config="key=kml-satellite-dev.tfstate"
 
-tofu plan -var "subscription_id=<SUBSCRIPTION_ID>" -var-file="environments/dev.tfvars"
-tofu apply -var "subscription_id=<SUBSCRIPTION_ID>" -var-file="environments/dev.tfvars"
+tofu plan -var "subscription_id=<SUBSCRIPTION_ID>" -var "deploy_principal_client_id=<AZURE_CLIENT_ID>" -var-file="environments/dev.tfvars"
+tofu apply -var "subscription_id=<SUBSCRIPTION_ID>" -var "deploy_principal_client_id=<AZURE_CLIENT_ID>" -var-file="environments/dev.tfvars"
 ```
 
 ## Clean-Slate Migration Sequence (dev)

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -348,6 +348,27 @@ resource "azurerm_user_assigned_identity" "storage_cmk" {
   tags                = local.tags
 }
 
+resource "azurerm_role_assignment" "deployer_key_vault_crypto_officer" {
+  scope                = azurerm_key_vault.main.id
+  role_definition_name = "Key Vault Crypto Officer"
+  principal_id         = data.azurerm_client_config.current.object_id
+
+  lifecycle {
+    precondition {
+      condition     = data.azurerm_client_config.current.client_id == var.deploy_principal_client_id
+      error_message = "Authenticate OpenTofu as the configured deploy principal before managing the storage CMK key."
+    }
+  }
+}
+
+resource "time_sleep" "deployer_key_vault_crypto_officer_propagation" {
+  create_duration = "60s"
+
+  depends_on = [
+    azurerm_role_assignment.deployer_key_vault_crypto_officer,
+  ]
+}
+
 resource "azurerm_key_vault_key" "storage_cmk" {
   name            = "cmk-storage-${local.name_suffix}"
   key_vault_id    = azurerm_key_vault.main.id
@@ -369,6 +390,10 @@ resource "azurerm_key_vault_key" "storage_cmk" {
     "wrapKey",
   ]
   tags = local.tags
+
+  depends_on = [
+    time_sleep.deployer_key_vault_crypto_officer_propagation,
+  ]
 }
 
 resource "azurerm_role_assignment" "storage_cmk_kv_crypto_user" {

--- a/infra/tofu/variables.tf
+++ b/infra/tofu/variables.tf
@@ -3,6 +3,11 @@ variable "subscription_id" {
   type        = string
 }
 
+variable "deploy_principal_client_id" {
+  description = "Azure client ID for the GitHub Actions OIDC deploy principal that is allowed to manage CMK keys."
+  type        = string
+}
+
 variable "location" {
   description = "Azure region for deployment."
   type        = string

--- a/infra/tofu/versions.tf
+++ b/infra/tofu/versions.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.13"
+    }
   }
 
   backend "azurerm" {}


### PR DESCRIPTION
## Summary
- grant the GitHub Actions OIDC deploy principal Key Vault Crypto Officer on the vault before CMK key management
- require OpenTofu to run as that explicit deploy principal when managing the storage CMK key
- wait for RBAC propagation and document the CMK deploy requirement in the workflow and runbooks

## Validation
- tofu init -backend=false
- tofu validate

Fixes #721