### PR TITLE
feat(infra): wire CIAM auth-mode env and fail-fast guardrails (#709)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -258,6 +258,10 @@ jobs:
     environment: ${{ github.event.inputs.environment || 'dev' }}
     env:
       TF_VAR_deploy_principal_client_id: ${{ secrets.AZURE_CLIENT_ID }}
+      TF_VAR_auth_mode: ${{ secrets.TF_VAR_AUTH_MODE || 'legacy_principal' }}
+      TF_VAR_ciam_authority: ${{ secrets.TF_VAR_CIAM_AUTHORITY || '' }}
+      TF_VAR_ciam_tenant_id: ${{ secrets.TF_VAR_CIAM_TENANT_ID || '' }}
+      TF_VAR_ciam_api_audience: ${{ secrets.TF_VAR_CIAM_API_AUDIENCE || '' }}
     outputs:
       function_app_hostname: ${{ steps.hostname.outputs.hostname }}
       appinsights_connection_string: ${{ steps.appinsights.outputs.connection_string }}
@@ -277,6 +281,34 @@ jobs:
         uses: opentofu/setup-opentofu@fc711fa910b93cba0f3fbecaafc9f42fd0c411cb # v2.0.0
         with:
           tofu_version: ${{ env.TOFU_VERSION }}
+
+      - name: Validate CIAM auth env wiring
+        shell: bash
+        run: |
+          trim_space() {
+            local value="${1-}"
+            value="${value#"${value%%[![:space:]]*}"}"
+            value="${value%"${value##*[![:space:]]}"}"
+            printf '%s' "$value"
+          }
+          set -euo pipefail
+          mode="${TF_VAR_auth_mode:-legacy_principal}"
+          case "$mode" in
+            legacy_principal) ;;
+            dual|bearer_only)
+              ciam_authority="$(trim_space "${TF_VAR_ciam_authority:-}")"
+              ciam_tenant_id="$(trim_space "${TF_VAR_ciam_tenant_id:-}")"
+              ciam_api_audience="$(trim_space "${TF_VAR_ciam_api_audience:-}")"
+              if [[ -z "$ciam_authority" || -z "$ciam_tenant_id" || -z "$ciam_api_audience" ]]; then
+                echo "CIAM auth misconfigured: TF_VAR_auth_mode=${mode} requires TF_VAR_ciam_authority, TF_VAR_ciam_tenant_id, and TF_VAR_ciam_api_audience."
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Invalid TF_VAR_auth_mode='${mode}'. Expected legacy_principal, dual, or bearer_only."
+              exit 1
+              ;;
+          esac
 
       - name: Cache OpenTofu providers
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -41,6 +41,10 @@ jobs:
     environment: dev
     env:
       TF_VAR_deploy_principal_client_id: ${{ secrets.AZURE_CLIENT_ID }}
+      TF_VAR_auth_mode: ${{ secrets.TF_VAR_AUTH_MODE || 'legacy_principal' }}
+      TF_VAR_ciam_authority: ${{ secrets.TF_VAR_CIAM_AUTHORITY || '' }}
+      TF_VAR_ciam_tenant_id: ${{ secrets.TF_VAR_CIAM_TENANT_ID || '' }}
+      TF_VAR_ciam_api_audience: ${{ secrets.TF_VAR_CIAM_API_AUDIENCE || '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -85,6 +89,35 @@ jobs:
         uses: opentofu/setup-opentofu@fc711fa910b93cba0f3fbecaafc9f42fd0c411cb # v2.0.0
         with:
           tofu_version: ${{ env.TOFU_VERSION }}
+
+      - name: Validate CIAM auth env wiring
+        if: steps.azure_login.outcome == 'success'
+        shell: bash
+        run: |
+          trim_space() {
+            local value="${1-}"
+            value="${value#"${value%%[![:space:]]*}"}"
+            value="${value%"${value##*[![:space:]]}"}"
+            printf '%s' "$value"
+          }
+          set -euo pipefail
+          mode="${TF_VAR_auth_mode:-legacy_principal}"
+          case "$mode" in
+            legacy_principal) ;;
+            dual|bearer_only)
+              ciam_authority="$(trim_space "${TF_VAR_ciam_authority:-}")"
+              ciam_tenant_id="$(trim_space "${TF_VAR_ciam_tenant_id:-}")"
+              ciam_api_audience="$(trim_space "${TF_VAR_ciam_api_audience:-}")"
+              if [[ -z "$ciam_authority" || -z "$ciam_tenant_id" || -z "$ciam_api_audience" ]]; then
+                echo "CIAM auth misconfigured: TF_VAR_auth_mode=${mode} requires TF_VAR_ciam_authority, TF_VAR_ciam_tenant_id, and TF_VAR_ciam_api_audience."
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Invalid TF_VAR_auth_mode='${mode}'. Expected legacy_principal, dual, or bearer_only."
+              exit 1
+              ;;
+          esac
 
       - name: Cache OpenTofu providers
         if: steps.azure_login.outcome == 'success'

--- a/infra/tofu/README.md
+++ b/infra/tofu/README.md
@@ -51,6 +51,18 @@ Configure for each environment (`dev`, `prd`):
 - `TF_STATE_CONTAINER`
 - `TF_STATE_KEY`
 
+## Optional GitHub Environment Secrets (CIAM/Bearer Token Auth — Issue #709)
+
+To enable CIAM bearer-token authentication, configure:
+
+- `TF_VAR_AUTH_MODE` — Auth transition mode: `legacy_principal` (default, SWA headers only), `dual` (both paths), or `bearer_only` (JWT only)
+- `TF_VAR_CIAM_AUTHORITY` — Azure Entra CIAM authority endpoint (required if `auth_mode` is `dual` or `bearer_only`)
+- `TF_VAR_CIAM_TENANT_ID` — Azure Entra tenant ID for CIAM app registration (required if `auth_mode` is `dual` or `bearer_only`)
+- `TF_VAR_CIAM_API_AUDIENCE` — API audience (app ID URI) from CIAM app registration (required if `auth_mode` is `dual` or `bearer_only`)
+
+The Function App will validate that CIAM settings are consistent: if `auth_mode=dual` or `auth_mode=bearer_only`, all three CIAM variables must be set.
+`auth_mode=bearer_only` should be enabled only after frontend bearer-token support is deployed (tracked separately in issue #710); until then use `legacy_principal` or `dual`.
+
 ## Local Usage
 
 ```bash
@@ -60,7 +72,22 @@ tofu init \
   -backend-config="container_name=<TF_STATE_CONTAINER>" \
   -backend-config="key=kml-satellite-dev.tfstate"
 
-tofu plan -var "subscription_id=<SUBSCRIPTION_ID>" -var "deploy_principal_client_id=<AZURE_CLIENT_ID>" -var-file="environments/dev.tfvars"
+# Default (legacy SWA auth)
+tofu plan \
+  -var "subscription_id=<SUBSCRIPTION_ID>" \
+  -var "deploy_principal_client_id=<AZURE_CLIENT_ID>" \
+  -var-file="environments/dev.tfvars"
+
+# With CIAM bearer-token auth (dual mode)
+tofu plan \
+  -var "subscription_id=<SUBSCRIPTION_ID>" \
+  -var "deploy_principal_client_id=<AZURE_CLIENT_ID>" \
+  -var "auth_mode=dual" \
+  -var "ciam_authority=https://login.microsoftonline.com/<TENANT_ID>" \
+  -var "ciam_tenant_id=<TENANT_ID>" \
+  -var "ciam_api_audience=<API_APP_ID_URI>" \
+  -var-file="environments/dev.tfvars"
+
 tofu apply -var "subscription_id=<SUBSCRIPTION_ID>" -var "deploy_principal_client_id=<AZURE_CLIENT_ID>" -var-file="environments/dev.tfvars"
 ```
 

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -1177,11 +1177,17 @@ locals {
       CORS_ALLOWED_ORIGINS                = join(",", local.browser_allowed_origins)
       PRIMARY_SITE_URL                    = local.primary_site_url
       REQUIRE_AUTH                        = "true"
+      AUTH_MODE                           = var.auth_mode
       OPS_DASHBOARD_KEY                   = var.ops_dashboard_key
     },
     var.enable_cosmos_db ? {
       COSMOS_ENDPOINT      = azurerm_cosmosdb_account.main[0].endpoint
       COSMOS_DATABASE_NAME = azurerm_cosmosdb_sql_database.main[0].name
+    } : {},
+    var.auth_mode != "legacy_principal" ? {
+      CIAM_AUTHORITY     = var.ciam_authority
+      CIAM_TENANT_ID     = var.ciam_tenant_id
+      CIAM_API_AUDIENCE  = var.ciam_api_audience
     } : {}
   )
 

--- a/infra/tofu/variables.tf
+++ b/infra/tofu/variables.tf
@@ -191,3 +191,37 @@ variable "notification_email" {
   type        = string
   default     = ""
 }
+
+# --- CIAM / Bearer Token Auth (Issue #709) ---
+
+variable "auth_mode" {
+  description = "Auth transition mode: legacy_principal (SWA headers only), dual (both paths), or bearer_only (JWT only)."
+  type        = string
+  default     = "legacy_principal"
+
+  validation {
+    condition     = contains(["legacy_principal", "dual", "bearer_only"], var.auth_mode)
+    error_message = "auth_mode must be one of: legacy_principal, dual, bearer_only."
+  }
+}
+
+variable "ciam_authority" {
+  description = "Azure Entra CIAM authority endpoint (https://login.microsoftonline.com/<tenant>). Required when auth_mode is 'dual' or 'bearer_only'."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "ciam_tenant_id" {
+  description = "Azure Entra tenant ID for CIAM app registration. Required when auth_mode is 'dual' or 'bearer_only'."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "ciam_api_audience" {
+  description = "API audience (app ID URI) from CIAM app registration. Required when auth_mode is 'dual' or 'bearer_only'."
+  type        = string
+  default     = ""
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary
- wire auth transition app settings through OpenTofu (AUTH_MODE, optional CIAM values)
- pass CIAM-related TF_VAR_* values in deploy and infracost workflows
- add fail-fast CIAM consistency checks in Terraform variable validation
- add workflow preflight checks to fail early on invalid auth-mode/secret combinations
- document CIAM secret wiring and bearer-only cutover dependency in infra README

## Why
Keeps the migration path simple for the JS app while preventing runtime breakage from partial CIAM config. AUTH_MODE=legacy_principal remains default; AUTH_MODE=dual is supported for transition; AUTH_MODE=bearer_only is guarded until frontend bearer support lands.

## Validation
- make lint
- python -m pytest tests/test_auth.py tests/test_frontend_config.py tests/test_analysis_submission_endpoints.py -q
- python -m pytest tests/test_config.py tests/test_auth.py -q

Closes #709