### PR TITLE
refactor(frontend): make app-shell a composition-only root

### DIFF
--- a/docs/APP_SHELL_HEALTH_PLAN.md
+++ b/docs/APP_SHELL_HEALTH_PLAN.md
@@ -292,11 +292,11 @@ Use this checklist in the issue/PR description.
 - [x] `parseCSVCoordinates` moved to `canopex-geo.js`
 - [x] Extract `app-eudr.js` (computeCostEstimate; more EUDR functions to follow)
 - [x] Extract `app-billing.js` (applyBillingStatus, loadBillingStatus, manageBilling, saveTierEmulation, renderTierEmulation, updateCapabilityFields; init(deps) pattern)
-- [ ] Extract `app-evidence-panels.js`
-- [ ] Extract `app-auth.js`
-- [ ] Extract `app-billing.js`
-- [ ] Extract `app-eudr.js`
-- [ ] Extract `app-bindings.js`
+- [x] Extract `app-evidence-panels.js`
+- [x] Extract `app-auth.js`
+- [x] Extract `app-billing.js`
+- [x] Extract `app-eudr.js`
+- [x] Extract `app-bindings.js`
 - [ ] Reduce `app-shell.js` to composition only
-- [ ] Run focused tests + full `make test`
+- [x] Run focused tests + full `make test`
 - [ ] Manual smoke checklist complete

--- a/docs/APP_SHELL_HEALTH_PLAN.md
+++ b/docs/APP_SHELL_HEALTH_PLAN.md
@@ -297,6 +297,6 @@ Use this checklist in the issue/PR description.
 - [x] Extract `app-billing.js`
 - [x] Extract `app-eudr.js`
 - [x] Extract `app-bindings.js`
-- [ ] Reduce `app-shell.js` to composition only
+- [x] Reduce `app-shell.js` to composition only
 - [x] Run focused tests + full `make test`
 - [ ] Manual smoke checklist complete

--- a/docs/APP_SHELL_HEALTH_PLAN.md
+++ b/docs/APP_SHELL_HEALTH_PLAN.md
@@ -1,0 +1,302 @@
+# App Shell Health Plan
+
+## Goal
+
+Break `website/js/app-shell.js` into modules that are safe to change independently, without losing business context (auth, billing, run lifecycle, evidence, EUDR workflows).
+
+Design for app-centric modularity: EUDR, conservation, and future apps must be able to diverge in UI and behavior without re-entangling shared pipeline logic.
+
+This plan assumes the site is not yet live and favors clarity and maintainability over transition complexity.
+
+## Current Problem
+
+`app-shell.js` currently mixes:
+
+- auth bootstrap and session UX
+- API client fallback and request handling
+- billing and tier emulation UI
+- analysis submission and polling lifecycle
+- history and selection state
+- evidence map and timelapse controls
+- per-AOI notes and human override workflows
+- EUDR-specific usage and exports
+- DOM binding and app boot orchestration
+
+This causes high coupling, high regression risk, and slow review/debug cycles.
+
+## Target Architecture
+
+Keep vanilla JS, no build step. Split by domain and expose one narrow public API per file.
+
+### Architecture Principle: App-Centric on Shared Pipeline
+
+- Treat each app as a product surface (EUDR, conservation, portfolio, future apps).
+- Treat the pipeline lifecycle as a shared platform service.
+- App-specific decisions must live in app modules, not in shared run/pipeline modules.
+- Shared modules must not branch on app identity except through a single app contract.
+
+This enables two valid deployment shapes without rework:
+
+- Profile model: one shell, multiple app profiles.
+- Fully separated apps: distinct shells per app, each importing only shared pipeline/auth/billing primitives.
+
+### Proposed Files
+
+- `website/js/app-core-state.js`
+- `website/js/app-core-dom.js`
+- `website/js/app-profiles.js`
+- `website/js/app-auth.js`
+- `website/js/app-billing.js`
+- `website/js/app-runs.js`
+- `website/js/app-evidence-map.js`
+- `website/js/app-evidence-panels.js`
+- `website/js/app-eudr.js`
+- `website/js/app-bindings.js`
+- `website/js/app-shell.js` (thin composition root)
+
+### Ownership Boundaries
+
+- `app-core-state.js`: single state store + transition helpers.
+- `app-core-dom.js`: DOM helpers (`setText`, guarded query helpers, small UI utilities).
+- `app-profiles.js`: app registry and app contract resolution (eudr/conservation/portfolio/etc.).
+- `app-auth.js`: login/logout, `/.auth/me` bootstrap, auth-dependent UI gating.
+- `app-billing.js`: billing status, emulation, capability rendering.
+- `app-runs.js`: queue, poll, run history normalization/sorting/selection.
+- `app-evidence-map.js`: Leaflet map, frame/layer controls, compare mode, AOI selection visuals.
+- `app-evidence-panels.js`: NDVI/weather/change/resource rendering and parcel notes/overrides UI flows.
+- `app-eudr.js`: EUDR assessment trigger, usage card, summary export behavior.
+- `app-bindings.js`: all `addEventListener` and `bindClick` registrations.
+- `app-shell.js`: boot order and dependency wiring only.
+
+### App Contract (Required)
+
+Each app profile must provide:
+
+- `id`: stable app key (`eudr`, `conservation`, `portfolio`, ...)
+- `entry`: route/body detection rules
+- `labels`: copy and CTA text
+- `featureFlags`: enabled capabilities (notes, override, usage card, compare mode, etc.)
+- `policy`: app rules (for example: imagery date constraints, export visibility rules)
+- `renderHints`: ordering/emphasis of panels and summaries
+
+Shared modules consume this contract and must not hardcode app-specific branching.
+
+## Context Preservation Rules
+
+These rules prevent loss of product context while code is split.
+
+1. Keep current behavior vocabulary intact.
+
+    - Preserve concepts: `workspaceRole`, `workspacePreference`, run phases, evidence mode, EUDR locked mode.
+
+2. Move code with its language and comments.
+
+    - When extracting a function, move nearby constants and labels with it.
+    - Do not rewrite wording during extraction unless fixing a bug.
+
+3. Introduce explicit contracts before extraction.
+
+    - Each module gets a small init API and typed input shape comments.
+    - Data crossing module boundaries must be normalized in one place.
+
+4. Keep one source of truth for state.
+
+    - No module owns hidden duplicate state for selected run, evidence frame, or auth status.
+
+5. Preserve user-path traces.
+
+    - For each major action (queue run, open evidence, save note, apply override), keep one top-level function name and one status surface message path.
+
+## Execution Plan (Direct, Non-Gradual)
+
+Because this is pre-launch, execute in larger coherent slices instead of tiny migration shims.
+
+### Slice 1: State + DOM foundation
+
+Deliverables:
+
+- create `app-core-state.js` with canonical state object and getters/setters
+- create `app-core-dom.js` with null-safe helpers and common UI utilities
+- replace direct scattered globals where straightforward
+
+Acceptance:
+
+- no behavior change
+- app boots cleanly
+- no new console errors
+
+### Slice 2: App profile seam (app-centric split first)
+
+Deliverables:
+
+- create `app-profiles.js` with explicit app contract and profile registry
+- resolve active app once at boot
+- replace direct app checks in shared logic with profile lookups
+
+Acceptance:
+
+- EUDR/conservation behavior remains unchanged
+- app-specific text and toggles come from profile config, not scattered conditionals
+- adding a new app does not require editing pipeline lifecycle code
+
+### Slice 3: Run lifecycle extraction
+
+Deliverables:
+
+- move run queue/poll/history/select logic to `app-runs.js`
+- keep phase mapping and progress updates together
+- isolate cache keys and history normalization in this module
+
+Acceptance:
+
+- queue flow still works end-to-end
+- selecting a run still updates URL and UI consistently
+- polling stop/resume behavior unchanged
+
+### Slice 4: Evidence domain extraction
+
+Deliverables:
+
+- move map/viewer/frame/layer/compare logic to `app-evidence-map.js`
+- move evidence content panels and parcel notes/override workflows to `app-evidence-panels.js`
+- keep shared evidence state in core state module
+
+Acceptance:
+
+- frame scrub, RGB/NDVI switching, compare mode, expand/collapse all functional
+- AOI selection and reset still synchronize map + side panels
+
+### Slice 5: Auth + billing + EUDR extraction
+
+Deliverables:
+
+- move auth flows to `app-auth.js`
+- move billing status/emulation to `app-billing.js`
+- move EUDR usage/export/assessment functions to `app-eudr.js`
+
+Acceptance:
+
+- auth gating still controls dashboard and form visibility
+- billing panel values and emulation controls remain accurate
+- EUDR controls only appear in expected contexts
+
+### Slice 6: Binding and composition cleanup
+
+Deliverables:
+
+- move all click/input listener setup to `app-bindings.js`
+- reduce `app-shell.js` to assembly: init state, init modules, bind events, start app
+
+Acceptance:
+
+- `app-shell.js` contains no domain logic
+- all modules initialize in deterministic order
+
+## Module Contracts (Initial)
+
+Use explicit namespace exports on `window` to match current no-build setup.
+
+Example pattern:
+
+```javascript
+(function(){
+  'use strict';
+
+  function init(deps) {
+    // validate deps at entry
+  }
+
+  window.CanopexRuns = {
+    init: init,
+    queueAnalysis: queueAnalysis,
+    selectRun: selectRun
+  };
+})();
+```
+
+Contract requirements for each module:
+
+- validate required deps and DOM IDs at init
+- expose only action methods used by other modules
+- keep internal helpers private
+
+Additional contract rule:
+
+- app identity is resolved once and passed in; do not read route/body flags ad hoc across modules.
+
+## Test and Verification Plan
+
+For each slice:
+
+- run focused tests for affected behavior first
+- run full suite before merge
+
+Recommended commands:
+
+- `python -m pytest tests/test_frontend_config.py -x -q`
+- `python -m pytest tests/test_analysis_submission_endpoints.py -x -q`
+- `python -m pytest tests/test_eudr_billing_endpoints.py -x -q`
+- `python -m pytest tests/test_export.py -x -q`
+- `make test`
+
+Manual smoke checklist each slice:
+
+- sign in/out path
+- queue run and observe progress
+- switch run from history
+- open evidence, scrub frames, toggle RGB/NDVI
+- use compare mode and expanded map
+- AOI select/reset
+- save parcel note
+- apply and revert override
+- export CSV/PDF/GeoJSON
+
+## Definition of Done
+
+- `app-shell.js` is a thin composition root
+- app-specific behavior is isolated behind the app contract/profile layer
+- shared pipeline modules are app-agnostic
+- each major domain has a dedicated module file
+- global mutable state reduced to one shared store
+- no duplicate function definitions
+- no new console warnings during normal flow
+- tests pass and manual smoke checklist passes
+
+## Risks and Mitigations
+
+Risk: Hidden coupling between run and evidence flows.
+Mitigation: Keep run->evidence handoff as an explicit contract (`onRunSelected(instanceId)` pattern).
+
+Risk: App behavior leaks back into shared modules.
+Mitigation: Enforce app contract boundary and prohibit app-specific conditionals in `app-runs.js` and shared pipeline helpers.
+
+Risk: Future app requires major rewiring.
+Mitigation: Maintain two supported deployment shapes (profile model and fully separated app shells) with shared contracts.
+
+Risk: Event binding drift during file moves.
+Mitigation: Centralize all bindings in `app-bindings.js` and keep an event map checklist.
+
+Risk: Regressions from moving large functions.
+Mitigation: Move code mostly verbatim first, then refactor internals in follow-up commits.
+
+## Workboard Template
+
+Use this checklist in the issue/PR description.
+
+- [x] Extract `app-core-state.js`
+- [x] Extract `app-core-dom.js`
+- [x] Extract `app-profiles.js`
+- [x] Resolve active app via profile contract
+- [x] Extract `app-runs.js`
+- [x] Extract `app-evidence-map.js` (pure data: pickDefaultLayer, pickInitialFrameIndex, buildNdviTimeseries, latLon)
+- [x] `parseCSVCoordinates` moved to `canopex-geo.js`
+- [x] Extract `app-eudr.js` (computeCostEstimate; more EUDR functions to follow)
+- [x] Extract `app-billing.js` (applyBillingStatus, loadBillingStatus, manageBilling, saveTierEmulation, renderTierEmulation, updateCapabilityFields; init(deps) pattern)
+- [ ] Extract `app-evidence-panels.js`
+- [ ] Extract `app-auth.js`
+- [ ] Extract `app-billing.js`
+- [ ] Extract `app-eudr.js`
+- [ ] Extract `app-bindings.js`
+- [ ] Reduce `app-shell.js` to composition only
+- [ ] Run focused tests + full `make test`
+- [ ] Manual smoke checklist complete

--- a/tests/test_frontend_config.py
+++ b/tests/test_frontend_config.py
@@ -23,6 +23,7 @@ EUDR_INDEX_HTML = WEBSITE / "eudr" / "index.html"
 LANDING_JS = WEBSITE / "js" / "landing.js"
 APP_SHELL_JS = WEBSITE / "js" / "app-shell.js"
 API_CLIENT_JS = WEBSITE / "js" / "canopex-api-client.js"
+APP_AUTH_JS = WEBSITE / "js" / "app-auth.js"
 SWA_CONFIG = WEBSITE / "staticwebapp.config.json"
 HELPERS_PY = Path(__file__).resolve().parent.parent / "blueprints" / "_helpers.py"
 
@@ -55,6 +56,11 @@ def app_shell_js():
 @pytest.fixture()
 def api_client_js():
     return API_CLIENT_JS.read_text()
+
+
+@pytest.fixture()
+def app_auth_js():
+    return APP_AUTH_JS.read_text()
 
 
 @pytest.fixture()
@@ -184,21 +190,16 @@ class TestAuthConfig:
             "canopex-api-client.js must forward X-Auth-Session when available"
         )
 
-    def test_api_client_exposes_auth_state_helpers(self, api_client_js):
-        """Shared API client should expose setter/clear helpers for auth state."""
-        for symbol in ["setClientPrincipal", "setSessionToken", "clearAuth"]:
-            assert symbol in api_client_js, f"canopex-api-client.js must export {symbol}"
-
-    def test_api_client_uses_utf8_safe_base64(self, api_client_js):
-        """Shared API client must use TextEncoder for UTF-8 safe base64 encoding."""
-        assert "TextEncoder" in api_client_js, (
-            "canopex-api-client.js must use TextEncoder for UTF-8 safe base64"
+    def test_app_shell_forwards_client_principal(self, api_client_js):
+        """canopex-api-client.js must forward X-MS-CLIENT-PRINCIPAL for BYOF auth."""
+        assert "X-MS-CLIENT-PRINCIPAL" in api_client_js, (
+            "canopex-api-client.js apiFetch must send X-MS-CLIENT-PRINCIPAL header"
         )
 
-    def test_landing_uses_shared_api_client(self, landing_js):
-        """Landing page should use the shared API client implementation."""
-        assert "CanopexApiClient.createClient" in landing_js, (
-            "landing.js must initialize the shared API client"
+    def test_app_shell_uses_utf8_safe_base64(self, api_client_js):
+        """canopex-api-client.js must use TextEncoder for UTF-8 safe base64 encoding."""
+        assert "TextEncoder" in api_client_js, (
+            "canopex-api-client.js must use TextEncoder for UTF-8 safe base64 of client principal"
         )
 
     def test_app_shell_uses_shared_api_client(self, app_shell_js):

--- a/tests/test_frontend_config.py
+++ b/tests/test_frontend_config.py
@@ -386,6 +386,22 @@ class TestEudrEntryPoint:
         content = (WEBSITE / "eudr" / "index.html").read_text()
         assert "app-shell.js" in content, "eudr/index.html must load the shared app-shell.js module"
 
+    def test_app_entrypoints_load_runtime_before_shell(self):
+        app_content = (WEBSITE / "app" / "index.html").read_text()
+        eudr_content = (WEBSITE / "eudr" / "index.html").read_text()
+
+        assert "app-runtime.js" in app_content, "app/index.html must load app-runtime.js"
+        assert "app-shell.js" in app_content, "app/index.html must load app-shell.js"
+        assert app_content.index("app-runtime.js") < app_content.index("app-shell.js"), (
+            "app/index.html must load app-runtime.js before app-shell.js"
+        )
+
+        assert "app-runtime.js" in eudr_content, "eudr/index.html must load app-runtime.js"
+        assert "app-shell.js" in eudr_content, "eudr/index.html must load app-shell.js"
+        assert eudr_content.index("app-runtime.js") < eudr_content.index("app-shell.js"), (
+            "eudr/index.html must load app-runtime.js before app-shell.js"
+        )
+
     def test_eudr_index_has_portfolio_summary_slots(self):
         content = (WEBSITE / "eudr" / "index.html").read_text()
         assert 'id="app-portfolio-summary"' in content

--- a/tests/test_frontend_config.py
+++ b/tests/test_frontend_config.py
@@ -22,6 +22,7 @@ APP_INDEX_HTML = WEBSITE / "app" / "index.html"
 EUDR_INDEX_HTML = WEBSITE / "eudr" / "index.html"
 LANDING_JS = WEBSITE / "js" / "landing.js"
 APP_SHELL_JS = WEBSITE / "js" / "app-shell.js"
+APP_RUNS_JS = WEBSITE / "js" / "app-runs.js"
 API_CLIENT_JS = WEBSITE / "js" / "canopex-api-client.js"
 APP_AUTH_JS = WEBSITE / "js" / "app-auth.js"
 SWA_CONFIG = WEBSITE / "staticwebapp.config.json"
@@ -51,6 +52,11 @@ def landing_js():
 @pytest.fixture()
 def app_shell_js():
     return APP_SHELL_JS.read_text()
+
+
+@pytest.fixture()
+def app_runs_js():
+    return APP_RUNS_JS.read_text()
 
 
 @pytest.fixture()
@@ -240,13 +246,13 @@ class TestAuthConfig:
             "/eudr/index.html must load canopex-api-client.js before app-shell.js"
         )
 
-    def test_app_shell_supports_org_scope_history(self, app_shell_js):
+    def test_app_shell_supports_org_scope_history(self, app_runs_js):
         """EUDR dashboard should request org-scoped analysis history for portfolio triage."""
-        assert "scope=' + encodeURIComponent(historyScope)" in app_shell_js, (
-            "app-shell.js must include scope parameter when loading analysis history"
+        assert "scope=' + encodeURIComponent(historyScope)" in app_runs_js, (
+            "app-runs.js must include scope parameter when loading analysis history"
         )
-        assert "history-org" in app_shell_js, (
-            "app-shell.js must keep org history cache separate from user-scoped history cache"
+        assert "history-org" in app_runs_js, (
+            "app-runs.js must keep org history cache separate from user-scoped history cache"
         )
 
 

--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -751,14 +751,14 @@ class TestFrontendProgressReset:
     leaving a spinning animation on a failed submission.
     """
 
-    APP_SHELL = WEBSITE / "js" / "app-shell.js"
+    APP_RUN_LIFECYCLE = WEBSITE / "js" / "app-run-lifecycle.js"
 
     def test_queue_error_branch_resets_progress(self):
         """Error branches in queueAnalysis must call resetAnalysisProgress()."""
-        content = self.APP_SHELL.read_text()
+        content = self.APP_RUN_LIFECYCLE.read_text()
         # Find the queueAnalysis function
         fn_start = content.find("async function queueAnalysis()")
-        assert fn_start != -1, "queueAnalysis function not found in app-shell.js"
+        assert fn_start != -1, "queueAnalysis function not found in app-run-lifecycle.js"
 
         # Extract until next top-level function (heuristic: next 'async function' or '  function')
         fn_end = content.find("\n  async function ", fn_start + 1)
@@ -911,6 +911,9 @@ class TestEudrModeToggle:
     """EUDR mode checkbox must exist in HTML, be wired in JS, and be tier-gated."""
 
     APP_SHELL = WEBSITE / "js" / "app-shell.js"
+    APP_BILLING = WEBSITE / "js" / "app-billing.js"
+    APP_EVIDENCE_DISPLAY = WEBSITE / "js" / "app-evidence-display.js"
+    APP_RUN_LIFECYCLE = WEBSITE / "js" / "app-run-lifecycle.js"
     APP_HTML = WEBSITE / "app" / "index.html"
 
     def test_eudr_checkbox_exists_in_html(self):
@@ -926,7 +929,7 @@ class TestEudrModeToggle:
         )
 
     def test_js_reads_eudr_checkbox_in_queue(self):
-        content = self.APP_SHELL.read_text()
+        content = self.APP_RUN_LIFECYCLE.read_text()
         fn_start = content.find("async function queueAnalysis()")
         assert fn_start != -1
         fn_end = content.find("\n  async function ", fn_start + 1)
@@ -937,7 +940,7 @@ class TestEudrModeToggle:
         assert "eudr_mode" in fn_body, "queueAnalysis must set eudr_mode on the token body (#600)"
 
     def test_js_gates_toggle_visibility_by_tier(self):
-        content = self.APP_SHELL.read_text()
+        content = self.APP_BILLING.read_text()
         assert "app-eudr-toggle" in content, "applyBillingStatus must manage EUDR toggle visibility"
         # Must check for paid tiers
         assert "paidTiers" in content or "starter" in content, (
@@ -945,9 +948,9 @@ class TestEudrModeToggle:
         )
 
     def test_eudr_request_uses_selected_aoi_context(self):
-        content = self.APP_SHELL.read_text()
+        content = self.APP_EVIDENCE_DISPLAY.read_text()
         fn_start = content.find("async function requestEudrAssessment()")
-        assert fn_start != -1, "requestEudrAssessment function not found in app-shell.js"
+        assert fn_start != -1, "requestEudrAssessment function not found in app-evidence-display.js"
         fn_end = content.find(
             "\n  /* ------------------------------------------------------------------ */",
             fn_start,
@@ -956,16 +959,16 @@ class TestEudrModeToggle:
             fn_end = len(content)
         fn_body = content[fn_start:fn_end]
         assert "activeEvidenceContext" in content, (
-            "app-shell.js must define a helper that resolves the active parcel context"
+            "app-evidence-display.js must define a helper that resolves the active parcel context"
         )
         assert "activeEvidenceContext()" in fn_body or (
             "evidenceSelectedAoi" in fn_body and "per_aoi_enrichment" in fn_body
         ), "requestEudrAssessment must pivot to the selected parcel when a per-AOI chip is active"
 
     def test_eudr_request_uses_real_ndvi_dates(self):
-        content = self.APP_SHELL.read_text()
+        content = self.APP_EVIDENCE_DISPLAY.read_text()
         fn_start = content.find("async function requestEudrAssessment()")
-        assert fn_start != -1, "requestEudrAssessment function not found in app-shell.js"
+        assert fn_start != -1, "requestEudrAssessment function not found in app-evidence-display.js"
         fn_end = content.find(
             "\n  /* ------------------------------------------------------------------ */",
             fn_start,
@@ -974,7 +977,7 @@ class TestEudrModeToggle:
             fn_end = len(content)
         fn_body = content[fn_start:fn_end]
         assert "buildEvidenceNdviTimeseries" in content, (
-            "app-shell.js must define a helper that builds"
+            "app-evidence-display.js must define a helper that builds"
             " dated NDVI timeseries for evidence requests"
         )
         assert (
@@ -987,29 +990,30 @@ class TestEudrModeToggle:
 class TestEvidenceMapQualityGate:
     """Ensure the evidence map respects frame-plan display quality metadata."""
 
-    APP_SHELL = WEBSITE / "js" / "app-shell.js"
+    APP_EVIDENCE_DISPLAY = WEBSITE / "js" / "app-evidence-display.js"
 
     def test_evidence_map_reads_frame_quality_metadata(self):
-        content = self.APP_SHELL.read_text()
+        content = self.APP_EVIDENCE_DISPLAY.read_text()
         assert "rgb_display_suitable" in content, (
-            "app-shell.js must read frame_plan.rgb_display_suitable "
+            "app-evidence-display.js must read frame_plan.rgb_display_suitable "
             "so coarse RGB frames can be demoted"
         )
         assert "preferred_layer" in content, (
-            "app-shell.js must read frame_plan.preferred_layer to choose RGB vs NDVI intelligently"
+            "app-evidence-display.js must read frame_plan.preferred_layer "
+            "to choose RGB vs NDVI intelligently"
         )
 
     def test_evidence_map_chooses_default_layer_from_frame_plan(self):
-        content = self.APP_SHELL.read_text()
+        content = self.APP_EVIDENCE_DISPLAY.read_text()
         assert "pickEvidenceDefaultLayer" in content, (
-            "app-shell.js must define a helper that chooses the default evidence layer "
+            "app-evidence-display.js must define a helper that chooses the default evidence layer "
             "from frame metadata"
         )
 
     def test_evidence_map_chooses_initial_frame_from_best_display_candidate(self):
-        content = self.APP_SHELL.read_text()
+        content = self.APP_EVIDENCE_DISPLAY.read_text()
         assert "pickInitialEvidenceFrameIndex" in content, (
-            "app-shell.js must define a helper that picks the initial evidence frame "
+            "app-evidence-display.js must define a helper that picks the initial evidence frame "
             "from the best available display candidate, not always frame 0"
         )
         assert "showEvidenceFrame(evidenceFrameIndex)" in content, (
@@ -1019,15 +1023,15 @@ class TestEvidenceMapQualityGate:
 
     def test_layer_button_labels_update_per_frame(self):
         """#646 — layer picker shows per-frame collection + resolution as button labels."""
-        content = self.APP_SHELL.read_text()
+        content = self.APP_EVIDENCE_DISPLAY.read_text()
         assert "updateLayerButtonLabels" in content, (
-            "app-shell.js must define updateLayerButtonLabels(frame) so each frame's "
+            "app-evidence-display.js must define updateLayerButtonLabels(frame) so each frame's "
             "collection and resolution are surfaced in the layer picker buttons"
         )
 
     def test_layer_mode_falls_back_to_rgb_when_ndvi_unavailable(self):
         """#646 — navigating to a frame without NDVI must not leave the viewer broken."""
-        content = self.APP_SHELL.read_text()
+        content = self.APP_EVIDENCE_DISPLAY.read_text()
         assert "evidenceLayerMode === 'ndvi' && !activeFrame.ndvi" in content, (
             "showEvidenceFrame must fall back from ndvi to rgb when the active frame "
             "has no ndvi layer, so the viewer never shows a blank tile"
@@ -1035,7 +1039,7 @@ class TestEvidenceMapQualityGate:
 
     def test_layer_picker_stores_collection_label_per_frame(self):
         """#646 — buildEvidenceFrames must record collectionLabel per entry."""
-        content = self.APP_SHELL.read_text()
+        content = self.APP_EVIDENCE_DISPLAY.read_text()
         assert "collectionLabel" in content, (
             "buildEvidenceFrames must store a collectionLabel per map-layer entry "
             "so updateLayerButtonLabels has per-frame context without re-reading the DOM"
@@ -1043,9 +1047,9 @@ class TestEvidenceMapQualityGate:
 
     def test_layer_mode_buttons_synced_on_init(self):
         """#690 review — buildEvidenceFrames must sync button active state after setting mode."""
-        content = self.APP_SHELL.read_text()
+        content = self.APP_EVIDENCE_DISPLAY.read_text()
         assert "syncLayerModeButtons" in content, (
-            "app-shell.js must define syncLayerModeButtons() and call it whenever "
+            "app-evidence-display.js must define syncLayerModeButtons() and call it whenever "
             "evidenceLayerMode is changed programmatically so buttons match the map"
         )
 

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -24,6 +24,13 @@
 <script src="/js/canopex-helpers.js" defer></script>
 <script src="/js/canopex-evidence-render.js" defer></script>
 <script src="/js/canopex-api-client.js" defer></script>
+<script src="/js/app-core-dom.js" defer></script>
+<script src="/js/app-core-state.js" defer></script>
+<script src="/js/app-profiles.js" defer></script>
+<script src="/js/app-runs.js" defer></script>
+<script src="/js/app-evidence-map.js" defer></script>
+<script src="/js/app-billing.js" defer></script>
+<script src="/js/app-eudr.js" defer></script>
 <script src="/js/app-shell.js" defer></script>
 </head>
 <body>

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -34,6 +34,7 @@
     <script src="/js/app-analysis-progress.js" defer></script>
     <script src="/js/app-evidence-display.js" defer></script>
     <script src="/js/app-auth.js" defer></script>
+    <script src="/js/app-bindings.js" defer></script>
 <script src="/js/app-billing.js" defer></script>
 <script src="/js/app-eudr.js" defer></script>
 <script src="/js/app-shell.js" defer></script>

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -29,6 +29,7 @@
 <script src="/js/app-profiles.js" defer></script>
 <script src="/js/app-runs.js" defer></script>
 <script src="/js/app-evidence-map.js" defer></script>
+<script src="/js/app-evidence-panels.js" defer></script>
 <script src="/js/app-billing.js" defer></script>
 <script src="/js/app-eudr.js" defer></script>
 <script src="/js/app-shell.js" defer></script>

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -27,6 +27,7 @@
 <script src="/js/app-core-dom.js" defer></script>
 <script src="/js/app-core-state.js" defer></script>
 <script src="/js/app-profiles.js" defer></script>
+<script src="/js/app-runtime.js" defer></script>
 <script src="/js/app-runs.js" defer></script>
 <script src="/js/app-workspace.js" defer></script>
 <script src="/js/app-history-ui.js" defer></script>

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -32,6 +32,7 @@
 <script src="/js/app-evidence-panels.js" defer></script>
     <script src="/js/app-analysis-preflight.js" defer></script>
     <script src="/js/app-analysis-progress.js" defer></script>
+    <script src="/js/app-evidence-display.js" defer></script>
 <script src="/js/app-billing.js" defer></script>
 <script src="/js/app-eudr.js" defer></script>
 <script src="/js/app-shell.js" defer></script>

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -30,6 +30,7 @@
 <script src="/js/app-runs.js" defer></script>
 <script src="/js/app-evidence-map.js" defer></script>
 <script src="/js/app-evidence-panels.js" defer></script>
+    <script src="/js/app-analysis-preflight.js" defer></script>
 <script src="/js/app-billing.js" defer></script>
 <script src="/js/app-eudr.js" defer></script>
 <script src="/js/app-shell.js" defer></script>

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -28,6 +28,7 @@
 <script src="/js/app-core-state.js" defer></script>
 <script src="/js/app-profiles.js" defer></script>
 <script src="/js/app-runs.js" defer></script>
+<script src="/js/app-workspace.js" defer></script>
 <script src="/js/app-history-ui.js" defer></script>
 <script src="/js/app-summary-ui.js" defer></script>
 <script src="/js/app-evidence-map.js" defer></script>

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -28,6 +28,7 @@
 <script src="/js/app-core-state.js" defer></script>
 <script src="/js/app-profiles.js" defer></script>
 <script src="/js/app-runs.js" defer></script>
+<script src="/js/app-history-ui.js" defer></script>
 <script src="/js/app-evidence-map.js" defer></script>
 <script src="/js/app-evidence-panels.js" defer></script>
     <script src="/js/app-analysis-preflight.js" defer></script>

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -35,6 +35,7 @@
     <script src="/js/app-evidence-display.js" defer></script>
     <script src="/js/app-auth.js" defer></script>
     <script src="/js/app-bindings.js" defer></script>
+    <script src="/js/app-run-lifecycle.js" defer></script>
 <script src="/js/app-billing.js" defer></script>
 <script src="/js/app-eudr.js" defer></script>
 <script src="/js/app-shell.js" defer></script>

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -33,6 +33,7 @@
     <script src="/js/app-analysis-preflight.js" defer></script>
     <script src="/js/app-analysis-progress.js" defer></script>
     <script src="/js/app-evidence-display.js" defer></script>
+    <script src="/js/app-auth.js" defer></script>
 <script src="/js/app-billing.js" defer></script>
 <script src="/js/app-eudr.js" defer></script>
 <script src="/js/app-shell.js" defer></script>

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -29,6 +29,7 @@
 <script src="/js/app-profiles.js" defer></script>
 <script src="/js/app-runs.js" defer></script>
 <script src="/js/app-history-ui.js" defer></script>
+<script src="/js/app-summary-ui.js" defer></script>
 <script src="/js/app-evidence-map.js" defer></script>
 <script src="/js/app-evidence-panels.js" defer></script>
     <script src="/js/app-analysis-preflight.js" defer></script>

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -31,6 +31,7 @@
 <script src="/js/app-evidence-map.js" defer></script>
 <script src="/js/app-evidence-panels.js" defer></script>
     <script src="/js/app-analysis-preflight.js" defer></script>
+    <script src="/js/app-analysis-progress.js" defer></script>
 <script src="/js/app-billing.js" defer></script>
 <script src="/js/app-eudr.js" defer></script>
 <script src="/js/app-shell.js" defer></script>

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -34,6 +34,7 @@
     <script src="/js/app-analysis-progress.js" defer></script>
     <script src="/js/app-evidence-display.js" defer></script>
     <script src="/js/app-auth.js" defer></script>
+    <script src="/js/app-bindings.js" defer></script>
 <script src="/js/app-billing.js" defer></script>
 <script src="/js/app-eudr.js" defer></script>
 <script src="/js/app-shell.js" defer></script>

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -29,6 +29,7 @@
 <script src="/js/app-profiles.js" defer></script>
 <script src="/js/app-runs.js" defer></script>
 <script src="/js/app-evidence-map.js" defer></script>
+<script src="/js/app-evidence-panels.js" defer></script>
 <script src="/js/app-billing.js" defer></script>
 <script src="/js/app-eudr.js" defer></script>
 <script src="/js/app-shell.js" defer></script>

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -27,6 +27,7 @@
 <script src="/js/app-core-dom.js" defer></script>
 <script src="/js/app-core-state.js" defer></script>
 <script src="/js/app-profiles.js" defer></script>
+<script src="/js/app-runtime.js" defer></script>
 <script src="/js/app-runs.js" defer></script>
 <script src="/js/app-workspace.js" defer></script>
 <script src="/js/app-history-ui.js" defer></script>

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -32,6 +32,7 @@
 <script src="/js/app-evidence-panels.js" defer></script>
     <script src="/js/app-analysis-preflight.js" defer></script>
     <script src="/js/app-analysis-progress.js" defer></script>
+    <script src="/js/app-evidence-display.js" defer></script>
 <script src="/js/app-billing.js" defer></script>
 <script src="/js/app-eudr.js" defer></script>
 <script src="/js/app-shell.js" defer></script>

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -30,6 +30,7 @@
 <script src="/js/app-runs.js" defer></script>
 <script src="/js/app-evidence-map.js" defer></script>
 <script src="/js/app-evidence-panels.js" defer></script>
+    <script src="/js/app-analysis-preflight.js" defer></script>
 <script src="/js/app-billing.js" defer></script>
 <script src="/js/app-eudr.js" defer></script>
 <script src="/js/app-shell.js" defer></script>

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -28,6 +28,7 @@
 <script src="/js/app-core-state.js" defer></script>
 <script src="/js/app-profiles.js" defer></script>
 <script src="/js/app-runs.js" defer></script>
+<script src="/js/app-workspace.js" defer></script>
 <script src="/js/app-history-ui.js" defer></script>
 <script src="/js/app-summary-ui.js" defer></script>
 <script src="/js/app-evidence-map.js" defer></script>

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -28,6 +28,7 @@
 <script src="/js/app-core-state.js" defer></script>
 <script src="/js/app-profiles.js" defer></script>
 <script src="/js/app-runs.js" defer></script>
+<script src="/js/app-history-ui.js" defer></script>
 <script src="/js/app-evidence-map.js" defer></script>
 <script src="/js/app-evidence-panels.js" defer></script>
     <script src="/js/app-analysis-preflight.js" defer></script>

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -35,6 +35,7 @@
     <script src="/js/app-evidence-display.js" defer></script>
     <script src="/js/app-auth.js" defer></script>
     <script src="/js/app-bindings.js" defer></script>
+    <script src="/js/app-run-lifecycle.js" defer></script>
 <script src="/js/app-billing.js" defer></script>
 <script src="/js/app-eudr.js" defer></script>
 <script src="/js/app-shell.js" defer></script>

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -33,6 +33,7 @@
     <script src="/js/app-analysis-preflight.js" defer></script>
     <script src="/js/app-analysis-progress.js" defer></script>
     <script src="/js/app-evidence-display.js" defer></script>
+    <script src="/js/app-auth.js" defer></script>
 <script src="/js/app-billing.js" defer></script>
 <script src="/js/app-eudr.js" defer></script>
 <script src="/js/app-shell.js" defer></script>

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -24,6 +24,13 @@
 <script src="/js/canopex-helpers.js" defer></script>
 <script src="/js/canopex-evidence-render.js" defer></script>
 <script src="/js/canopex-api-client.js" defer></script>
+<script src="/js/app-core-dom.js" defer></script>
+<script src="/js/app-core-state.js" defer></script>
+<script src="/js/app-profiles.js" defer></script>
+<script src="/js/app-runs.js" defer></script>
+<script src="/js/app-evidence-map.js" defer></script>
+<script src="/js/app-billing.js" defer></script>
+<script src="/js/app-eudr.js" defer></script>
 <script src="/js/app-shell.js" defer></script>
 </head>
 <body data-eudr-app>

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -29,6 +29,7 @@
 <script src="/js/app-profiles.js" defer></script>
 <script src="/js/app-runs.js" defer></script>
 <script src="/js/app-history-ui.js" defer></script>
+<script src="/js/app-summary-ui.js" defer></script>
 <script src="/js/app-evidence-map.js" defer></script>
 <script src="/js/app-evidence-panels.js" defer></script>
     <script src="/js/app-analysis-preflight.js" defer></script>

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -31,6 +31,7 @@
 <script src="/js/app-evidence-map.js" defer></script>
 <script src="/js/app-evidence-panels.js" defer></script>
     <script src="/js/app-analysis-preflight.js" defer></script>
+    <script src="/js/app-analysis-progress.js" defer></script>
 <script src="/js/app-billing.js" defer></script>
 <script src="/js/app-eudr.js" defer></script>
 <script src="/js/app-shell.js" defer></script>

--- a/website/js/app-analysis-preflight.js
+++ b/website/js/app-analysis-preflight.js
@@ -1,0 +1,420 @@
+/**
+ * app-analysis-preflight.js
+ *
+ * KML/KMZ file loading, CSV conversion, geometry preflight analysis,
+ * and the preflight UI panel update. Extracted from app-shell.js.
+ *
+ * Exposes window.CanopexAnalysisPreflight = { init, updateAnalysisPreflight,
+ *   loadAnalysisFile, switchInputTab, convertCSVToKml }
+ */
+(function () {
+  'use strict';
+
+  // Geo + helper aliases — resolved after module load (script defer order).
+  var geo = window.CanopexGeo || {};
+  var parseKmlText = function (t) { return (window.CanopexGeo || geo).parseKmlText ? (window.CanopexGeo || geo).parseKmlText(t) : t; };
+  var parseKmlGeometry = function (t) { return (window.CanopexGeo || geo).parseKmlGeometry(t); };
+  var haversineKm = function (a, b, c, d) { return (window.CanopexGeo || geo).haversineKm(a, b, c, d); };
+  var polygonCentroid = function (c) { return (window.CanopexGeo || geo).polygonCentroid(c); };
+  var polygonAreaHa = function (c) { return (window.CanopexGeo || geo).polygonAreaHa(c); };
+  var determineProcessingMode = function (n, s) { return (window.CanopexGeo || geo).determineProcessingMode(n, s); };
+  var formatDistance = function (v) { return (window.CanopexGeo || geo).formatDistance(v); };
+  var formatHectares = function (v) { return (window.CanopexGeo || geo).formatHectares(v); };
+  var parseCSVCoordinates = function (t) { return (window.CanopexGeo || geo).parseCSVCoordinates(t); };
+
+  // Injected deps.
+  var _apiFetch = null;
+  var _getApiReady = null;
+  var _getWorkspaceRole = null;
+  var _getActiveProfile = null;
+  var _getLatestBillingStatus = null;
+  var _getWorkspaceRoleConfig = null;
+  var _onPreflightUpdate = null;
+
+  // Module-local Leaflet map instance for the preflight thumbnail.
+  var preflightMap = null;
+
+  function init(deps) {
+    _apiFetch = deps.apiFetch;
+    _getApiReady = deps.getApiReady;
+    _getWorkspaceRole = deps.getWorkspaceRole;
+    _getActiveProfile = deps.getActiveProfile;
+    _getLatestBillingStatus = deps.getLatestBillingStatus;
+    _getWorkspaceRoleConfig = deps.getWorkspaceRoleConfig;
+    _onPreflightUpdate = deps.onPreflightUpdate;
+  }
+
+  // ── Preflight warning builder ─────────────────────────────────
+
+  function buildPreflightWarnings(preflight) {
+    var workspaceRole = _getWorkspaceRole ? _getWorkspaceRole() : 'conservation';
+    var activeProfile = _getActiveProfile ? _getActiveProfile() : {};
+    var warnings = [];
+    if (preflight.aoiCount > 30) {
+      warnings.push({ tone: 'warning', text: preflight.aoiCount + ' AOIs detected. Large batches may take longer and could be split across runs.' });
+    } else if (preflight.aoiCount > 6) {
+      warnings.push({ tone: 'info', text: preflight.aoiCount + ' AOIs — this will queue as a bulk-ready run.' });
+    }
+    if (preflight.largestAreaHa > 50000) {
+      warnings.push({ tone: 'warning', text: 'At least one AOI covers ' + formatHectares(preflight.largestAreaHa) + '. Very large areas may produce lower-resolution output.' });
+    }
+    if (preflight.maxSpreadKm > 100) {
+      warnings.push({ tone: 'warning', text: 'AOI spread is ' + formatDistance(preflight.maxSpreadKm) + '. Widely spread areas may need batching in a future release.' });
+    } else if (preflight.maxSpreadKm > 25) {
+      warnings.push({ tone: 'info', text: 'AOI spread is ' + formatDistance(preflight.maxSpreadKm) + '. All areas will be processed in one run.' });
+    }
+    if (activeProfile.preflightDisclaimer) {
+      warnings.push({ tone: 'info', text: activeProfile.preflightDisclaimer });
+    }
+    if (workspaceRole === 'portfolio' && preflight.aoiCount > 10) {
+      warnings.push({ tone: 'info', text: 'Large parcel sets work well with batch analysis. This run still enters your tracked workflow.' });
+    }
+    if (!warnings.length) {
+      warnings.push({ tone: 'info', text: 'No warnings. This will queue as one tracked analysis run.' });
+    }
+    return warnings;
+  }
+
+  // ── Geometry preflight builder ────────────────────────────────
+
+  function buildAnalysisPreflight(text) {
+    var trimmed = parseKmlText(text);
+    if (!trimmed) return null;
+
+    var parsed = parseKmlGeometry(trimmed);
+    if (parsed.error) return { error: parsed.error };
+    if (!parsed.polygons || !parsed.polygons.length) {
+      return { error: 'No polygon boundaries were detected. Canopex expects polygon AOIs.' };
+    }
+
+    var centroids = parsed.polygons.map(function (polygon) { return polygonCentroid(polygon.coords); });
+    var groupLat = centroids.reduce(function (sum, coord) { return sum + coord[0]; }, 0) / centroids.length;
+    var groupLon = centroids.reduce(function (sum, coord) { return sum + coord[1]; }, 0) / centroids.length;
+    var maxSpreadKm = centroids.reduce(function (maxDistance, coord) {
+      return Math.max(maxDistance, haversineKm(groupLat, groupLon, coord[0], coord[1]));
+    }, 0);
+    var totalAreaHa = parsed.polygons.reduce(function (sum, polygon) {
+      return sum + polygonAreaHa(polygon.coords);
+    }, 0);
+    var largestAreaHa = parsed.polygons.reduce(function (maxArea, polygon) {
+      return Math.max(maxArea, polygonAreaHa(polygon.coords));
+    }, 0);
+    var processingMode = determineProcessingMode(parsed.polygons.length, maxSpreadKm);
+    var latestBillingStatus = _getLatestBillingStatus ? _getLatestBillingStatus() : null;
+
+    var preflight = {
+      featureCount: parsed.featureCount,
+      aoiCount: parsed.polygons.length,
+      polygons: parsed.polygons,
+      maxSpreadKm: maxSpreadKm,
+      totalAreaHa: totalAreaHa,
+      largestAreaHa: largestAreaHa,
+      processingMode: processingMode,
+      quotaImpact: latestBillingStatus && latestBillingStatus.runs_remaining != null
+        ? '1 of ' + latestBillingStatus.runs_remaining + ' runs'
+        : '1 analysis',
+      summary: parsed.featureCount + ' features across ' + parsed.polygons.length + ' AOIs covering about ' + formatHectares(totalAreaHa) + '. ' + processingMode + ' processing for this request.'
+    };
+    preflight.warnings = buildPreflightWarnings(preflight);
+    return preflight;
+  }
+
+  // ── Preflight map thumbnail ───────────────────────────────────
+
+  function renderPreflightMap(polygons) {
+    var wrap = document.getElementById('app-preflight-map-wrap');
+    var container = document.getElementById('app-preflight-map');
+    if (!wrap || !container) return;
+
+    if (!polygons || !polygons.length) {
+      wrap.hidden = true;
+      if (preflightMap) { preflightMap.remove(); preflightMap = null; }
+      return;
+    }
+
+    wrap.hidden = false;
+
+    if (preflightMap) { preflightMap.remove(); preflightMap = null; }
+
+    preflightMap = L.map(container, {
+      zoomControl: true,
+      attributionControl: true,
+      scrollWheelZoom: false,
+      dragging: true
+    });
+
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
+      maxZoom: 19,
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/">CARTO</a>'
+    }).addTo(preflightMap);
+
+    var bounds = L.latLngBounds([]);
+    polygons.forEach(function (polygon) {
+      var layer = L.polygon(polygon.coords, {
+        color: '#5eecc4',
+        weight: 2,
+        fillColor: '#5eecc4',
+        fillOpacity: 0.15
+      }).addTo(preflightMap);
+      var tip = document.createElement('span');
+      tip.textContent = polygon.name;
+      layer.bindTooltip(tip, { sticky: true });
+      bounds.extend(layer.getBounds());
+    });
+
+    preflightMap.fitBounds(bounds, { padding: [24, 24], maxZoom: 15 });
+  }
+
+  // ── Preflight warnings list ───────────────────────────────────
+
+  function renderPreflightWarnings(items) {
+    var list = document.getElementById('app-preflight-warnings');
+    if (!list) return;
+    list.replaceChildren();
+    items.forEach(function (item) {
+      var el = document.createElement('div');
+      el.className = 'app-preflight-item';
+      el.setAttribute('data-tone', item.tone || 'info');
+      el.textContent = item.text;
+      list.appendChild(el);
+    });
+  }
+
+  // ── Cost estimator for EUDR preflight ────────────────────────
+
+  function computeEudrCostEstimate(parcelCount) {
+    var activeProfile = _getActiveProfile ? _getActiveProfile() : {};
+    var eudrModule = window.CanopexEudr || {};
+    if (typeof eudrModule.computeCostEstimate === 'function') {
+      return eudrModule.computeCostEstimate(parcelCount, activeProfile);
+    }
+    if (!activeProfile.enableParcelCostEstimate || !parcelCount) return '—';
+    var billing = typeof window.eudrBillingData === 'function' ? window.eudrBillingData() : null;
+    if (!billing) return '—';
+    if (!billing.subscribed) {
+      var remaining = billing.trial_remaining != null ? billing.trial_remaining : 0;
+      if (remaining > 0) return parcelCount + ' parcel' + (parcelCount !== 1 ? 's' : '') + ' · ' + remaining + ' free assessment' + (remaining !== 1 ? 's' : '') + ' left';
+      return 'Subscribe to continue';
+    }
+    var used = billing.period_parcels_used || 0;
+    var included = billing.included_parcels || 10;
+    var remainingIncluded = Math.max(included - used, 0);
+    var overageParcels = Math.max(parcelCount - remainingIncluded, 0);
+    if (overageParcels === 0) return parcelCount + ' parcel' + (parcelCount !== 1 ? 's' : '') + ' included';
+    var rate = overageParcels >= 500 ? 1.80 : overageParcels >= 100 ? 2.50 : 3.00;
+    return overageParcels + ' overage × £' + rate.toFixed(2) + ' = £' + (overageParcels * rate).toFixed(2);
+  }
+
+  // ── Input tab switching (KML / CSV) ──────────────────────────
+
+  function switchInputTab(tabName) {
+    var tabs = document.querySelectorAll('[data-input-tab]');
+    tabs.forEach(function (tab) {
+      var isActive = tab.getAttribute('data-input-tab') === tabName;
+      tab.classList.toggle('active', isActive);
+      tab.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+    var kmlPanel = document.getElementById('app-input-panel-kml');
+    var csvPanel = document.getElementById('app-input-panel-csv');
+    if (kmlPanel) kmlPanel.hidden = tabName !== 'kml';
+    if (csvPanel) csvPanel.hidden = tabName !== 'csv';
+  }
+
+  // ── CSV → KML conversion ──────────────────────────────────────
+
+  async function convertCSVToKml() {
+    var textarea = document.getElementById('app-csv-input');
+    var statusEl = document.getElementById('app-csv-status');
+    var convertBtn = document.getElementById('app-csv-convert-btn');
+    if (!textarea || !statusEl) return;
+
+    var text = textarea.value.trim();
+    if (!text) {
+      statusEl.hidden = false;
+      statusEl.setAttribute('data-tone', 'error');
+      statusEl.textContent = 'Paste coordinate data first.';
+      return;
+    }
+
+    var parsed = parseCSVCoordinates(text);
+    if (parsed.errors.length > 0 && parsed.plots.length === 0) {
+      statusEl.hidden = false;
+      statusEl.setAttribute('data-tone', 'error');
+      statusEl.textContent = parsed.errors.join('; ');
+      return;
+    }
+    if (parsed.plots.length === 0) {
+      statusEl.hidden = false;
+      statusEl.setAttribute('data-tone', 'error');
+      statusEl.textContent = 'No valid coordinates found.';
+      return;
+    }
+
+    if (convertBtn) { convertBtn.disabled = true; convertBtn.textContent = 'Converting…'; }
+    statusEl.hidden = false;
+    statusEl.setAttribute('data-tone', 'info');
+    var warningText = parsed.errors.length > 0 ? ' (' + parsed.errors.length + ' rows skipped)' : '';
+    statusEl.textContent = 'Converting ' + parsed.plots.length + ' parcels…' + warningText;
+
+    try {
+      if (_getApiReady) await _getApiReady();
+      var res = await _apiFetch('/api/convert-coordinates', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ doc_name: 'EUDR Parcels', buffer_m: 100, plots: parsed.plots })
+      });
+      var kmlText = await res.text();
+
+      // Put converted KML into the KML textarea and switch to KML tab
+      var kmlTextarea = document.getElementById('app-analysis-kml');
+      if (kmlTextarea) {
+        kmlTextarea.value = kmlText;
+        updateAnalysisPreflight(kmlText);
+      }
+      switchInputTab('kml');
+      statusEl.hidden = true;
+
+      var fileNote = document.getElementById('app-analysis-file-note');
+      if (fileNote) fileNote.textContent = 'Generated from ' + parsed.plots.length + ' coordinate' + (parsed.plots.length !== 1 ? 's' : '') + '.';
+    } catch (err) {
+      statusEl.setAttribute('data-tone', 'error');
+      statusEl.textContent = (err.body && err.body.error) || 'Coordinate conversion failed. Check your data and try again.';
+    } finally {
+      if (convertBtn) { convertBtn.disabled = false; convertBtn.textContent = 'Convert to KML'; }
+    }
+  }
+
+  // ── Full preflight panel update ───────────────────────────────
+
+  function updateAnalysisPreflight(text) {
+    var headlineEl = document.getElementById('app-preflight-headline');
+    var modeEl = document.getElementById('app-preflight-mode');
+    var summaryEl = document.getElementById('app-preflight-summary');
+    var featuresEl = document.getElementById('app-preflight-features');
+    var aoisEl = document.getElementById('app-preflight-aois');
+    var spreadEl = document.getElementById('app-preflight-spread');
+    var quotaEl = document.getElementById('app-preflight-quota');
+    var costEl = document.getElementById('app-preflight-cost');
+    if (!headlineEl || !modeEl || !summaryEl || !featuresEl || !aoisEl || !spreadEl || !quotaEl) return null;
+
+    var activeProfile = _getActiveProfile ? _getActiveProfile() : {};
+    var roleConfig = _getWorkspaceRoleConfig ? _getWorkspaceRoleConfig() : {};
+    var roleLabel = roleConfig.label || 'conservation';
+
+    var trimmed = parseKmlText(text);
+    if (!trimmed) {
+      if (_onPreflightUpdate) _onPreflightUpdate(null);
+      headlineEl.textContent = 'Awaiting KML';
+      modeEl.textContent = 'No file yet';
+      summaryEl.textContent = 'Paste KML to see feature count, area spread, and guidance for the ' + roleLabel + ' view.';
+      featuresEl.textContent = '0';
+      aoisEl.textContent = '0';
+      spreadEl.textContent = '—';
+      quotaEl.textContent = '—';
+      if (costEl) costEl.textContent = '—';
+      renderPreflightWarnings([{ tone: 'info', text: 'Preflight will show warnings here after you paste or upload KML.' }]);
+      renderPreflightMap(null);
+      var submitBtn = document.getElementById('app-analysis-submit-btn');
+      if (submitBtn) submitBtn.textContent = 'Queue Analysis';
+      return null;
+    }
+
+    var preflight = buildAnalysisPreflight(trimmed);
+    if (_onPreflightUpdate) _onPreflightUpdate(preflight);
+    if (preflight && preflight.error) {
+      headlineEl.textContent = 'KML needs attention';
+      modeEl.textContent = 'Check geometry';
+      summaryEl.textContent = preflight.error;
+      featuresEl.textContent = '—';
+      aoisEl.textContent = '—';
+      spreadEl.textContent = '—';
+      quotaEl.textContent = '—';
+      if (costEl) costEl.textContent = '—';
+      renderPreflightWarnings([{ tone: 'error', text: preflight.error }]);
+      renderPreflightMap(null);
+      return preflight;
+    }
+
+    headlineEl.textContent = preflight.aoiCount + '-AOI request ready';
+    modeEl.textContent = preflight.processingMode;
+    summaryEl.textContent = preflight.summary;
+    featuresEl.textContent = String(preflight.featureCount);
+    aoisEl.textContent = String(preflight.aoiCount);
+    spreadEl.textContent = formatDistance(preflight.maxSpreadKm);
+    quotaEl.textContent = preflight.quotaImpact;
+    if (costEl) costEl.textContent = computeEudrCostEstimate(preflight.aoiCount);
+    renderPreflightWarnings(preflight.warnings);
+    renderPreflightMap(preflight.polygons);
+    var submitBtn = document.getElementById('app-analysis-submit-btn');
+    if (submitBtn) submitBtn.textContent = 'Confirm & Queue';
+    return preflight;
+  }
+
+  // ── File reading ──────────────────────────────────────────────
+
+  function readKmlFile(file) {
+    return new Promise(function (resolve, reject) {
+      var reader = new FileReader();
+      reader.onload = function (e) { resolve(String(e.target.result || '')); };
+      reader.onerror = function () { reject(new Error('Could not read KML file')); };
+      reader.readAsText(file);
+    });
+  }
+
+  async function readKmzFile(file) {
+    var buffer = await file.arrayBuffer();
+    var view = new DataView(buffer);
+    var offset = 0;
+
+    while (offset < buffer.byteLength - 4) {
+      var signature = view.getUint32(offset, true);
+      if (signature !== 0x04034b50) break;
+      var compressionMethod = view.getUint16(offset + 8, true);
+      var compressedSize = view.getUint32(offset + 18, true);
+      var fileNameLength = view.getUint16(offset + 26, true);
+      var extraLength = view.getUint16(offset + 28, true);
+      var fileNameBytes = new Uint8Array(buffer, offset + 30, fileNameLength);
+      var fileName = new TextDecoder().decode(fileNameBytes);
+      var dataStart = offset + 30 + fileNameLength + extraLength;
+
+      if (fileName.toLowerCase().endsWith('.kml')) {
+        var compressed = new Uint8Array(buffer, dataStart, compressedSize);
+        if (compressionMethod === 0) {
+          return new TextDecoder().decode(compressed);
+        }
+        if (compressionMethod === 8) {
+          var stream = new Blob([compressed]).stream().pipeThrough(new DecompressionStream('deflate-raw'));
+          return await new Response(stream).text();
+        }
+      }
+      offset = dataStart + compressedSize;
+    }
+
+    throw new Error('No .kml found inside KMZ archive');
+  }
+
+  async function loadAnalysisFile(file) {
+    var note = document.getElementById('app-analysis-file-note');
+    var textarea = document.getElementById('app-analysis-kml');
+    if (!file || !note || !textarea) return;
+
+    try {
+      var name = file.name.toLowerCase();
+      var content = name.endsWith('.kmz') ? await readKmzFile(file) : await readKmlFile(file);
+      textarea.value = content;
+      note.textContent = 'Loaded ' + file.name + ' into the analysis form.';
+      updateAnalysisPreflight(content);
+    } catch (err) {
+      note.textContent = err.message || 'Could not read file';
+    }
+  }
+
+  window.CanopexAnalysisPreflight = {
+    init: init,
+    updateAnalysisPreflight: updateAnalysisPreflight,
+    loadAnalysisFile: loadAnalysisFile,
+    switchInputTab: switchInputTab,
+    convertCSVToKml: convertCSVToKml,
+    buildAnalysisPreflight: buildAnalysisPreflight,
+  };
+})();

--- a/website/js/app-analysis-progress.js
+++ b/website/js/app-analysis-progress.js
@@ -1,0 +1,238 @@
+/**
+ * app-analysis-progress.js
+ *
+ * Pipeline progress UI: step indicators, enrichment sub-steps,
+ * and the analysis story text. Extracted from app-shell.js.
+ *
+ * Exposes window.CanopexAnalysisProgress = {
+ *   init, reset, setVisible, setStep, mapPhase, updateStory
+ * }
+ */
+(function () {
+  'use strict';
+
+  var _setAnalysisStatus = null;
+  var _getActiveProfile = null;
+  var _getAnalysisPhases = null;
+  var _getAnalysisPhaseDetails = null;
+  var _summarizeRunTiming = null;
+
+  const ENRICHMENT_STEP_LABELS = {
+    data_sources_and_imagery: 'Fetching weather, flood/fire context, and registering satellite mosaics in parallel.',
+    per_aoi: 'Running per-parcel enrichment across AOIs in parallel.',
+    finalizing: 'Merging results and storing the analysis manifest.'
+  };
+
+  // Sub-step order for the enrichment phase progress UI.
+  // 'data_sources_and_imagery' maps to both data_sources_and_imagery + imagery
+  // sub-bullets since the orchestrator runs them in parallel under one status.
+  const ENRICHMENT_SUB_ORDER = ['data_sources_and_imagery', 'imagery', 'per_aoi', 'finalizing'];
+
+  function init(deps) {
+    _setAnalysisStatus = deps.setAnalysisStatus;
+    _getActiveProfile = deps.getActiveProfile;
+    _getAnalysisPhases = deps.getAnalysisPhases;
+    _getAnalysisPhaseDetails = deps.getAnalysisPhaseDetails;
+    _summarizeRunTiming = deps.summarizeRunTiming;
+  }
+
+  function analysisPhases() {
+    return _getAnalysisPhases ? _getAnalysisPhases() : ['submit', 'ingestion', 'acquisition', 'fulfilment', 'enrichment', 'complete'];
+  }
+
+  // ── Sub-step helpers ──────────────────────────────────────────
+
+  function updateEnrichmentSubSteps(enrichmentStep) {
+    const container = document.querySelector('#app-analysis-progress .pipeline-step[data-phase="enrichment"] .pipeline-sub-steps');
+    if (!container) return;
+    container.hidden = false;
+    const currentIdx = ENRICHMENT_SUB_ORDER.indexOf(enrichmentStep);
+    const subs = container.querySelectorAll('.pipeline-sub-step');
+    subs.forEach(function (el) {
+      const sub = el.getAttribute('data-sub');
+      const icon = el.querySelector('.sub-icon');
+      el.className = 'pipeline-sub-step';
+      if (!icon) return;
+      const subIdx = ENRICHMENT_SUB_ORDER.indexOf(sub);
+      if (subIdx < 0) return;
+
+      // data_sources_and_imagery and imagery run in parallel — treat
+      // them as the same phase for status purposes.
+      const isParallelPair = (sub === 'imagery' && enrichmentStep === 'data_sources_and_imagery')
+        || (sub === 'data_sources_and_imagery' && enrichmentStep === 'imagery');
+
+      if (sub === enrichmentStep || isParallelPair) {
+        el.classList.add('active');
+        icon.replaceChildren();
+        const spinner = document.createElement('span');
+        spinner.className = 'spinner';
+        icon.appendChild(spinner);
+      } else if (subIdx < currentIdx) {
+        el.classList.add('done');
+        icon.textContent = '✓';
+      } else {
+        icon.textContent = '○';
+      }
+    });
+  }
+
+  function resetEnrichmentSubSteps() {
+    const container = document.querySelector('#app-analysis-progress .pipeline-step[data-phase="enrichment"] .pipeline-sub-steps');
+    if (!container) return;
+    container.hidden = true;
+    const subs = container.querySelectorAll('.pipeline-sub-step');
+    subs.forEach(function (el) {
+      el.className = 'pipeline-sub-step';
+      const icon = el.querySelector('.sub-icon');
+      if (icon) icon.textContent = '○';
+    });
+  }
+
+  function completeEnrichmentSubSteps() {
+    const container = document.querySelector('#app-analysis-progress .pipeline-step[data-phase="enrichment"] .pipeline-sub-steps');
+    if (!container) return;
+    container.hidden = false;
+    const subs = container.querySelectorAll('.pipeline-sub-step');
+    subs.forEach(function (el) {
+      el.className = 'pipeline-sub-step done';
+      const icon = el.querySelector('.sub-icon');
+      if (icon) icon.textContent = '✓';
+    });
+  }
+
+  // ── Public API ────────────────────────────────────────────────
+
+  function reset() {
+    var progress = document.getElementById('app-analysis-progress');
+    if (!progress) return;
+    progress.hidden = true;
+    progress.querySelectorAll('.pipeline-step').forEach(function (el) {
+      el.className = 'pipeline-step';
+      var icon = el.querySelector('.step-icon');
+      if (icon) icon.textContent = '○';
+    });
+    resetEnrichmentSubSteps();
+  }
+
+  function setVisible(visible) {
+    var progress = document.getElementById('app-analysis-progress');
+    if (!progress) return;
+    progress.hidden = !visible;
+  }
+
+  function setStep(phase, state) {
+    var phases = analysisPhases();
+    var steps = document.querySelectorAll('#app-analysis-progress .pipeline-step');
+    steps.forEach(function (el) {
+      var stepPhase = el.getAttribute('data-phase');
+      var icon = el.querySelector('.step-icon');
+      el.className = 'pipeline-step';
+
+      if (stepPhase === phase) {
+        if (state === 'failed') el.classList.add('failed');
+        else if (state === 'done') el.classList.add('done');
+        else el.classList.add('active');
+        if (!icon) return;
+        if (state === 'done') {
+          icon.textContent = '✓';
+        } else if (state === 'failed') {
+          icon.textContent = '✗';
+        } else {
+          icon.replaceChildren();
+          var spinner = document.createElement('span');
+          spinner.className = 'spinner';
+          icon.appendChild(spinner);
+        }
+        return;
+      }
+
+      if (!icon) return;
+      var stepIndex = phases.indexOf(stepPhase);
+      var currentIndex = phases.indexOf(phase);
+      if (stepIndex > -1 && currentIndex > -1 && stepIndex < currentIndex) {
+        el.classList.add('done');
+        icon.textContent = '✓';
+      } else {
+        icon.textContent = '○';
+      }
+    });
+  }
+
+  function mapPhase(customStatus, runtimeStatus) {
+    var phases = analysisPhases();
+    var appRuns = window.CanopexAppRuns || {};
+    if (typeof appRuns.mapPhase === 'function') {
+      return appRuns.mapPhase(customStatus, runtimeStatus, phases);
+    }
+    if (runtimeStatus === 'Completed') return 'complete';
+    if (customStatus && customStatus.phase && phases.indexOf(customStatus.phase) > -1) {
+      return customStatus.phase;
+    }
+    return 'submit';
+  }
+
+  function updateStory(phase, runtimeStatus, data) {
+    var phases = analysisPhases();
+    var runtime = runtimeStatus || 'Pending';
+    var activeProfile = _getActiveProfile ? _getActiveProfile() : {};
+    var defaultPhaseDetails = _getAnalysisPhaseDetails ? _getAnalysisPhaseDetails() : {};
+    var phaseDetails = activeProfile.phaseDetails || defaultPhaseDetails;
+    var detail = phaseDetails[phase] || 'Working through the analysis pipeline.';
+    var timing = _summarizeRunTiming ? _summarizeRunTiming(data) : {};
+
+    if (runtime !== 'Completed' && phase === 'enrichment') {
+      var cs = data && data.customStatus;
+      var step = cs && cs.step;
+      const stepLabel = step && ENRICHMENT_STEP_LABELS[step];
+      if (stepLabel) {
+        detail = stepLabel;
+        if (step === 'per_aoi' && cs.aois) {
+          detail += ' (' + cs.aois + ' AOIs)';
+        }
+      } else {
+        detail += ' Enrichment batches weather, flood/fire checks, mosaic registration, NDVI, and change detection in parallel.';
+      }
+      if (timing.sinceUpdate) {
+        detail += ' Last backend update ' + timing.sinceUpdate + ' ago.';
+      }
+      // Drive the nested sub-step progress indicators.
+      if (step) updateEnrichmentSubSteps(step);
+    } else if (phase !== 'enrichment') {
+      // Past enrichment (complete) — mark all sub-steps done.
+      // Before enrichment — keep sub-steps hidden.
+      const enrichIdx = phases.indexOf('enrichment');
+      const phaseIdx = phases.indexOf(phase);
+      if (phaseIdx > enrichIdx) {
+        completeEnrichmentSubSteps();
+      } else {
+        resetEnrichmentSubSteps();
+      }
+      if (runtime !== 'Completed' && timing.elapsed) {
+        detail += ' Elapsed ' + timing.elapsed + '.';
+      }
+    } else {
+      // Completed while on enrichment phase — mark all sub-steps done.
+      completeEnrichmentSubSteps();
+    }
+
+    if (!_setAnalysisStatus) return;
+    if (runtime === 'Completed') {
+      _setAnalysisStatus(detail, 'success');
+      return;
+    }
+    if (runtime === 'Failed' || runtime === 'Canceled' || runtime === 'Terminated') {
+      _setAnalysisStatus('Analysis stopped during ' + phase + '. ' + detail, 'error');
+      return;
+    }
+    _setAnalysisStatus(detail, 'info');
+  }
+
+  window.CanopexAnalysisProgress = {
+    init: init,
+    reset: reset,
+    setVisible: setVisible,
+    setStep: setStep,
+    mapPhase: mapPhase,
+    updateStory: updateStory,
+  };
+})();

--- a/website/js/app-auth.js
+++ b/website/js/app-auth.js
@@ -30,6 +30,8 @@
   var _getAnalysisHistoryLoaded = null;
   var _getLatestAnalysisRun = null;
   var _clearAnalysisState = null;
+  var _clearAllCache = null;
+  var _postLoginDestinationKey = null;
 
   function init(deps) {
     _authEnabled = deps.authEnabled;
@@ -52,6 +54,31 @@
     _getAnalysisHistoryLoaded = deps.getAnalysisHistoryLoaded;
     _getLatestAnalysisRun = deps.getLatestAnalysisRun;
     _clearAnalysisState = deps.clearAnalysisState;
+    _clearAllCache = deps.clearAllCache;
+    _postLoginDestinationKey = deps.postLoginDestinationKey || 'canopex-post-login';
+  }
+
+  function authEnabled() {
+    return true;
+  }
+
+  function rememberPostLoginDestination() {
+    try {
+      sessionStorage.setItem(_postLoginDestinationKey, 'app');
+    } catch (_) { /* ignore */ }
+  }
+
+  function login() {
+    rememberPostLoginDestination();
+    window.location.href = '/.auth/login/aad';
+  }
+
+  function logout() {
+    if (_clearAllCache) _clearAllCache();
+    try {
+      sessionStorage.removeItem(_postLoginDestinationKey);
+    } catch (_) { /* ignore */ }
+    window.location.href = '/.auth/logout';
   }
 
   // ── updateAuthUI ─────────────────────────────────────────────
@@ -197,7 +224,10 @@
   // ── Public API ────────────────────────────────────────────────
 
   window.CanopexAuth = {
+    authEnabled: authEnabled,
     init: init,
+    login: login,
+    logout: logout,
     updateAuthUI: updateAuthUI,
     initAuth: initAuth,
   };

--- a/website/js/app-auth.js
+++ b/website/js/app-auth.js
@@ -32,6 +32,8 @@
   var _clearAnalysisState = null;
   var _clearAllCache = null;
   var _postLoginDestinationKey = null;
+  var _clearClientAuth = null;
+  var _setAnalysisStatus = null;
 
   function init(deps) {
     _authEnabled = deps.authEnabled;
@@ -56,6 +58,8 @@
     _clearAnalysisState = deps.clearAnalysisState;
     _clearAllCache = deps.clearAllCache;
     _postLoginDestinationKey = deps.postLoginDestinationKey || 'canopex-post-login';
+    _clearClientAuth = deps.clearClientAuth;
+    _setAnalysisStatus = deps.setAnalysisStatus;
   }
 
   function authEnabled() {
@@ -79,6 +83,17 @@
       sessionStorage.removeItem(_postLoginDestinationKey);
     } catch (_) { /* ignore */ }
     window.location.href = '/.auth/logout';
+  }
+
+  function handleApiError(err) {
+    if (!err || err.status !== 401 || !authEnabled()) return;
+    if (_setAccount) _setAccount(null);
+    if (_clearClientAuth) _clearClientAuth();
+    if (_updateAuthUI) _updateAuthUI();
+    if (_setAnalysisStatus) {
+      _setAnalysisStatus('Your session has expired. Please sign in again.', 'error');
+    }
+    if (_stopAnalysisPolling) _stopAnalysisPolling();
   }
 
   // ── updateAuthUI ─────────────────────────────────────────────
@@ -225,6 +240,7 @@
 
   window.CanopexAuth = {
     authEnabled: authEnabled,
+    handleApiError: handleApiError,
     init: init,
     login: login,
     logout: logout,

--- a/website/js/app-auth.js
+++ b/website/js/app-auth.js
@@ -1,0 +1,204 @@
+/**
+ * app-auth.js
+ *
+ * SWA built-in auth bootstrap: /.auth/me check, updateAuthUI DOM updates,
+ * and HMAC session token acquisition (#534). Extracted from app-shell.js.
+ *
+ * Exposes window.CanopexAuth = { init, updateAuthUI, initAuth }
+ */
+(function () {
+  'use strict';
+
+  // ── Injected deps ────────────────────────────────────────────
+  var _authEnabled = null;
+  var _getApiReady = null;
+  var _getAccount = null;
+  var _setAccount = null;
+  var _setClientPrincipal = null;
+  var _setSessionToken = null;
+  var _apiFetch = null;
+  var _getAppBase = null;
+  var _loadAnalysisHistory = null;
+  var _loadBillingStatus = null;
+  var _loadEudrUsage = null;
+  var _setHeroRunSummary = null;
+  var _updateHistorySummary = null;
+  var _renderAnalysisHistoryList = null;
+  var _stopAnalysisPolling = null;
+  var _resetAnalysisProgress = null;
+  var _updateAnalysisRun = null;
+  var _getAnalysisHistoryLoaded = null;
+  var _getLatestAnalysisRun = null;
+  var _clearAnalysisState = null;
+
+  function init(deps) {
+    _authEnabled = deps.authEnabled;
+    _getApiReady = deps.getApiReady;
+    _getAccount = deps.getAccount;
+    _setAccount = deps.setAccount;
+    _setClientPrincipal = deps.setClientPrincipal;
+    _setSessionToken = deps.setSessionToken;
+    _apiFetch = deps.apiFetch;
+    _getAppBase = deps.getAppBase;
+    _loadAnalysisHistory = deps.loadAnalysisHistory;
+    _loadBillingStatus = deps.loadBillingStatus;
+    _loadEudrUsage = deps.loadEudrUsage;
+    _setHeroRunSummary = deps.setHeroRunSummary;
+    _updateHistorySummary = deps.updateHistorySummary;
+    _renderAnalysisHistoryList = deps.renderAnalysisHistoryList;
+    _stopAnalysisPolling = deps.stopAnalysisPolling;
+    _resetAnalysisProgress = deps.resetAnalysisProgress;
+    _updateAnalysisRun = deps.updateAnalysisRun;
+    _getAnalysisHistoryLoaded = deps.getAnalysisHistoryLoaded;
+    _getLatestAnalysisRun = deps.getLatestAnalysisRun;
+    _clearAnalysisState = deps.clearAnalysisState;
+  }
+
+  // ── updateAuthUI ─────────────────────────────────────────────
+
+  function updateAuthUI() {
+    var loginBtn = document.getElementById('auth-login-btn');
+    var logoutBtn = document.getElementById('auth-logout-btn');
+    var userSpan = document.getElementById('auth-user');
+    var gate = document.getElementById('app-unauthenticated');
+    var dashboard = document.getElementById('app-dashboard');
+    var userName = document.getElementById('app-user-name');
+    var accountIdentifier = document.getElementById('app-account-identifier');
+    var accountNote = document.getElementById('app-account-note');
+    var billingBtn = document.getElementById('app-manage-billing-btn');
+
+    var authOk = typeof _authEnabled === 'function' ? _authEnabled() : true;
+    var currentAccount = _getAccount ? _getAccount() : null;
+    var apiReady = _getApiReady ? _getApiReady() : Promise.resolve();
+
+    if (!authOk) {
+      loginBtn.style.display = 'none';
+      logoutBtn.style.display = 'none';
+      userSpan.textContent = 'Local dev';
+      userSpan.style.display = 'inline';
+      gate.hidden = true;
+      dashboard.hidden = false;
+      var localAuthGate = document.getElementById('app-analysis-auth-gate');
+      var localFormFields = document.getElementById('app-analysis-form-fields');
+      if (localAuthGate) localAuthGate.hidden = true;
+      if (localFormFields) localFormFields.hidden = false;
+      userName.textContent = 'Local developer';
+      accountIdentifier.textContent = 'Authentication disabled';
+      accountNote.textContent = 'Auth is disabled in this environment, so this workspace is running in local development mode.';
+      billingBtn.style.display = 'none';
+      document.getElementById('app-tier').textContent = 'Local';
+      document.getElementById('app-subscription-status').textContent = 'disabled';
+      document.getElementById('app-runs-remaining').textContent = 'n/a';
+      document.getElementById('app-concurrency').textContent = 'n/a';
+      document.getElementById('app-ai-access').textContent = 'n/a';
+      document.getElementById('app-api-access').textContent = 'n/a';
+      document.getElementById('app-retention').textContent = 'n/a';
+      document.getElementById('app-billing-note').textContent = 'Billing is unavailable when auth is disabled';
+      document.getElementById('app-tier-emulation-card').hidden = true;
+      apiReady.then(function () { if (_loadAnalysisHistory) _loadAnalysisHistory(); });
+      return;
+    }
+
+    if (currentAccount) {
+      var displayName = currentAccount.name || currentAccount.userId || 'User';
+      var identifier = currentAccount.userId || currentAccount.name || 'Signed in';
+      userSpan.textContent = displayName;
+      userSpan.style.display = 'inline';
+      loginBtn.style.display = 'none';
+      logoutBtn.style.display = 'inline';
+      gate.hidden = true;
+      dashboard.hidden = false;
+      userName.textContent = displayName;
+      accountIdentifier.textContent = identifier;
+      accountNote.textContent = 'This is your Canopex dashboard. Choose the analysis type and work preference that match the job at hand.';
+      var analysisAuthGate = document.getElementById('app-analysis-auth-gate');
+      var analysisFormFields = document.getElementById('app-analysis-form-fields');
+      var historyCard = document.getElementById('app-history-card');
+      if (analysisAuthGate) analysisAuthGate.hidden = true;
+      if (analysisFormFields) analysisFormFields.hidden = false;
+      if (historyCard) historyCard.hidden = false;
+      var historyLoaded = _getAnalysisHistoryLoaded ? _getAnalysisHistoryLoaded() : false;
+      var latestRun = _getLatestAnalysisRun ? _getLatestAnalysisRun() : null;
+      if (!historyLoaded && !latestRun) {
+        if (_setHeroRunSummary) _setHeroRunSummary('Checking recent runs', 'Loading your recent runs.');
+        if (_updateHistorySummary) _updateHistorySummary(null);
+        if (_renderAnalysisHistoryList) _renderAnalysisHistoryList();
+      }
+      apiReady.then(function () { if (_loadBillingStatus) _loadBillingStatus(); });
+      apiReady.then(function () { if (_loadEudrUsage) _loadEudrUsage(); });
+      apiReady.then(function () { if (_loadAnalysisHistory) _loadAnalysisHistory(); });
+    } else {
+      userSpan.style.display = 'none';
+      loginBtn.style.display = 'inline';
+      logoutBtn.style.display = 'none';
+      gate.hidden = false;
+      dashboard.hidden = true;
+      billingBtn.style.display = 'none';
+      var unauthGate = document.getElementById('app-analysis-auth-gate');
+      var unauthFormFields = document.getElementById('app-analysis-form-fields');
+      if (unauthGate) unauthGate.hidden = false;
+      if (unauthFormFields) unauthFormFields.hidden = true;
+      if (_clearAnalysisState) _clearAnalysisState();
+      if (_stopAnalysisPolling) _stopAnalysisPolling();
+      if (_resetAnalysisProgress) _resetAnalysisProgress();
+      if (_renderAnalysisHistoryList) _renderAnalysisHistoryList();
+      if (_updateAnalysisRun) _updateAnalysisRun(null);
+    }
+  }
+
+  // ── initAuth ─────────────────────────────────────────────────
+
+  function initAuth() {
+    // Strip legacy ?mode=demo from URL if present
+    try {
+      const url = new URL(window.location.href);
+      if (url.searchParams.get('mode') === 'demo') {
+        url.searchParams.delete('mode');
+        const nextUrl = url.pathname + (url.search || '') + (url.hash || '');
+        const appBase = _getAppBase ? _getAppBase() : '/app/';
+        window.history.replaceState({}, '', nextUrl || appBase);
+      }
+    } catch { /* ignore */ }
+
+    // SWA built-in auth: fetch /.auth/me to check if the user is signed in.
+    fetch('/.auth/me').then(function (resp) {
+      if (!resp.ok) throw new Error('auth/me failed');
+      return resp.json();
+    }).then(function (payload) {
+      var principal = payload && payload.clientPrincipal;
+      if (principal && principal.userId) {
+        if (_setClientPrincipal) _setClientPrincipal(principal); // store raw for X-MS-CLIENT-PRINCIPAL forwarding
+        if (_setAccount) {
+          _setAccount({
+            userId: principal.userId,
+            name: principal.userDetails || '',
+            identityProvider: principal.identityProvider || 'aad',
+            userRoles: principal.userRoles || [],
+          });
+        }
+        // Acquire HMAC session token for principal verification (#534).
+        // Waits for API base discovery so the request goes to the right host.
+        var apiReady = _getApiReady ? _getApiReady() : Promise.resolve();
+        (apiReady || Promise.resolve()).then(function () {
+          return _apiFetch('/api/auth/session', { method: 'POST' });
+        }).then(function (resp) { return resp.json(); }).then(function (data) {
+          if (data && data.token && _setSessionToken) _setSessionToken(data.token);
+        }).catch(function () { /* session token unavailable — backend may not enforce HMAC */ });
+      }
+      updateAuthUI();
+    }).catch(function (err) {
+      console.warn('SWA auth check failed:', err);
+      // When running locally without SWA CLI, auth/me won't exist.
+      // Fall back to unauthenticated state — updateAuthUI handles it.
+      updateAuthUI();
+    });
+  }
+
+  // ── Public API ────────────────────────────────────────────────
+
+  window.CanopexAuth = {
+    init: init,
+    updateAuthUI: updateAuthUI,
+    initAuth: initAuth,
+  };
+})();

--- a/website/js/app-billing.js
+++ b/website/js/app-billing.js
@@ -1,0 +1,248 @@
+/**
+ * app-billing.js
+ *
+ * Billing status display, tier emulation, and Stripe portal management.
+ * Stateful: tracks the latest billing status internally and notifies the
+ * shell via onStatusChange so cross-cutting reads (AI block, quota label)
+ * stay consistent.
+ *
+ * Exposes: window.CanopexBilling
+ *
+ * Contract:
+ *   init(deps)           — call once at boot, before initAuth
+ *   apply(data)          — apply a billing status payload (DOM + state)
+ *   load()               — fetch /api/billing/status and apply
+ *   manage()             — open Stripe portal or interest mailto
+ *   saveEmulation()      — POST /api/billing/emulation with selected tier
+ *   getStatus()          — return latest billing status (or null)
+ */
+(function () {
+  'use strict';
+
+  var _apiFetch = null;
+  var _getApiReady = null;
+  var _getAccount = null;
+  var _login = null;
+  var _readCache = null;
+  var _writeCache = null;
+  var _clearCacheKey = null;
+  var _onStatusChange = null;
+  var _onLoadError = null;
+
+  var _latestBillingStatus = null;
+
+  var CACHE_TTL_BILLING = 5 * 60 * 1000; // 5 minutes
+
+  function init(deps) {
+    _apiFetch = deps.apiFetch;
+    _getApiReady = deps.getApiReady;
+    _getAccount = deps.getAccount;
+    _login = deps.login;
+    _readCache = deps.readCache;
+    _writeCache = deps.writeCache;
+    _clearCacheKey = deps.clearCacheKey;
+    _onStatusChange = deps.onStatusChange || function () {};
+    _onLoadError = deps.onLoadError || function () {};
+  }
+
+  function getStatus() {
+    return _latestBillingStatus;
+  }
+
+  // ── Pure display helpers ──────────────────────────────────────
+
+  function updateCapabilityFields(caps) {
+    var formatRetention = (window.CanopexHelpers && window.CanopexHelpers.formatRetention) || function (d) { return d != null ? String(d) + 'd' : '—'; };
+    var concEl = document.getElementById('app-concurrency');
+    var aiEl = document.getElementById('app-ai-access');
+    var apiEl = document.getElementById('app-api-access');
+    var retEl = document.getElementById('app-retention');
+    if (concEl) concEl.textContent = caps.concurrency == null ? '—' : String(caps.concurrency);
+    if (aiEl) aiEl.textContent = caps.ai_insights ? 'Included' : 'Not included';
+    if (apiEl) apiEl.textContent = caps.api_access ? 'Enabled' : 'Not included';
+    if (retEl) retEl.textContent = formatRetention(caps.retention_days);
+  }
+
+  function renderTierEmulation(data) {
+    var card = document.getElementById('app-tier-emulation-card');
+    var select = document.getElementById('app-tier-emulation-select');
+    var note = document.getElementById('app-tier-emulation-note');
+
+    if (!card || !select || !note) return;
+
+    if (!data.emulation || !data.emulation.available) {
+      card.hidden = true;
+      return;
+    }
+
+    card.hidden = false;
+    select.replaceChildren();
+
+    var actualOption = document.createElement('option');
+    actualOption.value = 'actual';
+    actualOption.textContent = 'Actual billing state';
+    select.appendChild(actualOption);
+
+    (data.emulation.tiers || []).forEach(function (tier) {
+      var option = document.createElement('option');
+      option.value = tier;
+      option.textContent = tier.charAt(0).toUpperCase() + tier.slice(1);
+      select.appendChild(option);
+    });
+
+    select.value = data.emulation.active ? data.emulation.tier : 'actual';
+    if (data.emulation.active) {
+      note.textContent = 'Currently emulating ' + (data.capabilities.label || data.tier) + ' for your account. Billing remains ' + ((data.subscription && data.subscription.tier) || 'free') + '.';
+    } else {
+      note.textContent = 'Using the actual billing state for this account.';
+    }
+  }
+
+  // ── Status application ────────────────────────────────────────
+
+  function apply(data) {
+    var tierEl = document.getElementById('app-tier');
+    var statusEl = document.getElementById('app-subscription-status');
+    var remainingEl = document.getElementById('app-runs-remaining');
+    var billingNoteEl = document.getElementById('app-billing-note');
+    var billingBtn = document.getElementById('app-manage-billing-btn');
+    var accountNote = document.getElementById('app-account-note');
+    var caps = data.capabilities || {};
+
+    _latestBillingStatus = data;
+
+    if (tierEl) tierEl.textContent = (caps.label || data.tier || 'Free') + (data.tier_source === 'emulated' ? ' (emulated)' : '');
+    if (statusEl) statusEl.textContent = data.status || 'none';
+    if (remainingEl) remainingEl.textContent = data.runs_remaining == null ? '—' : String(data.runs_remaining);
+    var usedEl = document.getElementById('app-runs-used');
+    if (usedEl) usedEl.textContent = data.runs_used == null ? '—' : String(data.runs_used);
+    updateCapabilityFields(caps);
+
+    if (data.tier_source === 'emulated') {
+      if (billingNoteEl) billingNoteEl.textContent = 'Local tier override active. Real billing is ' + ((data.subscription && data.subscription.tier) || 'free') + '.';
+      if (billingBtn) billingBtn.style.display = data.billing_configured ? 'inline-block' : 'none';
+      if (accountNote) accountNote.textContent = 'Use the role view and work preference controls to tune this workspace for the job at hand.';
+    } else if (data.billing_gated) {
+      if (billingNoteEl) billingNoteEl.textContent = 'Billing is not yet available for your account. Contact us to express interest.';
+      if (billingBtn) { billingBtn.textContent = 'Express Interest'; billingBtn.style.display = 'inline-block'; }
+      if (accountNote) accountNote.textContent = 'You are on the free plan. Express interest to unlock paid tiers when billing becomes available.';
+    } else if (data.billing_configured) {
+      if (billingNoteEl) billingNoteEl.textContent = 'Stripe customer portal available';
+      if (billingBtn) { billingBtn.textContent = 'Billing'; billingBtn.style.display = 'inline-block'; }
+      if (accountNote) accountNote.textContent = 'Use the role view and work preference controls to bias the workspace toward investigation, monitoring, or reporting.';
+    } else {
+      if (billingNoteEl) billingNoteEl.textContent = 'Billing is not configured in this environment';
+      if (billingBtn) billingBtn.style.display = 'none';
+      if (accountNote) accountNote.textContent = 'Use the role view and work preference controls to bias the workspace toward investigation, monitoring, or reporting.';
+    }
+
+    renderTierEmulation(data);
+
+    // Show EUDR toggle only for paid tiers
+    var eudrToggle = document.getElementById('app-eudr-toggle');
+    if (eudrToggle) {
+      var paidTiers = ['starter', 'pro', 'team', 'enterprise'];
+      eudrToggle.hidden = !paidTiers.includes(data.tier);
+    }
+
+    // Notify shell for cross-cutting reads (hero summary, AI block, quota labels)
+    _onStatusChange(data);
+  }
+
+  // ── Async operations ──────────────────────────────────────────
+
+  async function load() {
+    var apiReady = _getApiReady ? _getApiReady() : null;
+    if (apiReady) await apiReady;
+    if (_getAccount && !_getAccount()) return;
+
+    // Render cached billing data instantly while fetching fresh data
+    var cached = _readCache && _readCache('billing');
+    if (cached) apply(cached);
+
+    try {
+      var res = await _apiFetch('/api/billing/status');
+      var data = await res.json();
+      if (_writeCache) _writeCache('billing', data, CACHE_TTL_BILLING);
+      apply(data);
+    } catch {
+      // Only show error state if we had no cached data to show
+      if (!cached) {
+        var tierEl = document.getElementById('app-tier');
+        var statusEl = document.getElementById('app-subscription-status');
+        var remainingEl = document.getElementById('app-runs-remaining');
+        var billingNoteEl = document.getElementById('app-billing-note');
+        var billingBtn = document.getElementById('app-manage-billing-btn');
+        if (tierEl) tierEl.textContent = 'Unknown';
+        if (statusEl) statusEl.textContent = 'Unavailable';
+        if (remainingEl) remainingEl.textContent = '—';
+        if (billingNoteEl) billingNoteEl.textContent = 'Could not load billing state';
+        if (billingBtn) billingBtn.style.display = 'none';
+        updateCapabilityFields({});
+        _onLoadError();
+      }
+    }
+  }
+
+  async function manage() {
+    // If billing is gated for this user, redirect to express interest
+    if (_latestBillingStatus && _latestBillingStatus.billing_gated) {
+      window.location.href = 'mailto:hello@canopex.io';
+      return;
+    }
+
+    if (_getAccount && !_getAccount()) {
+      if (_login) _login();
+      return;
+    }
+
+    var apiReady = _getApiReady ? _getApiReady() : null;
+    if (apiReady) await apiReady;
+    try {
+      var res = await _apiFetch('/api/billing/portal', { method: 'POST' });
+      var data = await res.json();
+      if (data.portal_url) window.location.href = data.portal_url;
+    } catch (err) {
+      alert((err && err.message) || 'Could not open billing portal. Please try again.');
+    }
+  }
+
+  async function saveEmulation() {
+    if (_getAccount && !_getAccount()) {
+      if (_login) _login();
+      return;
+    }
+
+    var button = document.getElementById('app-apply-tier-emulation-btn');
+    var select = document.getElementById('app-tier-emulation-select');
+    if (!button || !select) return;
+
+    button.disabled = true;
+    button.textContent = 'Applying…';
+    try {
+      var apiReady = _getApiReady ? _getApiReady() : null;
+      if (apiReady) await apiReady;
+      var res = await _apiFetch('/api/billing/emulation', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tier: select.value })
+      });
+      if (_clearCacheKey) _clearCacheKey('billing');
+      apply(await res.json());
+    } catch (err) {
+      alert((err && err.message) || 'Could not update plan emulation. Please try again.');
+    } finally {
+      button.disabled = false;
+      button.textContent = 'Apply';
+    }
+  }
+
+  window.CanopexBilling = {
+    init: init,
+    apply: apply,
+    load: load,
+    manage: manage,
+    saveEmulation: saveEmulation,
+    getStatus: getStatus,
+  };
+})();

--- a/website/js/app-bindings.js
+++ b/website/js/app-bindings.js
@@ -1,0 +1,234 @@
+/**
+ * app-bindings.js
+ *
+ * All DOM event listener registrations for the Canopex app.
+ * Extracted from app-shell.js to reduce shell size and group
+ * all click/input/change wiring in one place.
+ *
+ * Exposes window.CanopexBindings = { init }
+ */
+(function () {
+  'use strict';
+
+  // ── Injected deps ────────────────────────────────────────────
+  var _deps = {};
+
+  function init(deps) {
+    _deps = deps || {};
+    _registerAll();
+  }
+
+  // ── Helper ────────────────────────────────────────────────────
+
+  function bindClick(id, handler) {
+    var coreDom = window.CanopexCoreDom || {};
+    if (typeof coreDom.bindClick === 'function') {
+      coreDom.bindClick(id, handler);
+      return;
+    }
+    var el = document.getElementById(id);
+    if (el) el.addEventListener('click', handler);
+  }
+
+  // ── All registrations ─────────────────────────────────────────
+
+  function _registerAll() {
+    var d = _deps;
+
+    // Workspace role / preference chooser cards
+    document.querySelectorAll('[data-role-choice]').forEach(function (button) {
+      button.addEventListener('click', function () {
+        if (d.setWorkspaceRole) d.setWorkspaceRole(button.getAttribute('data-role-choice'));
+      });
+    });
+
+    document.querySelectorAll('[data-preference-choice]').forEach(function (button) {
+      button.addEventListener('click', function () {
+        if (d.setWorkspacePreference) d.setWorkspacePreference(button.getAttribute('data-preference-choice'));
+      });
+    });
+
+    // Auth
+    bindClick('auth-login-btn', function () { if (d.login) d.login(); });
+    bindClick('auth-logout-btn', function () { if (d.logout) d.logout(); });
+    bindClick('app-sign-in-btn', function () { if (d.login) d.login(); });
+    bindClick('app-analysis-sign-in-btn', function () { if (d.login) d.login(); });
+
+    // Billing / account
+    bindClick('app-manage-billing-btn', function () { if (d.manageBilling) d.manageBilling(); });
+    bindClick('app-apply-tier-emulation-btn', function () { if (d.saveTierEmulation) d.saveTierEmulation(); });
+
+    // Guided workflow
+    bindClick('app-guided-primary-btn', function () {
+      var target = this.getAttribute('data-target');
+      if (d.revealWorkflowTarget && d.currentPreferenceConfig) {
+        d.revealWorkflowTarget(target || d.currentPreferenceConfig().primaryTarget);
+      }
+    });
+    bindClick('app-guided-secondary-btn', function () {
+      var target = this.getAttribute('data-target');
+      if (d.revealWorkflowTarget && d.currentPreferenceConfig) {
+        d.revealWorkflowTarget(target || d.currentPreferenceConfig().secondaryTarget);
+      }
+    });
+
+    // Analysis submit
+    bindClick('app-analysis-submit-btn', function () { if (d.queueAnalysis) d.queueAnalysis(); });
+
+    // Run-link copy-to-clipboard
+    bindClick('app-run-link', function (event) {
+      var el = document.getElementById('app-run-link');
+      var href = el && el.href;
+      if (!href) return;
+      if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
+        return; // Let normal navigation proceed
+      }
+      var fullUrl = new URL(href, window.location.origin).href;
+      event.preventDefault();
+      try {
+        navigator.clipboard.writeText(fullUrl).then(function () {
+          if (el._copyTimer) clearTimeout(el._copyTimer);
+          var prev = el.textContent;
+          el.textContent = 'Link copied!';
+          el._copyTimer = setTimeout(function () {
+            if (el.textContent === 'Link copied!') el.textContent = prev;
+            el._copyTimer = null;
+          }, 1500);
+        }).catch(function () {
+          window.location.href = href;
+        });
+      } catch (_) {
+        window.location.href = href;
+      }
+    });
+
+    // Run export format buttons (data-export-format)
+    document.querySelectorAll('[data-export-format]').forEach(function (button) {
+      button.addEventListener('click', function (event) {
+        event.stopPropagation();
+        if (d.downloadRunExport) d.downloadRunExport(button.getAttribute('data-export-format'));
+      });
+    });
+
+    // KML text input
+    var kmlInput = document.getElementById('app-analysis-kml');
+    if (kmlInput) {
+      kmlInput.addEventListener('input', function () {
+        if (d.updateAnalysisPreflight) d.updateAnalysisPreflight(this.value);
+      });
+    }
+
+    // File upload
+    var fileInput = document.getElementById('app-analysis-file');
+    if (fileInput) {
+      fileInput.addEventListener('change', function () {
+        if (this.files && this.files[0] && d.loadAnalysisFile) d.loadAnalysisFile(this.files[0]);
+      });
+    }
+
+    // Input tab switching (KML / CSV)
+    document.querySelectorAll('[data-input-tab]').forEach(function (tab) {
+      tab.addEventListener('click', function () {
+        if (d.switchInputTab) d.switchInputTab(this.getAttribute('data-input-tab'));
+      });
+    });
+    bindClick('app-csv-convert-btn', function () { if (d.convertCSVToKml) d.convertCSVToKml(); });
+
+    // Evidence surface controls
+    bindClick('app-map-play-btn', function () { if (d.toggleEvidencePlay) d.toggleEvidencePlay(); });
+    var frameSlider = document.getElementById('app-map-frame-slider');
+    if (frameSlider) {
+      frameSlider.addEventListener('input', function () {
+        if (d.showEvidenceFrame) d.showEvidenceFrame(parseInt(this.value, 10));
+      });
+    }
+    bindClick('app-map-btn-rgb', function () { if (d.setEvidenceLayerMode) d.setEvidenceLayerMode('rgb'); });
+    bindClick('app-map-btn-ndvi', function () { if (d.setEvidenceLayerMode) d.setEvidenceLayerMode('ndvi'); });
+    bindClick('app-evidence-ai-btn', function () { if (d.requestAiAnalysis) d.requestAiAnalysis(); });
+    bindClick('app-evidence-eudr-btn', function () { if (d.requestEudrAssessment) d.requestEudrAssessment(); });
+
+    // Parcel notes (#669)
+    bindClick('app-evidence-notes-add-btn', function () { if (d.showNoteEditor) d.showNoteEditor(); });
+    bindClick('app-evidence-notes-cancel-btn', function () { if (d.hideNoteEditor) d.hideNoteEditor(); });
+    bindClick('app-evidence-notes-save-btn', function () { if (d.saveParcelNote) d.saveParcelNote(); });
+
+    // Override determination controls (#672)
+    bindClick('app-evidence-override-btn', function () {
+      if (d.getOverrideContext && d.openOverrideModal) {
+        var ctx = d.getOverrideContext();
+        d.openOverrideModal(ctx.parcelKey, ctx.aoiData);
+      }
+    });
+    bindClick('app-evidence-override-revert-btn', function () { if (d.revertOverride) d.revertOverride(); });
+    bindClick('app-override-confirm-btn', function () { if (d.confirmOverride) d.confirmOverride(); });
+    bindClick('app-override-cancel-btn', function () { if (d.closeOverrideModal) d.closeOverrideModal(); });
+    var overrideBackdrop = document.getElementById('app-override-backdrop');
+    if (overrideBackdrop) {
+      overrideBackdrop.addEventListener('click', function (e) {
+        if (e.target === this && d.closeOverrideModal) d.closeOverrideModal();
+      });
+    }
+    var overrideReasonInput = document.getElementById('app-override-reason-input');
+    if (overrideReasonInput) {
+      overrideReasonInput.addEventListener('input', function () {
+        if (d.onOverrideReasonInput) d.onOverrideReasonInput();
+      });
+    }
+
+    // Portfolio summary export (#674)
+    bindClick('app-summary-export-btn', function () {
+      if (!d.apiFetch) return;
+      var btn = document.getElementById('app-summary-export-btn');
+      if (btn) { btn.disabled = true; btn.textContent = 'Downloading\u2026'; }
+      d.apiFetch('/api/eudr/summary-export')
+        .then(function (res) {
+          if (!res.ok) throw new Error('Export failed (' + res.status + ')');
+          return res.blob();
+        })
+        .then(function (blob) {
+          var url = URL.createObjectURL(blob);
+          var a = document.createElement('a');
+          a.href = url;
+          a.download = 'eudr_summary_export.csv';
+          document.body.appendChild(a);
+          a.click();
+          document.body.removeChild(a);
+          URL.revokeObjectURL(url);
+        })
+        .catch(function (err) {
+          console.warn('EUDR summary export error:', err);
+          var note = document.getElementById('app-summary-export-note');
+          if (note) note.textContent = 'Export failed \u2014 try again';
+        })
+        .finally(function () {
+          if (btn) { btn.disabled = false; btn.textContent = 'Export all runs (CSV)'; }
+        });
+    });
+
+    // Expanded map viewer controls
+    bindClick('app-map-expand-btn', function () { if (d.expandEvidenceMap) d.expandEvidenceMap(); });
+    bindClick('app-map-collapse-btn', function () { if (d.collapseEvidenceMap) d.collapseEvidenceMap(); });
+    bindClick('app-map-btn-compare', function () { if (d.toggleCompareView) d.toggleCompareView(); }); // #671
+    var expandedBackdrop = document.getElementById('app-map-expanded-backdrop');
+    if (expandedBackdrop) {
+      expandedBackdrop.addEventListener('click', function (e) {
+        if (e.target === this && d.collapseEvidenceMap) d.collapseEvidenceMap();
+      });
+    }
+    bindClick('app-map-expanded-play-btn', function () { if (d.toggleEvidencePlay) d.toggleEvidencePlay(); });
+    var expandedSlider = document.getElementById('app-map-expanded-slider');
+    if (expandedSlider) {
+      expandedSlider.addEventListener('input', function () {
+        if (d.showEvidenceFrame) d.showEvidenceFrame(parseInt(this.value, 10));
+      });
+    }
+    bindClick('app-map-expanded-btn-rgb', function () { if (d.setEvidenceLayerMode) d.setEvidenceLayerMode('rgb'); });
+    bindClick('app-map-expanded-btn-ndvi', function () { if (d.setEvidenceLayerMode) d.setEvidenceLayerMode('ndvi'); });
+  }
+
+  // ── Public API ────────────────────────────────────────────────
+
+  window.CanopexBindings = {
+    init: init,
+  };
+})();

--- a/website/js/app-core-dom.js
+++ b/website/js/app-core-dom.js
@@ -30,10 +30,34 @@
     return true;
   }
 
+  function setAnalysisStatus(message, tone) {
+    var status = getById('app-analysis-status');
+    if (!status) return;
+    if (!message) {
+      status.hidden = true;
+      status.textContent = '';
+      status.removeAttribute('data-tone');
+      return;
+    }
+    status.hidden = false;
+    status.textContent = message;
+    status.setAttribute('data-tone', tone || 'info');
+  }
+
+  function setHeroRunSummary(title, note) {
+    var titleEl = getById('app-hero-active-run');
+    var noteEl = getById('app-hero-active-run-note');
+    if (!titleEl || !noteEl) return;
+    titleEl.textContent = title || 'Ready to queue';
+    noteEl.textContent = note || 'Ready to run an analysis.';
+  }
+
   window.CanopexCoreDom = {
     getById: getById,
     setText: setText,
     bindClick: bindClick,
     bindInput: bindInput,
+    setAnalysisStatus: setAnalysisStatus,
+    setHeroRunSummary: setHeroRunSummary,
   };
 })();

--- a/website/js/app-core-dom.js
+++ b/website/js/app-core-dom.js
@@ -1,0 +1,39 @@
+/**
+ * app-core-dom.js - Shared DOM helpers for app modules.
+ *
+ * Keep these helpers tiny and null-safe so module code can focus on
+ * behavior instead of repetitive element guards.
+ */
+(function () {
+  'use strict';
+
+  function getById(id) {
+    return document.getElementById(id);
+  }
+
+  function setText(id, value) {
+    var el = getById(id);
+    if (el) el.textContent = value;
+  }
+
+  function bindClick(id, handler) {
+    var el = getById(id);
+    if (!el) return false;
+    el.addEventListener('click', handler);
+    return true;
+  }
+
+  function bindInput(id, handler) {
+    var el = getById(id);
+    if (!el) return false;
+    el.addEventListener('input', handler);
+    return true;
+  }
+
+  window.CanopexCoreDom = {
+    getById: getById,
+    setText: setText,
+    bindClick: bindClick,
+    bindInput: bindInput,
+  };
+})();

--- a/website/js/app-core-state.js
+++ b/website/js/app-core-state.js
@@ -38,10 +38,72 @@
     }
   }
 
+  function scopedCacheKey(prefix, userId, key) {
+    if (!prefix || !userId || !key) return null;
+    return prefix + userId + ':' + key;
+  }
+
+  function readScopedCache(prefix, userId, key) {
+    try {
+      var full = scopedCacheKey(prefix, userId, key);
+      if (!full) return null;
+      var raw = localStorage.getItem(full);
+      if (!raw) return null;
+      var entry = JSON.parse(raw);
+      if (!entry || typeof entry.expires !== 'number' || Date.now() > entry.expires) {
+        localStorage.removeItem(full);
+        return null;
+      }
+      return entry.data;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function writeScopedCache(prefix, userId, key, data, ttlMs) {
+    if (!Number.isFinite(ttlMs)) return false;
+    try {
+      var full = scopedCacheKey(prefix, userId, key);
+      if (!full) return false;
+      localStorage.setItem(full, JSON.stringify({ data: data, expires: Date.now() + ttlMs }));
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function clearScopedCacheKey(prefix, userId, key) {
+    try {
+      var full = scopedCacheKey(prefix, userId, key);
+      if (full) localStorage.removeItem(full);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function clearAllScopedCache(prefix) {
+    try {
+      var keys = [];
+      for (var i = 0; i < localStorage.length; i++) {
+        var k = localStorage.key(i);
+        if (k && k.indexOf(prefix) === 0) keys.push(k);
+      }
+      keys.forEach(function (k) { localStorage.removeItem(k); });
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
   window.CanopexCoreState = {
     get: get,
     set: set,
     readStoredValue: readStoredValue,
     storeValue: storeValue,
+    readScopedCache: readScopedCache,
+    writeScopedCache: writeScopedCache,
+    clearScopedCacheKey: clearScopedCacheKey,
+    clearAllScopedCache: clearAllScopedCache,
   };
 })();

--- a/website/js/app-core-state.js
+++ b/website/js/app-core-state.js
@@ -1,0 +1,47 @@
+/**
+ * app-core-state.js - Shared state helpers for app modules.
+ *
+ * This is the initial Slice 1 foundation: simple in-memory state and
+ * localStorage-backed preference helpers.
+ */
+(function () {
+  'use strict';
+
+  var state = {
+    workspaceRole: 'conservation',
+    workspacePreference: 'investigate',
+  };
+
+  function get(key) {
+    return state[key];
+  }
+
+  function set(key, value) {
+    state[key] = value;
+    return value;
+  }
+
+  function readStoredValue(key) {
+    try {
+      return localStorage.getItem(key);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function storeValue(key, value) {
+    try {
+      localStorage.setItem(key, value);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  window.CanopexCoreState = {
+    get: get,
+    set: set,
+    readStoredValue: readStoredValue,
+    storeValue: storeValue,
+  };
+})();

--- a/website/js/app-eudr.js
+++ b/website/js/app-eudr.js
@@ -1,0 +1,55 @@
+/**
+ * app-eudr.js
+ *
+ * EUDR-specific pure helpers. No DOM, no fetch, no Leaflet.
+ *
+ * Exposes: window.CanopexEudr
+ *
+ * Contract:
+ *   computeCostEstimate(parcelCount, profile) → string label for the UI
+ */
+(function () {
+  'use strict';
+
+  /**
+   * Compute a human-readable cost/quota label for a pending EUDR submission.
+   *
+   * Returns '—' when:
+   *   - the active profile does not enable parcel cost estimates
+   *   - billing data is not yet loaded
+   *
+   * @param {number} parcelCount - number of parcels the user intends to submit
+   * @param {object} profile - active app profile (from CanopexAppProfiles.resolveActiveProfile())
+   * @returns {string}
+   */
+  function computeCostEstimate(parcelCount, profile) {
+    if (!profile || !profile.enableParcelCostEstimate || !parcelCount) return '—';
+    var billing = typeof window.eudrBillingData === 'function' ? window.eudrBillingData() : null;
+    if (!billing) return '—';
+
+    if (!billing.subscribed) {
+      var remaining = billing.trial_remaining != null ? billing.trial_remaining : 0;
+      if (remaining > 0) {
+        return parcelCount + ' parcel' + (parcelCount !== 1 ? 's' : '') + ' · ' +
+          remaining + ' free assessment' + (remaining !== 1 ? 's' : '') + ' left';
+      }
+      return 'Subscribe to continue';
+    }
+
+    // Pro subscriber — estimate only the incremental overage caused by this submission.
+    var used = billing.period_parcels_used || 0;
+    var included = billing.included_parcels || 10;
+    var remainingIncluded = Math.max(included - used, 0);
+    var overageParcels = Math.max(parcelCount - remainingIncluded, 0);
+    if (overageParcels === 0) {
+      return parcelCount + ' parcel' + (parcelCount !== 1 ? 's' : '') + ' included';
+    }
+    var rate = overageParcels >= 500 ? 1.80 : overageParcels >= 100 ? 2.50 : 3.00;
+    var cost = (overageParcels * rate).toFixed(2);
+    return overageParcels + ' overage × £' + rate.toFixed(2) + ' = £' + cost;
+  }
+
+  window.CanopexEudr = {
+    computeCostEstimate: computeCostEstimate,
+  };
+})();

--- a/website/js/app-eudr.js
+++ b/website/js/app-eudr.js
@@ -1,15 +1,82 @@
 /**
  * app-eudr.js
  *
- * EUDR-specific pure helpers. No DOM, no fetch, no Leaflet.
+ * EUDR-specific helpers: pure cost estimate + EUDR usage dashboard loader.
  *
  * Exposes: window.CanopexEudr
  *
  * Contract:
- *   computeCostEstimate(parcelCount, profile) → string label for the UI
+ *   init(deps)                    — wire apiFetch / getApiReady / getAccount
+ *   computeCostEstimate(n, prof)  → string label for the UI
+ *   loadUsage()                   → Promise<void>  — fetch + render /api/eudr/usage
  */
 (function () {
   'use strict';
+
+  var _apiFetch = null;
+  var _getApiReady = null;
+  var _getAccount = null;
+
+  function init(deps) {
+    _apiFetch    = deps.apiFetch    || _apiFetch;
+    _getApiReady = deps.getApiReady || _getApiReady;
+    _getAccount  = deps.getAccount  || _getAccount;
+  }
+
+  async function loadUsage() {
+    if (_getApiReady) await _getApiReady();
+    if (!_getAccount || !_getAccount()) return;
+
+    var includedEl     = document.getElementById('app-eudr-usage-included');
+    var overageEl      = document.getElementById('app-eudr-usage-overage');
+    var spendEl        = document.getElementById('app-eudr-usage-spend');
+    var nextTierEl     = document.getElementById('app-eudr-usage-next-tier');
+    var historyListEl  = document.getElementById('app-eudr-usage-history-list');
+    if (!includedEl) return; // card not present in this build
+
+    try {
+      var res = await _apiFetch('/api/eudr/usage');
+      if (!res.ok) return;
+      var data = await res.json();
+      var cur = data.current || {};
+
+      var periodUsed = cur.periodParcelsUsed || 0;
+      var included   = cur.includedParcels   || 0;
+      if (includedEl) includedEl.textContent = periodUsed + ' / ' + included;
+      if (overageEl)  overageEl.textContent  = (cur.overageParcels || 0) + ' parcels';
+      if (spendEl) {
+        var spend = cur.estimatedSpendGbp;
+        spendEl.textContent = (spend != null) ? ('£' + spend.toFixed(2)) : '—';
+      }
+      if (nextTierEl) {
+        if (cur.nextTierThreshold) {
+          var msg = cur.parcelsToNextTier + ' until next tier (£' + cur.nextTierRateGbp + '/parcel)';
+          nextTierEl.textContent = msg;
+          if (cur.within20PercentOfNextTier) nextTierEl.style.fontWeight = '600';
+        } else {
+          nextTierEl.textContent = 'Maximum tier reached';
+        }
+      }
+
+      if (historyListEl && data.history && data.history.length) {
+        var html = '<div class="app-usage-history-list">';
+        data.history.forEach(function(m) {
+          html += '<div class="app-usage-row">' +
+            '<strong>' + (m.month || '') + '</strong>' +
+            '<span>' + (m.runs || 0) + ' runs</span>' +
+            '<span>' + (m.parcels || 0) + ' parcels</span>' +
+            (m.overageRuns ? '<span class="app-warning-text">' + m.overageRuns + ' overage</span>' : '') +
+            '</div>';
+        });
+        html += '</div>';
+        historyListEl.innerHTML = html;
+      } else if (historyListEl) {
+        historyListEl.textContent = 'No usage history yet.';
+      }
+    } catch (e) {
+      console.warn('EUDR usage load error:', e);
+    }
+  }
 
   /**
    * Compute a human-readable cost/quota label for a pending EUDR submission.
@@ -50,6 +117,8 @@
   }
 
   window.CanopexEudr = {
+    init: init,
     computeCostEstimate: computeCostEstimate,
+    loadUsage: loadUsage,
   };
 })();

--- a/website/js/app-evidence-display.js
+++ b/website/js/app-evidence-display.js
@@ -1,0 +1,1071 @@
+/**
+ * app-evidence-display.js
+ *
+ * Evidence surface: Leaflet map, frame/layer/compare controls, expand/collapse,
+ * per-AOI selection, AI analysis, EUDR assessment, and the clearEvidencePanels
+ * reset helper. Extracted from app-shell.js.
+ *
+ * Depends (window globals):
+ *   L                       — Leaflet
+ *   CanopexEvidenceRender   — pcTileUrl, pcNdviTileUrl, renderEvidenceNdvi,
+ *                             renderEvidenceWeather, renderEvidenceChangeDetection,
+ *                             renderEvidenceAnalysis, renderAoiDetail, clearAoiDetail,
+ *                             renderResourceUsage
+ *   CanopexHelpers          — createCallout
+ *   CanopexEvidenceMap      — pickDefaultLayer, pickInitialFrameIndex,
+ *                             buildNdviTimeseries, latLon
+ *   CanopexEvidencePanels   — parcelKeyForIndex, renderParcelNotes, renderParcelOverride
+ *
+ * Exposes window.CanopexEvidenceDisplay = {
+ *   init, load, clear, showSurface, expand, collapse,
+ *   showFrame, setLayerMode, toggleCompare, togglePlay, stopPlay,
+ *   requestAi, requestEudr, getManifest, getInstanceId, getOverrideContext
+ * }
+ */
+(function () {
+  'use strict';
+
+  // ── Injected deps ────────────────────────────────────────────
+  var _apiFetch = null;
+  var _getApiReady = null;
+  var _getWorkspaceRole = null;
+  var _getLatestBillingStatus = null;
+
+  // ── Evidence state ───────────────────────────────────────────
+  var evidenceMap = null;
+  var evidenceMapLayers = [];
+  var evidenceFrameIndex = 0;
+  var evidenceLayerMode = 'rgb'; // 'rgb' | 'ndvi'
+  var evidencePlayInterval = null;
+  var evidenceManifest = null;
+  var evidenceAnalysis = null;
+  var evidenceInstanceId = null;
+  var evidenceMapExpanded = false;
+  var evidenceAoiPolygons = []; // Leaflet polygon layers for per-AOI click
+  var evidenceSelectedAoi = -1; // -1 = aggregate, >=0 = per-AOI index
+  var evidenceCompareMode = false; // #671 before/after compare state
+  var evidenceCompareMaps = null; // { before: L.Map, after: L.Map } | null
+
+  // Parcel notes + override context — kept here because they depend on
+  // which AOI is selected; the panels module mutates them through callbacks.
+  var _currentOverrideParcelKey = null;
+  var _currentOverrideAoiData = null;
+
+  // ── Dep accessors ────────────────────────────────────────────
+
+  function er() { return window.CanopexEvidenceRender || {}; }
+  function ep() { return window.CanopexEvidencePanels || {}; }
+  function em() { return window.CanopexEvidenceMap || {}; }
+
+  function init(deps) {
+    _apiFetch = deps.apiFetch;
+    _getApiReady = deps.getApiReady;
+    _getWorkspaceRole = deps.getWorkspaceRole;
+    _getLatestBillingStatus = deps.getLatestBillingStatus;
+  }
+
+  // ── Expand/collapse ──────────────────────────────────────────
+
+  function expandEvidenceMap() {
+    var mapEl = document.getElementById('app-evidence-map');
+    var backdrop = document.getElementById('app-map-expanded-backdrop');
+    var body = document.getElementById('app-map-expanded-body');
+    if (!mapEl || !backdrop || !body || evidenceMapExpanded) return;
+
+    body.appendChild(mapEl);
+    backdrop.hidden = false;
+    evidenceMapExpanded = true;
+
+    syncExpandedControls();
+
+    setTimeout(function () { if (evidenceMap) evidenceMap.invalidateSize(); }, 100);
+    document.addEventListener('keydown', _expandedEscHandler);
+  }
+
+  function collapseEvidenceMap() {
+    var mapEl = document.getElementById('app-evidence-map');
+    var backdrop = document.getElementById('app-map-expanded-backdrop');
+    var wrap = document.getElementById('app-evidence-map-wrap');
+    if (!mapEl || !backdrop || !wrap || !evidenceMapExpanded) return;
+
+    wrap.insertBefore(mapEl, wrap.firstChild);
+    backdrop.hidden = true;
+    evidenceMapExpanded = false;
+
+    setTimeout(function () { if (evidenceMap) evidenceMap.invalidateSize(); }, 100);
+    document.removeEventListener('keydown', _expandedEscHandler);
+  }
+
+  function _expandedEscHandler(e) {
+    if (e.key === 'Escape') collapseEvidenceMap();
+  }
+
+  function syncExpandedControls() {
+    var slider = document.getElementById('app-map-expanded-slider');
+    var counter = document.getElementById('app-map-expanded-counter');
+    var label = document.getElementById('app-map-expanded-label');
+    var rgbBtn = document.getElementById('app-map-expanded-btn-rgb');
+    var ndviBtn = document.getElementById('app-map-expanded-btn-ndvi');
+
+    if (slider && evidenceMapLayers.length) {
+      slider.max = evidenceMapLayers.length - 1;
+      slider.value = evidenceFrameIndex;
+    }
+    if (counter) counter.textContent = (evidenceFrameIndex + 1) + '/' + evidenceMapLayers.length;
+    if (label && evidenceMapLayers[evidenceFrameIndex]) {
+      var expandedFrame = evidenceMapLayers[evidenceFrameIndex];
+      label.textContent = expandedFrame.label + ' — ' + expandedFrame.info +
+        (expandedFrame.rgbDisplayWarning ? ' — ' + expandedFrame.rgbDisplayWarning : '');
+    }
+    syncEvidenceLayerButtons(evidenceMapLayers[evidenceFrameIndex]);
+    if (rgbBtn) rgbBtn.classList.toggle('active', evidenceLayerMode === 'rgb');
+    if (ndviBtn) ndviBtn.classList.toggle('active', evidenceLayerMode === 'ndvi');
+  }
+
+  // ── Layer helpers ────────────────────────────────────────────
+
+  function pickEvidenceDefaultLayer(frame) {
+    if (typeof em().pickDefaultLayer === 'function') {
+      return em().pickDefaultLayer(frame);
+    }
+    if (!frame) return 'rgb';
+    if (frame.preferredLayer === 'ndvi' || frame.preferred_layer === 'ndvi') return 'ndvi';
+    return 'rgb';
+  }
+
+  function pickInitialEvidenceFrameIndex(frames) {
+    if (typeof em().pickInitialFrameIndex === 'function') {
+      return em().pickInitialFrameIndex(frames);
+    }
+    if (!Array.isArray(frames) || !frames.length) return 0;
+    return 0;
+  }
+
+  function syncEvidenceLayerButtons(frame) {
+    var rgbBtn = document.getElementById('app-map-btn-rgb');
+    var ndviBtn = document.getElementById('app-map-btn-ndvi');
+    var expandedRgbBtn = document.getElementById('app-map-expanded-btn-rgb');
+    var expandedNdviBtn = document.getElementById('app-map-expanded-btn-ndvi');
+    var rgbDisabled = !!(frame && frame.rgbDisplaySuitable === false);
+    var warning = frame && frame.rgbDisplayWarning ? frame.rgbDisplayWarning : '';
+
+    [rgbBtn, expandedRgbBtn].forEach(function (btn) {
+      if (!btn) return;
+      btn.disabled = rgbDisabled;
+      btn.title = rgbDisabled ? warning : '';
+      btn.classList.toggle('is-disabled', rgbDisabled);
+    });
+    [ndviBtn, expandedNdviBtn].forEach(function (btn) {
+      if (!btn) return;
+      btn.disabled = false;
+      btn.title = '';
+      btn.classList.remove('is-disabled');
+    });
+  }
+
+  // #646 — update layer button aria-labels and titles with per-frame
+  // collection and resolution so the picker is self-documenting.
+  function updateLayerButtonLabels(frame) {
+    var btnRgb = document.getElementById('app-map-btn-rgb');
+    var btnNdvi = document.getElementById('app-map-btn-ndvi');
+    var expRgb = document.getElementById('app-map-expanded-btn-rgb');
+    var expNdvi = document.getElementById('app-map-expanded-btn-ndvi');
+    if (!frame) return;
+    var info = frame.collectionLabel
+      ? (frame.collectionLabel + (frame.resLabel || ''))
+      : '';
+    [btnRgb, expRgb].forEach(function (btn) {
+      if (!btn) return;
+      var base = info ? 'True-colour RGB — ' + info : 'True-colour RGB';
+      if (!btn.disabled) btn.title = base;
+      btn.setAttribute('aria-label', info ? 'RGB (' + info + ')' : 'RGB');
+    });
+    [btnNdvi, expNdvi].forEach(function (btn) {
+      if (!btn) return;
+      btn.title = info ? 'Vegetation index (NDVI) — ' + info : 'Vegetation index (NDVI)';
+      btn.setAttribute('aria-label', info ? 'NDVI (' + info + ')' : 'NDVI');
+    });
+  }
+
+  // Sync the active/inactive classes on all RGB and NDVI buttons (both inline
+  // panel and expanded modal) to match the current evidenceLayerMode.
+  function syncLayerModeButtons() {
+    var isRgb = evidenceLayerMode === 'rgb';
+    ['app-map-btn-rgb', 'app-map-expanded-btn-rgb'].forEach(function (id) {
+      var btn = document.getElementById(id);
+      if (btn) btn.classList.toggle('active', isRgb);
+    });
+    ['app-map-btn-ndvi', 'app-map-expanded-btn-ndvi'].forEach(function (id) {
+      var btn = document.getElementById(id);
+      if (btn) btn.classList.toggle('active', !isRgb);
+    });
+  }
+
+  function setEvidenceLayerMode(mode) {
+    if (mode !== 'rgb' && mode !== 'ndvi') return;
+    evidenceLayerMode = mode;
+    syncLayerModeButtons();
+    showEvidenceFrame(evidenceFrameIndex);
+  }
+
+  // ── Surface visibility ───────────────────────────────────────
+
+  function showEvidenceSurface(visible) {
+    var surface = document.getElementById('app-evidence-surface');
+    var phaseStatus = document.getElementById('app-content-phase-status');
+    if (surface) surface.hidden = !visible;
+    if (phaseStatus) phaseStatus.hidden = visible;
+  }
+
+  // ── Main evidence load ───────────────────────────────────────
+
+  async function loadRunEvidence(instanceId) {
+    if (evidenceInstanceId === instanceId && evidenceManifest) return;
+    evidenceInstanceId = instanceId;
+    evidenceManifest = null;
+    evidenceAnalysis = null;
+    showEvidenceSurface(true);
+    clearEvidencePanels();
+
+    var shortId = instanceId.slice(0, 8);
+    var footerEl = document.getElementById('app-content-footer');
+    if (footerEl) footerEl.textContent = 'Loading evidence for run ' + shortId + '…';
+
+    try {
+      await (_getApiReady ? _getApiReady() : Promise.resolve());
+      var manifestRes = await _apiFetch('/api/timelapse-data/' + encodeURIComponent(instanceId));
+      var manifest = await manifestRes.json();
+      // Guard: user may have switched runs while we were fetching.
+      if (evidenceInstanceId !== instanceId) return;
+      evidenceManifest = manifest;
+    } catch (err) {
+      // Retry once after a short delay — the orchestrator may have just
+      // completed and storage propagation can lag a few seconds.
+      if (err && err.status === 404 && !arguments[1]) {
+        await new Promise(function (r) { setTimeout(r, 3000); });
+        if (evidenceInstanceId !== instanceId) return;
+        return loadRunEvidence(instanceId, true);
+      }
+      if (evidenceInstanceId !== instanceId) return;
+      if (footerEl) footerEl.textContent = 'Could not load enrichment data: ' + ((err && err.message) || 'unknown error');
+      return;
+    }
+
+    var _er = er();
+    if (typeof _er.renderEvidenceNdvi === 'function') _er.renderEvidenceNdvi(evidenceManifest);
+    if (typeof _er.renderEvidenceWeather === 'function') _er.renderEvidenceWeather(evidenceManifest);
+    if (typeof _er.renderEvidenceChangeDetection === 'function') _er.renderEvidenceChangeDetection(evidenceManifest);
+    if (typeof _er.renderResourceUsage === 'function') _er.renderResourceUsage(evidenceManifest);
+    initEvidenceMap(evidenceManifest);
+    initCompareView(evidenceManifest); // #671 before/after compare button
+
+    // Show persistent run reference in the evidence header.
+    var runRefEl = document.getElementById('app-evidence-run-ref');
+    if (runRefEl) {
+      runRefEl.textContent = 'Run ' + shortId;
+      runRefEl.title = instanceId;
+      runRefEl.hidden = false;
+    }
+
+    // Per-AOI selector (multi-polygon runs)
+    evidenceSelectedAoi = -1;
+    populateAoiSelector(evidenceManifest.per_aoi_enrichment);
+
+    // Load saved AI analysis (non-blocking)
+    loadSavedAnalysis(instanceId);
+
+    // Show EUDR block for eudr role
+    var eudrBlock = document.getElementById('app-evidence-eudr-block');
+    if (eudrBlock) eudrBlock.hidden = (_getWorkspaceRole ? _getWorkspaceRole() : '') !== 'eudr';
+
+    // Show AI block if tier supports it
+    var aiBlock = document.getElementById('app-evidence-ai-block');
+    if (aiBlock) {
+      var billing = _getLatestBillingStatus ? _getLatestBillingStatus() : null;
+      aiBlock.hidden = !(billing && billing.capabilities && billing.capabilities.ai_insights);
+    }
+
+    if (footerEl) {
+      footerEl.textContent = 'Evidence loaded for run ' + instanceId.slice(0, 8) + '.';
+    }
+  }
+
+  // ── Compare view (#671) ──────────────────────────────────────
+
+  function initCompareView(manifest) {
+    var compareWrap = document.getElementById('app-evidence-compare-wrap');
+    var compareBtn = document.getElementById('app-map-btn-compare');
+    if (!compareWrap) return;
+
+    var searchIds = manifest.search_ids || [];
+    if (searchIds.length < 2) {
+      if (compareBtn) compareBtn.hidden = true;
+      return;
+    }
+
+    if (compareBtn) compareBtn.hidden = false;
+  }
+
+  function openCompareView(manifest) {
+    var mainWrap = document.getElementById('app-evidence-map-wrap');
+    var compareWrap = document.getElementById('app-evidence-compare-wrap');
+    var frameControls = document.getElementById('app-evidence-frame-controls');
+    var frameLabel = document.getElementById('app-map-frame-label');
+    var compareBtn = document.getElementById('app-map-btn-compare');
+    if (!mainWrap || !compareWrap) return;
+
+    // Stop playback
+    if (evidencePlayInterval) { clearInterval(evidencePlayInterval); evidencePlayInterval = null; }
+
+    mainWrap.hidden = true;
+    if (frameControls) frameControls.hidden = true;
+    if (frameLabel) frameLabel.textContent = '';
+    compareWrap.hidden = false;
+    evidenceCompareMode = true;
+    if (compareBtn) compareBtn.classList.add('active');
+
+    buildCompareView(manifest);
+  }
+
+  function closeCompareView() {
+    var mainWrap = document.getElementById('app-evidence-map-wrap');
+    var compareWrap = document.getElementById('app-evidence-compare-wrap');
+    var compareBtn = document.getElementById('app-map-btn-compare');
+    if (!mainWrap || !compareWrap) return;
+
+    destroyCompareMaps();
+    compareWrap.hidden = true;
+    mainWrap.hidden = false;
+    evidenceCompareMode = false;
+    if (compareBtn) compareBtn.classList.remove('active');
+
+    var frameControls = document.getElementById('app-evidence-frame-controls');
+    if (frameControls && evidenceMapLayers.length) frameControls.hidden = false;
+    showEvidenceFrame(evidenceFrameIndex);
+  }
+
+  function destroyCompareMaps() {
+    if (evidenceCompareMaps) {
+      if (evidenceCompareMaps.before) { evidenceCompareMaps.before.remove(); }
+      if (evidenceCompareMaps.after) { evidenceCompareMaps.after.remove(); }
+      evidenceCompareMaps = null;
+    }
+    var before = document.getElementById('app-evidence-compare-map-before');
+    var after = document.getElementById('app-evidence-compare-map-after');
+    if (before) before.textContent = '';
+    if (after) after.textContent = '';
+  }
+
+  function buildCompareView(manifest) {
+    destroyCompareMaps();
+
+    var searchIds = manifest.search_ids || [];
+    var framePlan = manifest.frame_plan || [];
+    var center = manifest.center || manifest.coords;
+    if (!center || !searchIds.length) return;
+
+    var lat = Array.isArray(center) ? center[0] : center.lat || center.latitude;
+    var lon = Array.isArray(center) ? center[1] : center.lon || center.longitude;
+    if (!lat || !lon) return;
+
+    var firstFrame = framePlan[0] || {};
+    var lastFrame = framePlan[framePlan.length - 1] || {};
+    var firstSid = searchIds[0];
+    var lastSid = searchIds[searchIds.length - 1];
+
+    var firstCollection = firstFrame.display_collection || firstFrame.collection || 'sentinel-2-l2a';
+    var lastCollection = lastFrame.display_collection || lastFrame.collection || 'sentinel-2-l2a';
+    var firstAsset = firstFrame.asset || (firstCollection.indexOf('naip') >= 0 ? 'image' : 'visual');
+    var lastAsset = lastFrame.asset || (lastCollection.indexOf('naip') >= 0 ? 'image' : 'visual');
+
+    var labelBefore = document.getElementById('app-evidence-compare-label-before');
+    var labelAfter = document.getElementById('app-evidence-compare-label-after');
+    if (labelBefore) labelBefore.textContent = 'Before — ' + (firstFrame.label || 'earliest');
+    if (labelAfter) labelAfter.textContent = 'After — ' + (lastFrame.label || 'most recent');
+
+    var mapOptions = { zoomControl: false, attributionControl: false };
+    var basemapUrl = 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
+    var _er = er();
+    var _pcTileUrl = typeof _er.pcTileUrl === 'function' ? _er.pcTileUrl : function () { return ''; };
+
+    var beforeEl = document.getElementById('app-evidence-compare-map-before');
+    var afterEl = document.getElementById('app-evidence-compare-map-after');
+    if (!beforeEl || !afterEl) return;
+
+    var beforeMap = L.map(beforeEl, mapOptions).setView([lat, lon], 13);
+    L.tileLayer(basemapUrl, { maxZoom: 18 }).addTo(beforeMap);
+    if (firstSid) {
+      L.tileLayer(_pcTileUrl(firstSid, firstCollection, firstAsset), { maxZoom: 18 }).addTo(beforeMap);
+    }
+
+    var afterMap = L.map(afterEl, mapOptions).setView([lat, lon], 13);
+    L.tileLayer(basemapUrl, { maxZoom: 18 }).addTo(afterMap);
+    if (lastSid) {
+      L.tileLayer(_pcTileUrl(lastSid, lastCollection, lastAsset), { maxZoom: 18 }).addTo(afterMap);
+    }
+
+    // Keep the two maps in sync when panning/zooming
+    function syncMaps(source, target) {
+      source.on('moveend', function () {
+        target.setView(source.getCenter(), source.getZoom(), { animate: false });
+      });
+    }
+    syncMaps(beforeMap, afterMap);
+    syncMaps(afterMap, beforeMap);
+
+    evidenceCompareMaps = { before: beforeMap, after: afterMap };
+
+    // Fit to AOI bounds if available
+    var perAoi = manifest.per_aoi_enrichment || [];
+    try {
+      var allBounds = L.latLngBounds([]);
+      perAoi.forEach(function (aoi) {
+        if (!aoi.coords || !aoi.coords.length) return;
+        aoi.coords.forEach(function (c) { allBounds.extend([c[1], c[0]]); });
+      });
+      if (!allBounds.isValid() && manifest.coords && manifest.coords.length) {
+        manifest.coords.forEach(function (c) { allBounds.extend([c[1], c[0]]); });
+      }
+      if (allBounds.isValid()) {
+        beforeMap.fitBounds(allBounds.pad(0.1));
+        afterMap.fitBounds(allBounds.pad(0.1));
+      }
+    } catch (e) { /* keep default view */ }
+
+    setTimeout(function () {
+      beforeMap.invalidateSize();
+      afterMap.invalidateSize();
+    }, 150);
+  }
+
+  function toggleCompareView() {
+    if (evidenceCompareMode) {
+      closeCompareView();
+    } else if (evidenceManifest) {
+      openCompareView(evidenceManifest);
+    }
+  }
+
+  // ── clearEvidencePanels ──────────────────────────────────────
+
+  function clearEvidencePanels() {
+    var ids = [
+      'app-evidence-ndvi-grid',
+      'app-evidence-weather-grid',
+      'app-evidence-change-list',
+      'app-evidence-ai-content',
+      'app-evidence-eudr-content',
+      'app-evidence-resources-grid'
+    ];
+    ids.forEach(function (id) { var el = document.getElementById(id); if (el) el.textContent = ''; });
+    var noteEl = document.getElementById('app-evidence-ndvi-note');
+    if (noteEl) noteEl.textContent = '';
+    var resourceNote = document.getElementById('app-evidence-resources-note');
+    if (resourceNote) resourceNote.textContent = '';
+    var resourcesBlock = document.getElementById('app-evidence-resources-block');
+    if (resourcesBlock) resourcesBlock.hidden = true;
+    var runRefEl = document.getElementById('app-evidence-run-ref');
+    if (runRefEl) { runRefEl.textContent = ''; runRefEl.title = ''; runRefEl.hidden = true; }
+    var canvases = ['app-evidence-ndvi-canvas', 'app-evidence-weather-canvas'];
+    canvases.forEach(function (id) {
+      var c = document.getElementById(id);
+      if (c) { var ctx = c.getContext('2d'); ctx.clearRect(0, 0, c.width, c.height); }
+    });
+    if (evidencePlayInterval) { clearInterval(evidencePlayInterval); evidencePlayInterval = null; }
+    evidenceAoiPolygons = [];
+    evidenceSelectedAoi = -1;
+    var _er = er();
+    if (typeof _er.clearAoiDetail === 'function') _er.clearAoiDetail();
+    var aoiBlock = document.getElementById('app-evidence-aoi-block');
+    if (aoiBlock) aoiBlock.hidden = true;
+    // Reset compare mode so it doesn't persist across runs
+    destroyCompareMaps();
+    evidenceCompareMode = false;
+    var compareWrap = document.getElementById('app-evidence-compare-wrap');
+    var mainWrap = document.getElementById('app-evidence-map-wrap');
+    var compareBtn = document.getElementById('app-map-btn-compare');
+    if (compareWrap) compareWrap.hidden = true;
+    if (mainWrap) mainWrap.hidden = false;
+    if (compareBtn) { compareBtn.hidden = true; compareBtn.classList.remove('active'); }
+  }
+
+  // ── Map viewer ───────────────────────────────────────────────
+
+  function initEvidenceMap(manifest) {
+    var container = document.getElementById('app-evidence-map');
+    var overlay = document.getElementById('app-evidence-map-overlay');
+    var controls = document.getElementById('app-evidence-frame-controls');
+    if (!container) return;
+
+    // Clean up old map
+    if (evidenceMap) { evidenceMap.remove(); evidenceMap = null; }
+    evidenceMapLayers = [];
+    evidenceFrameIndex = 0;
+    if (evidencePlayInterval) { clearInterval(evidencePlayInterval); evidencePlayInterval = null; }
+
+    var center = manifest.center || manifest.coords;
+    if (!center) {
+      if (overlay) overlay.textContent = 'No location data available.';
+      return;
+    }
+
+    var lat = Array.isArray(center) ? center[0] : center.lat || center.latitude;
+    var lon = Array.isArray(center) ? center[1] : center.lon || center.longitude;
+    if (!lat || !lon) {
+      if (overlay) overlay.textContent = 'Invalid coordinates in manifest.';
+      return;
+    }
+
+    evidenceMap = L.map(container, { zoomControl: true, attributionControl: false }).setView([lat, lon], 13);
+    L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
+      maxZoom: 18
+    }).addTo(evidenceMap);
+
+    // AOI polygon outlines (coords are [lon, lat] GeoJSON; Leaflet needs [lat, lon])
+    evidenceAoiPolygons = [];
+    var perAoi = manifest.per_aoi_enrichment || [];
+    if (perAoi.length > 1) {
+      // Per-AOI mode: draw each AOI polygon as interactive
+      try {
+        var allBounds = L.latLngBounds([]);
+        perAoi.forEach(function (aoi, idx) {
+          if (!aoi.coords || !aoi.coords.length) return;
+          var ll = aoi.coords.map(function (c) { return [c[1], c[0]]; });
+          var poly = L.polygon(ll, {
+            color: 'rgba(88,166,255,.7)',
+            weight: 2,
+            fillOpacity: 0.05
+          }).addTo(evidenceMap);
+          var tip = document.createElement('span');
+          tip.textContent = aoi.name || ('Parcel ' + (idx + 1));
+          poly.bindTooltip(tip, { sticky: true });
+          poly.on('click', function () { selectAoi(idx); });
+          evidenceAoiPolygons.push(poly);
+          allBounds.extend(poly.getBounds());
+        });
+        if (allBounds.isValid()) evidenceMap.fitBounds(allBounds.pad(0.1));
+      } catch (e) { /* skip polygon */ }
+    } else if (manifest.coords && Array.isArray(manifest.coords)) {
+      // Single-AOI fallback: split concatenated ring
+      try {
+        var rings = [];
+        var ringStart = 0;
+        for (var ci = ringStart + 3; ci < manifest.coords.length; ci++) {
+          if (Math.abs(manifest.coords[ci][0] - manifest.coords[ringStart][0]) < 1e-5 &&
+            Math.abs(manifest.coords[ci][1] - manifest.coords[ringStart][1]) < 1e-5) {
+            rings.push(manifest.coords.slice(ringStart, ci + 1));
+            ringStart = ci + 1;
+            ci = ringStart + 2;
+          }
+        }
+        if (ringStart < manifest.coords.length) rings.push(manifest.coords.slice(ringStart));
+        if (!rings.length) rings.push(manifest.coords);
+
+        var singleBounds = L.latLngBounds([]);
+        rings.forEach(function (ring) {
+          var ll = ring.map(function (c) { return [c[1], c[0]]; });
+          L.polygon(ll, { color: 'rgba(88,166,255,.7)', weight: 2, fillOpacity: 0.05 }).addTo(evidenceMap);
+          singleBounds.extend(L.polygon(ll).getBounds());
+        });
+        evidenceMap.fitBounds(singleBounds.pad(0.1));
+      } catch (e) { /* skip polygon */ }
+    }
+
+    if (overlay) overlay.hidden = true;
+
+    // Add PC timelapse frames if search_ids available
+    var searchIds = manifest.search_ids || [];
+    var ndviSearchIds = manifest.ndvi_search_ids || [];
+    var framePlan = manifest.frame_plan || [];
+
+    if (searchIds.length && framePlan.length) {
+      buildEvidenceFrames(framePlan, searchIds, ndviSearchIds);
+      if (controls) controls.hidden = false;
+    } else if (controls) {
+      controls.hidden = true;
+    }
+
+    // Force resize
+    setTimeout(function () { if (evidenceMap) evidenceMap.invalidateSize(); }, 200);
+  }
+
+  // ── Per-AOI selection ────────────────────────────────────────
+
+  function populateAoiSelector(perAoi) {
+    var block = document.getElementById('app-evidence-aoi-block');
+    var list = document.getElementById('app-evidence-aoi-list');
+    var resetBtn = document.getElementById('app-evidence-aoi-reset');
+    if (!block || !list) return;
+
+    if (!perAoi || perAoi.length < 2) {
+      block.hidden = true;
+      return;
+    }
+
+    block.hidden = false;
+    list.textContent = '';
+
+    perAoi.forEach(function (aoi, idx) {
+      var chip = document.createElement('button');
+      chip.type = 'button';
+      chip.className = 'app-evidence-aoi-chip';
+      chip.textContent = aoi.name || ('Parcel ' + (idx + 1));
+      chip.addEventListener('click', function () { selectAoi(idx); });
+      list.appendChild(chip);
+    });
+
+    if (resetBtn) {
+      resetBtn.addEventListener('click', function () { resetAoiSelection(); });
+    }
+  }
+
+  function selectAoi(idx) {
+    if (!evidenceManifest || !evidenceManifest.per_aoi_enrichment) return;
+    var perAoi = evidenceManifest.per_aoi_enrichment;
+    if (idx < 0 || idx >= perAoi.length) return;
+
+    evidenceSelectedAoi = idx;
+    var aoi = perAoi[idx];
+
+    // Highlight selected polygon, dim others
+    evidenceAoiPolygons.forEach(function (poly, i) {
+      if (i === idx) {
+        poly.setStyle({ color: '#5eecc4', weight: 3, fillOpacity: 0.15 });
+      } else {
+        poly.setStyle({ color: 'rgba(88,166,255,.3)', weight: 1, fillOpacity: 0.02 });
+      }
+    });
+
+    // Zoom to selected AOI
+    if (evidenceAoiPolygons[idx] && evidenceMap) {
+      evidenceMap.fitBounds(evidenceAoiPolygons[idx].getBounds().pad(0.15));
+    }
+
+    // Update chip active state
+    var chips = document.querySelectorAll('.app-evidence-aoi-chip');
+    chips.forEach(function (chip, i) {
+      chip.className = 'app-evidence-aoi-chip' + (i === idx ? ' active' : '');
+    });
+
+    // Render per-AOI detail and parcel panels
+    var _er = er();
+    if (typeof _er.renderAoiDetail === 'function') _er.renderAoiDetail(aoi);
+
+    // Store current override context so the override button binding can use it
+    _currentOverrideParcelKey = _parcelKeyForIndex(idx);
+    _currentOverrideAoiData = aoi;
+
+    var _ep = ep();
+    if (typeof _ep.renderParcelNotes === 'function') _ep.renderParcelNotes(_parcelKeyForIndex(idx));
+    if (typeof _ep.renderParcelOverride === 'function') _ep.renderParcelOverride(_parcelKeyForIndex(idx), aoi);
+  }
+
+  function resetAoiSelection() {
+    evidenceSelectedAoi = -1;
+    _currentOverrideParcelKey = null;
+    _currentOverrideAoiData = null;
+
+    // Reset polygon styles
+    evidenceAoiPolygons.forEach(function (poly) {
+      poly.setStyle({ color: 'rgba(88,166,255,.7)', weight: 2, fillOpacity: 0.05 });
+    });
+
+    // Zoom to fit all
+    if (evidenceAoiPolygons.length && evidenceMap) {
+      var allBounds = L.latLngBounds([]);
+      evidenceAoiPolygons.forEach(function (poly) { allBounds.extend(poly.getBounds()); });
+      if (allBounds.isValid()) evidenceMap.fitBounds(allBounds.pad(0.1));
+    }
+
+    // Clear chip active state
+    var chips = document.querySelectorAll('.app-evidence-aoi-chip');
+    chips.forEach(function (chip) { chip.className = 'app-evidence-aoi-chip'; });
+
+    // Clear per-AOI detail
+    var _er = er();
+    if (typeof _er.clearAoiDetail === 'function') _er.clearAoiDetail();
+
+    // Clear parcel notes panel (reset to empty/add state)
+    var savedEl = document.getElementById('app-evidence-notes-saved');
+    var editEl = document.getElementById('app-evidence-notes-edit');
+    var addBtn = document.getElementById('app-evidence-notes-add-btn');
+    if (savedEl) savedEl.hidden = true;
+    if (editEl) editEl.hidden = true;
+    if (addBtn) { addBtn.hidden = false; addBtn.textContent = '+ Add note'; }
+    var overrideEl = document.getElementById('app-evidence-override');
+    if (overrideEl) overrideEl.hidden = true;
+  }
+
+  function _parcelKeyForIndex(idx) {
+    var _ep = ep();
+    if (typeof _ep.parcelKeyForIndex === 'function') return _ep.parcelKeyForIndex(idx);
+    return String(idx);
+  }
+
+  // ── Frame controls ───────────────────────────────────────────
+
+  function buildEvidenceFrames(framePlan, searchIds, ndviSearchIds) {
+    evidenceMapLayers = [];
+    var slider = document.getElementById('app-map-frame-slider');
+    if (slider) { slider.max = framePlan.length - 1; slider.value = 0; }
+
+    var _er = er();
+    var _pcTileUrl = typeof _er.pcTileUrl === 'function' ? _er.pcTileUrl : function () { return ''; };
+    var _pcNdviTileUrl = typeof _er.pcNdviTileUrl === 'function' ? _er.pcNdviTileUrl : function () { return ''; };
+
+    framePlan.forEach(function (frame, idx) {
+      var sid = searchIds[idx];
+      var ndviSid = ndviSearchIds[idx] || sid;
+      var collection = frame.display_collection || frame.collection || 'sentinel-2-l2a';
+      var asset = frame.asset || (collection.indexOf('naip') >= 0 ? 'image' : 'visual');
+
+      var rgbLayer = null;
+      var ndviLayer = null;
+      if (sid) {
+        rgbLayer = L.tileLayer(_pcTileUrl(sid, collection, asset), { maxZoom: 18, opacity: 0 });
+        rgbLayer.addTo(evidenceMap);
+      }
+      if (ndviSid && collection.indexOf('sentinel') >= 0) {
+        ndviLayer = L.tileLayer(_pcNdviTileUrl(ndviSid), { maxZoom: 18, opacity: 0 });
+        ndviLayer.addTo(evidenceMap);
+      }
+
+      // #646 — store human-readable collection label and resolution suffix so
+      // updateLayerButtonLabels can build informative button titles per frame.
+      var collectionLabel = collection.indexOf('naip') >= 0 ? 'NAIP'
+        : collection.indexOf('sentinel') >= 0 ? 'Sentinel-2'
+          : collection.indexOf('landsat') >= 0 ? 'Landsat'
+            : collection;
+      var resolutionM = (frame.provenance && frame.provenance.resolution_m)
+        || frame.display_resolution_m
+        || null;
+      var resLabel = resolutionM ? (' \u00b7 ' + resolutionM + 'm') : '';
+
+      evidenceMapLayers.push({
+        rgb: rgbLayer,
+        ndvi: ndviLayer,
+        label: frame.label || ('Frame ' + (idx + 1)),
+        info: [collection, frame.start_date, frame.end_date].filter(Boolean).join(' | '),
+        rgbDisplaySuitable: frame.rgb_display_suitable !== false,
+        rgbDisplayWarning: frame.rgb_display_warning || '',
+        preferredLayer: frame.preferred_layer || 'rgb',
+        displayResolutionM: frame.display_resolution_m || null,
+        collectionLabel: collectionLabel,
+        resLabel: resLabel
+      });
+    });
+
+    evidenceFrameIndex = pickInitialEvidenceFrameIndex(evidenceMapLayers);
+    evidenceLayerMode = pickEvidenceDefaultLayer(evidenceMapLayers[evidenceFrameIndex]);
+    syncLayerModeButtons();
+    showEvidenceFrame(evidenceFrameIndex);
+  }
+
+  function showEvidenceFrame(idx) {
+    if (idx < 0 || idx >= evidenceMapLayers.length) return;
+    evidenceFrameIndex = idx;
+    var activeFrame = evidenceMapLayers[idx];
+
+    // #646 — bidirectional mode adaptation:
+    // Fall back to rgb when the user is in ndvi mode but this frame has no ndvi layer.
+    if (evidenceLayerMode === 'ndvi' && !activeFrame.ndvi) {
+      evidenceLayerMode = 'rgb';
+    }
+    // Promote to ndvi for coarse frames where rgb is unsuitable (established in #645).
+    if (activeFrame.rgbDisplaySuitable === false && activeFrame.ndvi) {
+      evidenceLayerMode = 'ndvi';
+    }
+    // Keep button active classes in sync after any programmatic mode change.
+    syncLayerModeButtons();
+
+    evidenceMapLayers.forEach(function (frame, i) {
+      var showRgb = (i === idx && evidenceLayerMode === 'rgb');
+      var showNdvi = (i === idx && evidenceLayerMode === 'ndvi');
+      if (frame.rgb) frame.rgb.setOpacity(showRgb ? 1 : 0);
+      if (frame.ndvi) frame.ndvi.setOpacity(showNdvi ? 1 : 0);
+    });
+
+    var slider = document.getElementById('app-map-frame-slider');
+    var counter = document.getElementById('app-map-frame-counter');
+    var label = document.getElementById('app-map-frame-label');
+    if (slider) slider.value = idx;
+    if (counter) counter.textContent = (idx + 1) + '/' + evidenceMapLayers.length;
+    if (label) {
+      label.textContent = activeFrame.label + ' — ' + activeFrame.info +
+        (activeFrame.rgbDisplayWarning ? ' — ' + activeFrame.rgbDisplayWarning : '');
+    }
+    syncEvidenceLayerButtons(activeFrame);
+    updateLayerButtonLabels(activeFrame);
+
+    // Sync expanded controls if open
+    if (evidenceMapExpanded) syncExpandedControls();
+  }
+
+  function toggleEvidencePlay() {
+    var btn = document.getElementById('app-map-play-btn');
+    var expBtn = document.getElementById('app-map-expanded-play-btn');
+    if (evidencePlayInterval) {
+      clearInterval(evidencePlayInterval);
+      evidencePlayInterval = null;
+      if (btn) btn.textContent = '▶ Play';
+      if (expBtn) expBtn.textContent = '▶ Play';
+      return;
+    }
+    if (btn) btn.textContent = '⏸ Pause';
+    if (expBtn) expBtn.textContent = '⏸ Pause';
+    evidencePlayInterval = setInterval(function () {
+      var next = (evidenceFrameIndex + 1) % evidenceMapLayers.length;
+      showEvidenceFrame(next);
+    }, 1500);
+  }
+
+  function stopEvidencePlay() {
+    if (evidencePlayInterval) {
+      clearInterval(evidencePlayInterval);
+      evidencePlayInterval = null;
+    }
+  }
+
+  // ── AI analysis ──────────────────────────────────────────────
+
+  async function loadSavedAnalysis(instanceId) {
+    var aiBlock = document.getElementById('app-evidence-ai-block');
+    var content = document.getElementById('app-evidence-ai-content');
+    if (!aiBlock || !content) return;
+
+    try {
+      await (_getApiReady ? _getApiReady() : Promise.resolve());
+      var res = await _apiFetch('/api/timelapse-analysis-load/' + encodeURIComponent(instanceId));
+      evidenceAnalysis = await res.json();
+      var _er = er();
+      if (evidenceAnalysis && (evidenceAnalysis.observations || evidenceAnalysis.summary)) {
+        aiBlock.hidden = false;
+        if (typeof _er.renderEvidenceAnalysis === 'function') _er.renderEvidenceAnalysis(evidenceAnalysis);
+      }
+    } catch (e) {
+      // 404 = no saved analysis yet (expected). Other errors indicate a real problem.
+      if (e && e.status && e.status !== 404) {
+        console.warn('Failed to load saved analysis:', e.message || e);
+      }
+    }
+  }
+
+  async function requestAiAnalysis() {
+    var loading = document.getElementById('app-evidence-ai-loading');
+    var content = document.getElementById('app-evidence-ai-content');
+    var btn = document.getElementById('app-evidence-ai-btn');
+    if (!loading || !content || !evidenceManifest) return;
+
+    var _createCallout = (window.CanopexHelpers || {}).createCallout || function (t, m) {
+      var d = document.createElement('div');
+      d.className = 'callout callout-' + t;
+      d.textContent = m;
+      return d;
+    };
+
+    var originalLabel = btn ? btn.textContent : '';
+    if (btn) { btn.disabled = true; btn.textContent = 'Analyzing…'; }
+    loading.hidden = false;
+    content.textContent = '';
+
+    try {
+      await (_getApiReady ? _getApiReady() : Promise.resolve());
+
+      var ndviTimeseries = (evidenceManifest.ndvi_stats || []).map(function (f, i) {
+        if (!f) return null;
+        var fp = (evidenceManifest.frame_plan || [])[i] || {};
+        return { date: f.datetime || fp.label, mean: f.mean, min: f.min, max: f.max, year: fp.year, season: fp.season };
+      }).filter(Boolean);
+
+      // weather_monthly may be { labels, temp, precip } parallel arrays
+      var wm = evidenceManifest.weather_monthly;
+      var weatherTimeseries = [];
+      if (wm && wm.labels && Array.isArray(wm.labels)) {
+        weatherTimeseries = wm.labels.map(function (lbl, i) {
+          return { month_index: i, label: lbl, temperature: wm.temp ? wm.temp[i] : null, precipitation: wm.precip ? wm.precip[i] : null };
+        });
+      } else if (Array.isArray(wm)) {
+        weatherTimeseries = wm.map(function (m, i) {
+          return { month_index: i, temperature: m.temperature, precipitation: m.precipitation };
+        });
+      }
+
+      var center = evidenceManifest.center || evidenceManifest.coords;
+      var lat = Array.isArray(center) ? center[0] : (center && center.lat) || 0;
+      var lon = Array.isArray(center) ? center[1] : (center && center.lon) || 0;
+
+      var body = {
+        context: {
+          aoi_name: 'Analysis area',
+          latitude: lat,
+          longitude: lon,
+          frame_count: ndviTimeseries.length,
+          date_range_start: ndviTimeseries.length ? ndviTimeseries[0].date : '',
+          date_range_end: ndviTimeseries.length ? ndviTimeseries[ndviTimeseries.length - 1].date : '',
+          ndvi_timeseries: ndviTimeseries,
+          weather_timeseries: weatherTimeseries
+        }
+      };
+
+      var res = await _apiFetch('/api/timelapse-analysis', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+
+      evidenceAnalysis = await res.json();
+      var _er = er();
+      if (typeof _er.renderEvidenceAnalysis === 'function') _er.renderEvidenceAnalysis(evidenceAnalysis);
+
+      // Save the analysis (non-blocking but warn user on failure)
+      _apiFetch('/api/timelapse-analysis-save', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ instance_id: evidenceInstanceId, analysis: evidenceAnalysis })
+      }).catch(function () {
+        var saveWarn = document.getElementById('app-evidence-ai-content');
+        if (saveWarn) saveWarn.appendChild(_createCallout('warning', 'Analysis displayed but could not be saved. It will be lost on reload.'));
+      });
+    } catch (err) {
+      content.textContent = '';
+      content.appendChild(_createCallout('error', (err && err.message) || 'Could not run AI analysis.'));
+    } finally {
+      loading.hidden = true;
+      if (btn) { btn.disabled = false; btn.textContent = originalLabel; }
+    }
+  }
+
+  // ── EUDR assessment ──────────────────────────────────────────
+
+  function activeEvidenceContext() {
+    if (!evidenceManifest) return null;
+    var perAoi = evidenceManifest.per_aoi_enrichment || [];
+    if (evidenceSelectedAoi >= 0 && evidenceSelectedAoi < perAoi.length) {
+      return perAoi[evidenceSelectedAoi];
+    }
+    return evidenceManifest;
+  }
+
+  function buildEvidenceNdviTimeseries(source) {
+    var _em = em();
+    if (typeof _em.buildNdviTimeseries === 'function') {
+      return _em.buildNdviTimeseries(source);
+    }
+    if (!source) return [];
+    return (source.ndvi_stats || []).map(function (f, i) {
+      if (!f) return null;
+      var fp = (source.frame_plan || [])[i] || {};
+      return {
+        date: f.datetime || f.date || fp.start || fp.label,
+        mean: f.mean,
+        min: f.min,
+        max: f.max,
+        year: f.year || fp.year,
+        season: f.season || fp.season
+      };
+    }).filter(Boolean);
+  }
+
+  function evidenceLatLon(source) {
+    var _em = em();
+    if (typeof _em.latLon === 'function') {
+      return _em.latLon(source);
+    }
+    if (!source) return { lat: 0, lon: 0 };
+    var center = source.center || source.coords;
+    if (Array.isArray(center)) {
+      return { lat: center[0] || 0, lon: center[1] || 0 };
+    }
+    return {
+      lat: (center && (center.lat || center.latitude)) || 0,
+      lon: (center && (center.lon || center.longitude)) || 0
+    };
+  }
+
+  async function requestEudrAssessment() {
+    var loading = document.getElementById('app-evidence-eudr-loading');
+    var content = document.getElementById('app-evidence-eudr-content');
+    var btn = document.getElementById('app-evidence-eudr-btn');
+    if (!loading || !content || !evidenceManifest) return;
+
+    var _createCallout = (window.CanopexHelpers || {}).createCallout || function (t, m) {
+      var d = document.createElement('div');
+      d.className = 'callout callout-' + t;
+      d.textContent = m;
+      return d;
+    };
+
+    if (btn) btn.disabled = true;
+    loading.hidden = false;
+    content.textContent = '';
+
+    try {
+      await (_getApiReady ? _getApiReady() : Promise.resolve());
+
+      var source = activeEvidenceContext();
+      var ndviTimeseries = buildEvidenceNdviTimeseries(source);
+      var latLon = evidenceLatLon(source);
+
+      var body = {
+        context: {
+          aoi_name: source && source.name ? source.name : 'Analysis area',
+          latitude: latLon.lat,
+          longitude: latLon.lon,
+          ndvi_timeseries: ndviTimeseries,
+          reference_date: '2020-12-31'
+        }
+      };
+
+      var res = await _apiFetch('/api/eudr-assessment', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+
+      var result = await res.json();
+      var cls = (result.compliant || result.deforestation_free) ? 'compliant' : 'non-compliant';
+      var label = cls === 'compliant' ? '\u2713 No deforestation detected since Dec 2020' : '\u26A0 Potential deforestation detected';
+      content.textContent = '';
+      var resultDiv = document.createElement('div');
+      resultDiv.className = 'app-evidence-eudr-result ' + cls;
+      var strong = document.createElement('strong');
+      strong.textContent = label;
+      resultDiv.appendChild(strong);
+      if (result.summary) {
+        var p = document.createElement('p');
+        p.textContent = result.summary;
+        resultDiv.appendChild(p);
+      }
+      content.appendChild(resultDiv);
+    } catch (err) {
+      content.textContent = '';
+      content.appendChild(_createCallout('error', (err && err.message) || 'Could not run EUDR assessment.'));
+    } finally {
+      loading.hidden = true;
+      if (btn) btn.disabled = false;
+    }
+  }
+
+  // ── Public API ────────────────────────────────────────────────
+
+  window.CanopexEvidenceDisplay = {
+    init: init,
+    load: loadRunEvidence,
+    clear: clearEvidencePanels,
+    showSurface: showEvidenceSurface,
+    expand: expandEvidenceMap,
+    collapse: collapseEvidenceMap,
+    showFrame: showEvidenceFrame,
+    setLayerMode: setEvidenceLayerMode,
+    toggleCompare: toggleCompareView,
+    togglePlay: toggleEvidencePlay,
+    stopPlay: stopEvidencePlay,
+    requestAi: requestAiAnalysis,
+    requestEudr: requestEudrAssessment,
+    getManifest: function () { return evidenceManifest; },
+    getInstanceId: function () { return evidenceInstanceId; },
+    getOverrideContext: function () {
+      return { parcelKey: _currentOverrideParcelKey, aoiData: _currentOverrideAoiData };
+    },
+  };
+})();

--- a/website/js/app-evidence-map.js
+++ b/website/js/app-evidence-map.js
@@ -1,0 +1,135 @@
+/**
+ * app-evidence-map.js
+ *
+ * Pure data helpers for the evidence map domain. No DOM, no Leaflet, no fetch.
+ *
+ * Exposes: window.CanopexEvidenceMap
+ *
+ * Contract:
+ *   pickDefaultLayer(frame)              → 'rgb' | 'ndvi'
+ *   pickInitialFrameIndex(frames)        → number
+ *   buildNdviTimeseries(source)          → Array<{ date, mean, min, max, year, season }>
+ *   latLon(source)                       → { lat: number, lon: number }
+ */
+(function () {
+  'use strict';
+
+  /**
+   * Choose the default layer mode for a given evidence frame.
+   * Returns 'ndvi' when the frame has an explicit preference, otherwise 'rgb'.
+   *
+   * @param {object|null} frame
+   * @returns {'rgb'|'ndvi'}
+   */
+  function pickDefaultLayer(frame) {
+    if (!frame) return 'rgb';
+    if (frame.preferredLayer === 'ndvi' || frame.preferred_layer === 'ndvi') return 'ndvi';
+    return 'rgb';
+  }
+
+  /**
+   * Select the best initial frame index from an array of evidence map layers.
+   *
+   * Scoring priority (descending):
+   *   1. rgbDisplaySuitable — frames where RGB is shown are preferred.
+   *   2. displayResolutionM — lower resolution value wins (sharper imagery).
+   *   3. recency — latest index wins when tied on resolution.
+   *
+   * @param {Array} frames - evidence map layer descriptors
+   * @returns {number}
+   */
+  function pickInitialFrameIndex(frames) {
+    if (!Array.isArray(frames) || !frames.length) return 0;
+
+    var bestIndex = 0;
+    var bestScore = null;
+
+    frames.forEach(function (frame, idx) {
+      if (!frame) return;
+
+      var rgbSuitable = frame.rgbDisplaySuitable !== false;
+      var resolution = Number(frame.displayResolutionM || 9999);
+      var score = {
+        rgbSuitable: rgbSuitable ? 1 : 0,
+        resolution: Number.isFinite(resolution) ? -resolution : -9999,
+        recency: idx
+      };
+
+      if (!bestScore) {
+        bestScore = score;
+        bestIndex = idx;
+        return;
+      }
+
+      if (score.rgbSuitable > bestScore.rgbSuitable) {
+        bestScore = score;
+        bestIndex = idx;
+        return;
+      }
+
+      if (score.rgbSuitable < bestScore.rgbSuitable) return;
+
+      if (score.resolution > bestScore.resolution) {
+        bestScore = score;
+        bestIndex = idx;
+        return;
+      }
+
+      if (score.resolution === bestScore.resolution && score.recency > bestScore.recency) {
+        bestScore = score;
+        bestIndex = idx;
+      }
+    });
+
+    return bestIndex;
+  }
+
+  /**
+   * Build a normalised NDVI time-series array from an evidence source object.
+   * Works for both the top-level manifest and per-AOI enrichment entries.
+   *
+   * @param {object|null} source - evidence manifest or per-AOI context
+   * @returns {Array<{ date: string, mean: number, min: number, max: number, year, season }>}
+   */
+  function buildNdviTimeseries(source) {
+    if (!source) return [];
+    return (source.ndvi_stats || []).map(function (f, i) {
+      if (!f) return null;
+      var fp = (source.frame_plan || [])[i] || {};
+      return {
+        date: f.datetime || f.date || fp.start || fp.label,
+        mean: f.mean,
+        min: f.min,
+        max: f.max,
+        year: f.year || fp.year,
+        season: f.season || fp.season
+      };
+    }).filter(Boolean);
+  }
+
+  /**
+   * Extract a { lat, lon } coordinate pair from an evidence source.
+   * Falls back to { lat: 0, lon: 0 } when the source has no usable center.
+   *
+   * @param {object|null} source
+   * @returns {{ lat: number, lon: number }}
+   */
+  function latLon(source) {
+    if (!source) return { lat: 0, lon: 0 };
+    var center = source.center || source.coords;
+    if (Array.isArray(center)) {
+      return { lat: center[0] || 0, lon: center[1] || 0 };
+    }
+    return {
+      lat: (center && (center.lat || center.latitude)) || 0,
+      lon: (center && (center.lon || center.longitude)) || 0
+    };
+  }
+
+  window.CanopexEvidenceMap = {
+    pickDefaultLayer: pickDefaultLayer,
+    pickInitialFrameIndex: pickInitialFrameIndex,
+    buildNdviTimeseries: buildNdviTimeseries,
+    latLon: latLon
+  };
+})();

--- a/website/js/app-evidence-panels.js
+++ b/website/js/app-evidence-panels.js
@@ -1,0 +1,345 @@
+/**
+ * app-evidence-panels.js
+ *
+ * Evidence side-panel helpers: parcel notes (#669) and human-override
+ * determination (#672).  No Leaflet, no direct state mutation beyond the
+ * manifest object returned by getManifest().
+ *
+ * Exposes: window.CanopexEvidencePanels
+ *
+ * Contract:
+ *   init(deps)
+ *     deps.apiFetch      — authenticated fetch helper
+ *     deps.getApiReady   — () → Promise — resolves when API base is known
+ *     deps.getManifest   — () → evidenceManifest object (live reference, mutated in-place)
+ *     deps.getInstanceId — () → current evidenceInstanceId string | null
+ *
+ *   parcelKeyForIndex(idx)          → string
+ *   renderParcelNotes(parcelKey)    — update notes panel DOM
+ *   showNoteEditor()                — reveal the note editor
+ *   hideNoteEditor()                — hide the note editor
+ *   saveParcelNote()                → Promise<void>
+ *   renderParcelOverride(key, aoi)  — update override panel DOM
+ *   openOverrideModal(key, aoi)     — show override backdrop
+ *   closeOverrideModal()            — hide override backdrop
+ *   onOverrideReasonInput()         — validate + update char counter
+ *   confirmOverride()               → Promise<void>
+ *   revertOverride()                → Promise<void>
+ */
+(function () {
+  'use strict';
+
+  /* ---- deps (set via init) ---- */
+
+  var _apiFetch      = null;
+  var _getApiReady   = null;
+  var _getManifest   = null;
+  var _getInstanceId = null;
+
+  function init(deps) {
+    _apiFetch      = deps.apiFetch      || _apiFetch;
+    _getApiReady   = deps.getApiReady   || _getApiReady;
+    _getManifest   = deps.getManifest   || _getManifest;
+    _getInstanceId = deps.getInstanceId || _getInstanceId;
+  }
+
+  /* ---- module-level state ---- */
+
+  var currentNoteParcelKey     = null;
+  var currentOverrideParcelKey = null;
+  var currentOverrideAoiData   = null;
+
+  /* ---- parcel key helper ---- */
+
+  function parcelKeyForIndex(idx) {
+    return String(idx);
+  }
+
+  /* ---- parcel notes (#669) ---- */
+
+  function renderParcelNotes(parcelKey) {
+    currentNoteParcelKey = parcelKey;
+
+    var notesEl = document.getElementById('app-evidence-notes');
+    var savedEl = document.getElementById('app-evidence-notes-saved');
+    var textEl  = document.getElementById('app-evidence-notes-text');
+    var metaEl  = document.getElementById('app-evidence-notes-meta');
+    var editEl  = document.getElementById('app-evidence-notes-edit');
+    var addBtn  = document.getElementById('app-evidence-notes-add-btn');
+    if (!notesEl) return;
+
+    // Reset edit state
+    if (editEl) editEl.hidden = true;
+    if (addBtn) addBtn.hidden = false;
+    var input = document.getElementById('app-evidence-notes-input');
+    if (input) input.value = '';
+
+    var manifest = _getManifest ? _getManifest() : null;
+    var note = null;
+    if (manifest && manifest.parcel_notes) {
+      note = manifest.parcel_notes[parcelKey] || null;
+    }
+
+    if (note && note.text) {
+      if (savedEl) savedEl.hidden = false;
+      if (textEl)  textEl.textContent = note.text;
+      if (metaEl) {
+        var when = note.updated_at ? new Date(note.updated_at).toLocaleDateString() : '';
+        metaEl.textContent = when ? 'Note — ' + when : 'Note saved';
+      }
+      if (addBtn) addBtn.textContent = 'Edit note';
+    } else {
+      if (savedEl) savedEl.hidden = true;
+      if (textEl)  textEl.textContent = '';
+      if (metaEl)  metaEl.textContent = '';
+      if (addBtn)  addBtn.textContent = '+ Add note';
+    }
+  }
+
+  function showNoteEditor() {
+    var editEl = document.getElementById('app-evidence-notes-edit');
+    var addBtn = document.getElementById('app-evidence-notes-add-btn');
+    var input  = document.getElementById('app-evidence-notes-input');
+    if (!editEl) return;
+
+    var manifest = _getManifest ? _getManifest() : null;
+    if (input && manifest && manifest.parcel_notes && currentNoteParcelKey) {
+      var existing = manifest.parcel_notes[currentNoteParcelKey];
+      input.value = existing ? (existing.text || '') : '';
+    }
+    if (editEl) editEl.hidden = false;
+    if (addBtn) addBtn.hidden = true;
+    if (input)  input.focus();
+  }
+
+  function hideNoteEditor() {
+    var editEl = document.getElementById('app-evidence-notes-edit');
+    var addBtn = document.getElementById('app-evidence-notes-add-btn');
+    if (editEl) editEl.hidden = true;
+    if (addBtn) addBtn.hidden = false;
+  }
+
+  async function saveParcelNote() {
+    var input = document.getElementById('app-evidence-notes-input');
+    var instanceId = _getInstanceId ? _getInstanceId() : null;
+    if (!input || !instanceId || currentNoteParcelKey === null) return;
+
+    var noteText = input.value.trim();
+    var saveBtn  = document.getElementById('app-evidence-notes-save-btn');
+    if (saveBtn) { saveBtn.disabled = true; saveBtn.textContent = 'Saving…'; }
+
+    try {
+      if (_getApiReady) await _getApiReady();
+      var res = await _apiFetch('/api/analysis/notes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          instance_id: instanceId,
+          parcel_key: currentNoteParcelKey,
+          note: noteText,
+        }),
+      });
+      if (!res.ok) {
+        var err = await res.json().catch(function() { return {}; });
+        console.warn('Note save failed:', err);
+        return;
+      }
+      // Mutate the live manifest reference so the note appears immediately.
+      var manifest = _getManifest ? _getManifest() : null;
+      if (manifest) {
+        if (!manifest.parcel_notes) manifest.parcel_notes = {};
+        if (noteText) {
+          manifest.parcel_notes[currentNoteParcelKey] = {
+            text: noteText,
+            updated_at: new Date().toISOString(),
+          };
+        } else {
+          delete manifest.parcel_notes[currentNoteParcelKey];
+        }
+      }
+      hideNoteEditor();
+      renderParcelNotes(currentNoteParcelKey);
+    } catch (e) {
+      console.warn('Note save error:', e);
+    } finally {
+      if (saveBtn) { saveBtn.disabled = false; saveBtn.textContent = 'Save note'; }
+    }
+  }
+
+  /* ---- human override determination (#672) ---- */
+
+  function renderParcelOverride(parcelKey, aoiData) {
+    currentOverrideParcelKey = parcelKey;
+    currentOverrideAoiData   = aoiData;
+
+    var overrideEl  = document.getElementById('app-evidence-override');
+    var badgeEl     = document.getElementById('app-evidence-override-badge');
+    var overrideBtn = document.getElementById('app-evidence-override-btn');
+    var revertBtn   = document.getElementById('app-evidence-override-revert-btn');
+    if (!overrideEl) return;
+
+    var manifest = _getManifest ? _getManifest() : null;
+    var override = null;
+    if (manifest && manifest.parcel_overrides) {
+      override = manifest.parcel_overrides[parcelKey] || null;
+    }
+
+    var det           = aoiData && aoiData.determination;
+    var isNonCompliant = det && !det.deforestation_free;
+
+    overrideEl.hidden = !(isNonCompliant || override);
+
+    if (override) {
+      if (badgeEl) {
+        badgeEl.hidden    = false;
+        badgeEl.className = 'app-evidence-override-badge';
+        badgeEl.textContent = '\u2705 Compliant (overridden)';
+      }
+      if (overrideBtn) overrideBtn.hidden = true;
+      if (revertBtn)   revertBtn.hidden   = false;
+    } else {
+      if (badgeEl)     badgeEl.hidden     = true;
+      if (overrideBtn) overrideBtn.hidden = !isNonCompliant;
+      if (revertBtn)   revertBtn.hidden   = true;
+    }
+  }
+
+  function openOverrideModal(parcelKey, aoiData) {
+    var backdrop    = document.getElementById('app-override-backdrop');
+    var reasonInput = document.getElementById('app-override-reason-input');
+    var confirmBtn  = document.getElementById('app-override-confirm-btn');
+    var charCount   = document.getElementById('app-override-charcount');
+    var errorEl     = document.getElementById('app-override-error');
+    var originalEl  = document.getElementById('app-override-original');
+    if (!backdrop) return;
+
+    if (reasonInput) reasonInput.value = '';
+    if (confirmBtn)  confirmBtn.disabled = true;
+    if (charCount)   charCount.textContent = '0 / 500';
+    if (errorEl)     { errorEl.hidden = true; errorEl.textContent = ''; }
+    if (originalEl) {
+      var det    = aoiData && aoiData.determination;
+      var reason = det && det.reason ? det.reason : 'Risk detected';
+      originalEl.textContent = 'Algorithmic determination: ' + reason;
+    }
+
+    backdrop.hidden = false;
+    if (reasonInput) reasonInput.focus();
+  }
+
+  function closeOverrideModal() {
+    var backdrop = document.getElementById('app-override-backdrop');
+    if (backdrop) backdrop.hidden = true;
+  }
+
+  function onOverrideReasonInput() {
+    var reasonInput = document.getElementById('app-override-reason-input');
+    var confirmBtn  = document.getElementById('app-override-confirm-btn');
+    var charCount   = document.getElementById('app-override-charcount');
+    if (!reasonInput) return;
+    var len = reasonInput.value.trim().length;
+    if (charCount)  charCount.textContent  = len + ' / 500';
+    if (confirmBtn) confirmBtn.disabled    = len < 20;
+  }
+
+  async function confirmOverride() {
+    var reasonInput = document.getElementById('app-override-reason-input');
+    var confirmBtn  = document.getElementById('app-override-confirm-btn');
+    var errorEl     = document.getElementById('app-override-error');
+    var instanceId  = _getInstanceId ? _getInstanceId() : null;
+    if (!reasonInput || !instanceId || currentOverrideParcelKey === null) return;
+
+    var reason = reasonInput.value.trim();
+    if (reason.length < 20) return;
+
+    var originalText = confirmBtn ? confirmBtn.textContent : 'Confirm override';
+    if (confirmBtn) { confirmBtn.disabled = true; confirmBtn.textContent = 'Saving\u2026'; }
+    if (errorEl)    { errorEl.hidden = true; errorEl.textContent = ''; }
+
+    try {
+      if (_getApiReady) await _getApiReady();
+      var res = await _apiFetch('/api/analysis/override', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          instance_id: instanceId,
+          parcel_key: currentOverrideParcelKey,
+          reason: reason,
+          revert: false,
+        }),
+      });
+      if (!res.ok) {
+        var err = await res.json().catch(function() { return {}; });
+        if (errorEl) {
+          errorEl.textContent = (err && err.message) || 'Failed to save override. Try again.';
+          errorEl.hidden = false;
+        }
+        return;
+      }
+      var manifest = _getManifest ? _getManifest() : null;
+      if (manifest) {
+        if (!manifest.parcel_overrides) manifest.parcel_overrides = {};
+        manifest.parcel_overrides[currentOverrideParcelKey] = {
+          reason: reason,
+          overridden_at: new Date().toISOString(),
+          override_determination: 'compliant',
+        };
+      }
+      closeOverrideModal();
+      renderParcelOverride(currentOverrideParcelKey, currentOverrideAoiData);
+    } catch (e) {
+      if (errorEl) { errorEl.textContent = 'Failed to save override. Try again.'; errorEl.hidden = false; }
+      console.warn('Override save error:', e);
+    } finally {
+      if (confirmBtn) { confirmBtn.disabled = false; confirmBtn.textContent = originalText; }
+    }
+  }
+
+  async function revertOverride() {
+    var instanceId = _getInstanceId ? _getInstanceId() : null;
+    if (!instanceId || currentOverrideParcelKey === null) return;
+
+    var revertBtn = document.getElementById('app-evidence-override-revert-btn');
+    if (revertBtn) { revertBtn.disabled = true; revertBtn.textContent = 'Reverting\u2026'; }
+
+    try {
+      if (_getApiReady) await _getApiReady();
+      var res = await _apiFetch('/api/analysis/override', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          instance_id: instanceId,
+          parcel_key: currentOverrideParcelKey,
+          reason: '',
+          revert: true,
+        }),
+      });
+      if (res.ok) {
+        var manifest = _getManifest ? _getManifest() : null;
+        if (manifest && manifest.parcel_overrides) {
+          delete manifest.parcel_overrides[currentOverrideParcelKey];
+        }
+        renderParcelOverride(currentOverrideParcelKey, currentOverrideAoiData);
+      }
+    } catch (e) {
+      console.warn('Override revert error:', e);
+    } finally {
+      if (revertBtn) { revertBtn.disabled = false; revertBtn.textContent = 'Revert to algorithmic'; }
+    }
+  }
+
+  window.CanopexEvidencePanels = {
+    init: init,
+    parcelKeyForIndex: parcelKeyForIndex,
+    renderParcelNotes: renderParcelNotes,
+    showNoteEditor: showNoteEditor,
+    hideNoteEditor: hideNoteEditor,
+    saveParcelNote: saveParcelNote,
+    renderParcelOverride: renderParcelOverride,
+    openOverrideModal: openOverrideModal,
+    closeOverrideModal: closeOverrideModal,
+    onOverrideReasonInput: onOverrideReasonInput,
+    confirmOverride: confirmOverride,
+    revertOverride: revertOverride,
+  };
+})();

--- a/website/js/app-history-ui.js
+++ b/website/js/app-history-ui.js
@@ -1,0 +1,265 @@
+(function(){
+  'use strict';
+
+  var _d = {}; // deps
+
+  // ── renderAnalysisHistoryList ──────────────────────────────────────
+  // Populate DOM with run list. Calls selectAnalysisRun on click.
+
+  function renderAnalysisHistoryList() {
+    var container = document.getElementById('app-history-list');
+    if (!container) return;
+
+    container.replaceChildren();
+    var analysisHistoryLoaded = _d.getAnalysisHistoryLoaded ? _d.getAnalysisHistoryLoaded() : false;
+    var currentAccount = _d.getAccount ? _d.getAccount() : null;
+    var selectedAnalysisRunId = _d.getSelectedAnalysisRunId ? _d.getSelectedAnalysisRunId() : null;
+    var analysisHistoryRuns = _d.getAnalysisHistoryRuns ? _d.getAnalysisHistoryRuns() : [];
+
+    if (!analysisHistoryLoaded && currentAccount) {
+      var loading = document.createElement('div');
+      loading.className = 'app-history-empty';
+      loading.textContent = 'Loading your history…';
+      container.appendChild(loading);
+      return;
+    }
+    if (!analysisHistoryRuns.length) {
+      var empty = document.createElement('div');
+      empty.className = 'app-history-empty';
+      var roleConfig = _d.currentRoleConfig ? _d.currentRoleConfig() : { emptyHistoryNote: 'No runs yet.' };
+      empty.textContent = roleConfig.emptyHistoryNote;
+      container.appendChild(empty);
+      return;
+    }
+
+    analysisHistoryRuns.forEach(function(run) {
+      var instanceId = run.instanceId || run.instance_id;
+      var runtimeStatus = run.runtimeStatus || 'Pending';
+      var displayAnalysisPhase = _d.displayAnalysisPhase || function() { return 'unknown'; };
+      var phase = displayAnalysisPhase(run.customStatus, runtimeStatus);
+      var button = document.createElement('button');
+      var header = document.createElement('div');
+      var title = document.createElement('strong');
+      var status = document.createElement('span');
+      var meta = document.createElement('div');
+      var submitted = document.createElement('span');
+      var phaseMeta = document.createElement('span');
+      var scopeMeta = document.createElement('span');
+      var note = document.createElement('div');
+
+      button.type = 'button';
+      button.className = 'app-history-item';
+      button.setAttribute('data-selected', instanceId === selectedAnalysisRunId ? 'true' : 'false');
+      button.addEventListener('click', function(event) {
+        event.stopPropagation();
+        selectAnalysisRun(instanceId, { resume: historyRunIsActive(run) });
+      });
+
+      header.className = 'app-history-item-header';
+      title.className = 'app-history-item-title';
+      var titleParts = [];
+      var formatCountLabel = _d.formatCountLabel || function(n, singular) { return n + ' ' + singular; };
+      if (run.aoiCount) titleParts.push(formatCountLabel(run.aoiCount, 'AOI'));
+      if (run.totalAreaHa) titleParts.push(Number(run.totalAreaHa).toFixed(1) + ' ha');
+      var titleLabel = titleParts.length ? titleParts.join(' · ') : shortInstanceId(instanceId);
+      title.textContent = (historyRunIsActive(run) ? 'Resume: ' : '') + titleLabel;
+      status.className = 'app-history-item-status';
+      status.textContent = runtimeStatus;
+      header.appendChild(title);
+      header.appendChild(status);
+
+      meta.className = 'app-history-item-meta';
+      var formatHistoryTimestamp = _d.formatHistoryTimestamp || function(t) { return t; };
+      var providerLabel = _d.providerLabel || function(p) { return p || ''; };
+      submitted.textContent = formatHistoryTimestamp(run.submittedAt || run.createdTime);
+      phaseMeta.textContent = 'Phase ' + phase;
+      scopeMeta.textContent = [formatCountLabel(run.aoiCount, 'AOI'), providerLabel(run.providerName)].filter(Boolean).join(' • ') || 'Tracked run';
+      meta.appendChild(submitted);
+      meta.appendChild(phaseMeta);
+      meta.appendChild(scopeMeta);
+
+      note.className = 'app-history-item-note';
+      if (historyRunIsActive(run)) {
+        note.textContent = 'Resume this run from ' + phase + '.';
+      } else if (runtimeStatus === 'Completed') {
+        note.textContent = 'View completed results and download exports.';
+      } else {
+        note.textContent = 'Review this run state.';
+      }
+
+      button.appendChild(header);
+      button.appendChild(meta);
+      button.appendChild(note);
+      container.appendChild(button);
+    });
+  }
+
+  // ── selectAnalysisRun ──────────────────────────────────────────────
+
+  function selectAnalysisRun(instanceId, options) {
+    options = options || {};
+    var analysisHistoryRuns = _d.getAnalysisHistoryRuns ? _d.getAnalysisHistoryRuns() : [];
+    var run = analysisHistoryRuns.find(function(entry) {
+      return (entry.instanceId || entry.instance_id) === instanceId;
+    });
+    if (!run) return;
+
+    if (_d.setSelectedAnalysisRunId) _d.setSelectedAnalysisRunId(instanceId);
+    renderAnalysisHistoryList();
+    if (_d.updateRunSelectionLocation) _d.updateRunSelectionLocation(instanceId);
+
+    if (_d.stopAnalysisPolling) _d.stopAnalysisPolling();
+    if (_d.stopPlay) _d.stopPlay(); // Evidence display timelapse
+    if (_d.updateAnalysisRun) _d.updateAnalysisRun(run);
+    if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
+    if (_d.setAnalysisProgressVisible) _d.setAnalysisProgressVisible(true);
+
+    var runtimeStatus = run.runtimeStatus || 'Pending';
+    var mapAnalysisPhase = _d.mapAnalysisPhase || function() { return 'unknown'; };
+    var phase = mapAnalysisPhase(run.customStatus, runtimeStatus);
+    if (runtimeStatus === 'Completed') {
+      if (_d.setAnalysisStep) _d.setAnalysisStep('complete', 'done');
+      if (_d.updateAnalysisStory) _d.updateAnalysisStory('complete', runtimeStatus, run);
+      if (_d.loadRunEvidence) _d.loadRunEvidence(instanceId);
+      return;
+    }
+    if (runtimeStatus === 'Failed' || runtimeStatus === 'Canceled' || runtimeStatus === 'Terminated') {
+      if (_d.setAnalysisStep) _d.setAnalysisStep(phase, 'failed');
+      if (_d.updateAnalysisStory) _d.updateAnalysisStory(phase, runtimeStatus, run);
+      return;
+    }
+
+    if (_d.setAnalysisStep) _d.setAnalysisStep(phase, 'active');
+    if (_d.updateAnalysisStory) _d.updateAnalysisStory(phase, runtimeStatus || 'Pending', run);
+    if (options.resume !== false && _d.pollAnalysisRun) _d.pollAnalysisRun(instanceId);
+  }
+
+  // ── applyAnalysisHistory ───────────────────────────────────────────
+  // Load history payload, apply selection logic, update UI.
+
+  function applyAnalysisHistory(payload, options) {
+    options = options || {};
+    var readRunSelectionFromLocation = _d.readRunSelectionFromLocation || function() { return { instanceId: '' }; };
+    var locationSelection = readRunSelectionFromLocation();
+
+    if (typeof appRuns.applyHistoryPayload === 'function') {
+      var getSelectedAnalysisRunId = _d.getSelectedAnalysisRunId || function() { return null; };
+      var getLatestAnalysisRun = _d.getLatestAnalysisRun || function() { return null; };
+      var getAnalysisHistoryRuns = _d.getAnalysisHistoryRuns || function() { return []; };
+      var parseStatusTimestamp = _d.parseStatusTimestamp || function(t) { return t; };
+
+      var applied = appRuns.applyHistoryPayload(
+        payload,
+        options,
+        getSelectedAnalysisRunId(),
+        getLatestAnalysisRun(),
+        locationSelection.instanceId,
+        parseStatusTimestamp
+      );
+
+      if (_d.setLatestPortfolioSummary) _d.setLatestPortfolioSummary(applied.portfolioSummary);
+      if (_d.setAnalysisHistoryRuns) _d.setAnalysisHistoryRuns(applied.runs);
+
+      if (!applied.selectedId) {
+        if (_d.setSelectedAnalysisRunId) _d.setSelectedAnalysisRunId(null);
+        if (_d.updateRunSelectionLocation) _d.updateRunSelectionLocation('');
+        if (_d.stopAnalysisPolling) _d.stopAnalysisPolling();
+        if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
+        renderAnalysisHistoryList();
+        if (_d.updateAnalysisRun) _d.updateAnalysisRun(null);
+        if (_d.updateHistorySummary) _d.updateHistorySummary(null);
+        return;
+      }
+
+      var selectedRun = applied.runs.find(function(run) { return run.instanceId === applied.selectedId; });
+      selectAnalysisRun(applied.selectedId, { resume: historyRunIsActive(selectedRun) });
+      return;
+    }
+
+    // Fallback: apply history manually
+    if (_d.setLatestPortfolioSummary) {
+      _d.setLatestPortfolioSummary({
+        scope: payload && payload.scope,
+        orgId: payload && payload.orgId,
+        memberCount: payload && payload.memberCount,
+        stats: payload && payload.stats
+      });
+    }
+
+    var normalizeAnalysisRun = _d.normalizeAnalysisRun || function(r) { return r; };
+    var sortAnalysisHistoryRuns = _d.sortAnalysisHistoryRuns || function(r) { return r; };
+    var normalizedActiveRun = normalizeAnalysisRun(payload && payload.activeRun);
+    var runs = sortAnalysisHistoryRuns(payload && payload.runs);
+    if (_d.setAnalysisHistoryRuns) _d.setAnalysisHistoryRuns(runs);
+
+    if (normalizedActiveRun && !runs.some(function(run) { return run.instanceId === normalizedActiveRun.instanceId; })) {
+      runs.unshift(normalizedActiveRun);
+      runs = sortAnalysisHistoryRuns(runs);
+      if (_d.setAnalysisHistoryRuns) _d.setAnalysisHistoryRuns(runs);
+    }
+
+    var getLatestAnalysisRun = _d.getLatestAnalysisRun || function() { return null; };
+    if (options.preferInstanceId && getLatestAnalysisRun() &&
+        (getLatestAnalysisRun().instanceId || getLatestAnalysisRun().instance_id) === options.preferInstanceId &&
+        !runs.some(function(run) { return run.instanceId === options.preferInstanceId; })) {
+      var preserved = normalizeAnalysisRun(getLatestAnalysisRun());
+      if (preserved) {
+        runs.unshift(preserved);
+        runs = sortAnalysisHistoryRuns(runs);
+        if (_d.setAnalysisHistoryRuns) _d.setAnalysisHistoryRuns(runs);
+      }
+    }
+
+    var getSelectedAnalysisRunId = _d.getSelectedAnalysisRunId || function() { return null; };
+    var nextSelectedId = options.preferInstanceId || getSelectedAnalysisRunId() || locationSelection.instanceId;
+    if (nextSelectedId && !runs.some(function(run) { return run.instanceId === nextSelectedId; })) {
+      nextSelectedId = null;
+    }
+    if (!nextSelectedId && normalizedActiveRun) nextSelectedId = normalizedActiveRun.instanceId;
+    if (!nextSelectedId && runs[0]) nextSelectedId = runs[0].instanceId;
+
+    if (!nextSelectedId) {
+      if (_d.setSelectedAnalysisRunId) _d.setSelectedAnalysisRunId(null);
+      if (_d.updateRunSelectionLocation) _d.updateRunSelectionLocation('');
+      if (_d.stopAnalysisPolling) _d.stopAnalysisPolling();
+      if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
+      renderAnalysisHistoryList();
+      if (_d.updateAnalysisRun) _d.updateAnalysisRun(null);
+      if (_d.updateHistorySummary) _d.updateHistorySummary(null);
+      return;
+    }
+
+    var selectedRun = runs.find(function(run) { return run.instanceId === nextSelectedId; });
+    selectAnalysisRun(nextSelectedId, { resume: historyRunIsActive(selectedRun) });
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────
+
+  function shortInstanceId(id) {
+    if (!id) return '—';
+    return id.substring(0, 8) + '…';
+  }
+
+  function historyRunIsActive(run) {
+    if (typeof appRuns.isRunActive === 'function') {
+      return appRuns.isRunActive(run);
+    }
+    var runtimeStatus = String(run && run.runtimeStatus || '').trim().toLowerCase();
+    return ['completed', 'failed', 'terminated', 'canceled'].indexOf(runtimeStatus) === -1;
+  }
+
+  // --- init ---
+
+  function init(deps) {
+    _d = deps || {};
+  }
+
+  // --- Export ---
+
+  window.CanopexHistoryUi = {
+    init: init,
+    renderAnalysisHistoryList: renderAnalysisHistoryList,
+    selectAnalysisRun: selectAnalysisRun,
+    applyAnalysisHistory: applyAnalysisHistory,
+  };
+})();

--- a/website/js/app-profiles.js
+++ b/website/js/app-profiles.js
@@ -1,0 +1,106 @@
+/**
+ * app-profiles.js - App identity and profile contract resolution.
+ *
+ * Shared modules should consult this profile contract rather than branch
+ * directly on route or body attributes.
+ */
+(function () {
+  'use strict';
+
+  var ANALYSIS_PHASE_DETAILS = {
+    submit: 'Uploading your KML and reserving a pipeline worker for this run.',
+    ingestion: 'Parsing the file, validating AOI geometry, and preparing the analysis package.',
+    acquisition: 'Searching NAIP and Sentinel-2 coverage to find the best imagery for each AOI.',
+    fulfilment: 'Downloading scenes, clipping to your AOIs, and reprojecting them into the output stack.',
+    enrichment: 'Adding NDVI, weather context, and cached artifacts so the workspace has richer outputs ready.',
+    complete: 'Analysis complete - scroll down to review satellite imagery, vegetation health, and export options.'
+  };
+
+  var EUDR_ANALYSIS_PHASE_DETAILS = {
+    submit: 'Uploading KML and reserving pipeline capacity for this compliance run.',
+    ingestion: 'Parsing parcels, validating geometry, and preparing the evidence request.',
+    acquisition: 'Searching post-2020 Sentinel-2 imagery and polling scene availability for each parcel.',
+    fulfilment: 'Downloading scenes, clipping to parcel boundaries, and reprojecting into the evidence stack.',
+    enrichment: 'Building NDVI time series, deforestation risk, weather, fire, and land-cover evidence layers.',
+    complete: 'Evidence pack complete - scroll down to review per-parcel determination and export compliance records.'
+  };
+
+  var DEFAULT_CONTENT_PHASE_COPY = {
+    acquisition: {
+      imageryNote: 'NAIP and Sentinel-2 discovery is in progress so the run can pick the right source imagery.',
+      exportsNote: 'There is nothing to export until imagery is actually acquired.'
+    },
+    fulfilment: {
+      imageryNote: 'The pipeline is producing imagery assets for your analysis.',
+      enrichmentNote: 'NDVI and weather context will follow immediately after fulfilment finishes.',
+      exportsNote: 'The run is close enough that saved outputs should feel tangible, not hypothetical.'
+    },
+    enrichment: {
+      imageryNote: 'Core imagery is in place and the workspace is adding the last supporting layers.',
+      enrichmentNote: 'NDVI, weather, and derived context are being assembled for the run detail experience.',
+      exportsNote: 'Saved outputs, exports, and revisit paths will be available shortly.'
+    }
+  };
+
+  var EUDR_CONTENT_PHASE_COPY = {
+    acquisition: {
+      imageryNote: 'Sentinel-2 post-2020 imagery discovery is in progress for each parcel.',
+      exportsNote: 'Evidence pack exports are unavailable until imagery is acquired.'
+    },
+    fulfilment: {
+      imageryNote: 'The pipeline is clipping scenes to parcel boundaries for the evidence stack.',
+      enrichmentNote: 'Deforestation risk, NDVI time series, and land-cover evidence will follow immediately.',
+      exportsNote: 'Compliance exports are close - the evidence pack is being assembled.'
+    },
+    enrichment: {
+      imageryNote: 'Sentinel-2 and land-cover layers are in place; final evidence layers being added.',
+      enrichmentNote: 'Per-parcel deforestation determination, NDVI, weather, fire, and land-cover evidence are being assembled.',
+      exportsNote: 'Audit-grade PDF, GeoJSON, and CSV exports for compliance records will be available shortly.'
+    }
+  };
+
+  var profiles = {
+    default: {
+      id: 'default',
+      basePath: '/app/',
+      historyScope: 'user',
+      lockedWorkspace: false,
+      defaultRole: 'conservation',
+      defaultPreference: 'investigate',
+      enableParcelCostEstimate: false,
+      requiresEudrBillingGate: false,
+      phaseDetails: ANALYSIS_PHASE_DETAILS,
+      contentPhaseCopy: DEFAULT_CONTENT_PHASE_COPY,
+      preflightDisclaimer: null,
+    },
+    eudr: {
+      id: 'eudr',
+      basePath: '/eudr/',
+      historyScope: 'org',
+      lockedWorkspace: true,
+      defaultRole: 'eudr',
+      defaultPreference: 'report',
+      enableParcelCostEstimate: true,
+      requiresEudrBillingGate: true,
+      phaseDetails: EUDR_ANALYSIS_PHASE_DETAILS,
+      contentPhaseCopy: EUDR_CONTENT_PHASE_COPY,
+      preflightDisclaimer: 'This due diligence lens frames evidence for review and audit support. It is not a legal compliance certificate.',
+    }
+  };
+
+  function resolveActiveProfile() {
+    var isEudr = !!(document.body && document.body.hasAttribute('data-eudr-app'));
+    if (isEudr) return profiles.eudr;
+    return profiles.default;
+  }
+
+  function getProfile(id) {
+    if (id && profiles[id]) return profiles[id];
+    return profiles.default;
+  }
+
+  window.CanopexAppProfiles = {
+    getProfile: getProfile,
+    resolveActiveProfile: resolveActiveProfile,
+  };
+})();

--- a/website/js/app-run-lifecycle.js
+++ b/website/js/app-run-lifecycle.js
@@ -1,0 +1,641 @@
+/**
+ * app-run-lifecycle.js
+ *
+ * Analysis run queue, poll, display, and export.
+ * Extracted from app-shell.js. Covers:
+ *   - updateContentSummary  — phase-aware content panel wording
+ *   - updateRunDetail       — run metadata display (scope, delivery, link)
+ *   - downloadRunExport     — GeoJSON/CSV/PDF export trigger
+ *   - updateAnalysisRun     — master run view update (owns latestAnalysisRun)
+ *   - applyFirstRunLayout   — first-run vs returning user hero layout
+ *   - stopAnalysisPolling   — cancel active poll
+ *   - pollAnalysisRun       — 3 s poll loop with generation guard
+ *   - queueAnalysis         — full submission flow (token → upload → track)
+ *
+ * Exposes window.CanopexRunLifecycle = {
+ *   init, updateContentSummary, updateRunDetail, downloadRunExport,
+ *   updateAnalysisRun, applyFirstRunLayout, stopAnalysisPolling,
+ *   pollAnalysisRun, queueAnalysis, getLatestRun
+ * }
+ */
+(function () {
+  'use strict';
+
+  // ── Internal state ────────────────────────────────────────────
+  var latestAnalysisRun = null;
+  var activeAnalysisPoll = null;
+  var analysisPollGeneration = 0; // incremented on each pollAnalysisRun call to detect stale callbacks
+
+  // ── Injected deps ─────────────────────────────────────────────
+  var _d = {};
+
+  function init(deps) {
+    _d = deps || {};
+  }
+
+  // ── Helpers (reads from canopex-helpers / canopex-geo globals) ──
+
+  function _helpers() { return window.CanopexHelpers || {}; }
+  function _geo() { return window.CanopexGeo || {}; }
+
+  function _displayAnalysisPhase(cs, rs) {
+    var h = _helpers();
+    return typeof h.displayAnalysisPhase === 'function' ? h.displayAnalysisPhase(cs, rs) : (rs || 'Pending');
+  }
+  function _summarizeRunTiming(data) {
+    var h = _helpers();
+    return typeof h.summarizeRunTiming === 'function' ? h.summarizeRunTiming(data) : {};
+  }
+  function _parseDownloadFilename(res, fallback) {
+    var h = _helpers();
+    return typeof h.parseDownloadFilename === 'function' ? h.parseDownloadFilename(res, fallback) : fallback;
+  }
+  function _formatHistoryTimestamp(v) {
+    var h = _helpers();
+    return typeof h.formatHistoryTimestamp === 'function' ? h.formatHistoryTimestamp(v) : String(v || '\u2014');
+  }
+  function _formatCountLabel(n, s, p) {
+    var h = _helpers();
+    return typeof h.formatCountLabel === 'function' ? h.formatCountLabel(n, s, p) : null;
+  }
+  function _providerLabel(name) {
+    var h = _helpers();
+    return typeof h.providerLabel === 'function' ? h.providerLabel(name) : null;
+  }
+  function _summarizeFailureCounts(pf) {
+    var h = _helpers();
+    return typeof h.summarizeFailureCounts === 'function' ? h.summarizeFailureCounts(pf) : null;
+  }
+  function _formatDistance(km) {
+    var g = _geo();
+    return typeof g.formatDistance === 'function' ? g.formatDistance(km) : km + ' km';
+  }
+  function _formatHectares(ha) {
+    var g = _geo();
+    return typeof g.formatHectares === 'function' ? g.formatHectares(ha) : ha + ' ha';
+  }
+  function _parseKmlText(text) {
+    var g = _geo();
+    return typeof g.parseKmlText === 'function' ? g.parseKmlText(text) : text;
+  }
+
+  // ── Public accessors ──────────────────────────────────────────
+
+  function getLatestRun() { return latestAnalysisRun; }
+
+  // ── updateContentSummary ──────────────────────────────────────
+
+  function updateContentSummary(data) {
+    var role = _d.getCurrentRoleConfig ? _d.getCurrentRoleConfig() : {};
+    var imageryEl = document.getElementById('app-content-imagery');
+    var imageryNoteEl = document.getElementById('app-content-imagery-note');
+    var enrichmentEl = document.getElementById('app-content-enrichment');
+    var enrichmentNoteEl = document.getElementById('app-content-enrichment-note');
+    var exportsEl = document.getElementById('app-content-exports');
+    var exportsNoteEl = document.getElementById('app-content-exports-note');
+    if (!imageryEl || !imageryNoteEl || !enrichmentEl || !enrichmentNoteEl || !exportsEl || !exportsNoteEl) return;
+
+    var emptyContent = (role && role.emptyContent) || {};
+    if (!data) {
+      if (_d.showEvidenceSurface) _d.showEvidenceSurface(false);
+      imageryEl.textContent = emptyContent.imageryTitle || 'Imagery';
+      imageryNoteEl.textContent = emptyContent.imageryNote || '';
+      enrichmentEl.textContent = emptyContent.enrichmentTitle || 'Enrichment';
+      enrichmentNoteEl.textContent = emptyContent.enrichmentNote || '';
+      exportsEl.textContent = emptyContent.exportsTitle || 'Exports';
+      exportsNoteEl.textContent = emptyContent.exportsNote || '';
+      return;
+    }
+
+    var runtimeStatus = data.runtimeStatus || 'Pending';
+    var phase = (data.customStatus && data.customStatus.phase) || 'queued';
+    var profile = _d.getActiveProfile ? _d.getActiveProfile() : {};
+    var phaseCopy = (profile.contentPhaseCopy && profile.contentPhaseCopy[phase]) || {};
+
+    if (runtimeStatus === 'Completed') {
+      // Evidence surface is loaded by loadRunEvidence(), triggered from selectAnalysisRun
+      // Phase status is hidden; evidence surface is shown
+      return;
+    }
+
+    if (_d.showEvidenceSurface) _d.showEvidenceSurface(false);
+
+    if (runtimeStatus === 'Failed' || runtimeStatus === 'Canceled' || runtimeStatus === 'Terminated') {
+      imageryEl.textContent = 'Run interrupted';
+      imageryNoteEl.textContent = 'The pipeline stopped before the imagery stack completed.';
+      enrichmentEl.textContent = 'Context incomplete';
+      enrichmentNoteEl.textContent = 'This run needs explicit failure handling rather than silent fallback behavior.';
+      exportsEl.textContent = 'Nothing staged';
+      exportsNoteEl.textContent = 'No saved outputs should be implied when the real pipeline fails.';
+      return;
+    }
+
+    if (phase === 'ingestion' || phase === 'queued') {
+      imageryEl.textContent = 'AOIs preparing';
+      imageryNoteEl.textContent = 'The workspace is validating geometry and shaping the request for imagery search.';
+      enrichmentEl.textContent = 'Waiting on imagery';
+      enrichmentNoteEl.textContent = 'Context layers follow once the pipeline has something real to attach to.';
+      exportsEl.textContent = 'Pipeline in motion';
+      exportsNoteEl.textContent = 'Nothing is staged for export yet — outputs unlock after the run completes.';
+      return;
+    }
+
+    if (phase === 'acquisition') {
+      imageryEl.textContent = phaseCopy.imageryTitle || 'Scenes queued';
+      imageryNoteEl.textContent = phaseCopy.imageryNote || 'Imagery is being selected and staged for this AOI set.';
+      enrichmentEl.textContent = 'AOIs loading';
+      enrichmentNoteEl.textContent = 'Context layers are being applied as the imagery batch arrives.';
+      exportsEl.textContent = 'Preparing outputs';
+      exportsNoteEl.textContent = 'Exports are being assembled — nearly there.';
+      return;
+    }
+
+    if (phase === 'fulfilment') {
+      imageryEl.textContent = phaseCopy.imageryTitle || 'Scenes confirmed';
+      imageryNoteEl.textContent = phaseCopy.imageryNote || 'Imagery tiles are confirmed and being processed.';
+      enrichmentEl.textContent = 'Enrichment completing';
+      enrichmentNoteEl.textContent = 'Change detection, NDVI baselines, and weather context are being layered in.';
+      exportsEl.textContent = 'Assembling outputs';
+      exportsNoteEl.textContent = 'GeoJSON, CSV, and PDF packages are being built.';
+      return;
+    }
+
+    if (phase === 'enrichment') {
+      imageryEl.textContent = phaseCopy.imageryTitle || 'Imagery landed';
+      imageryNoteEl.textContent = phaseCopy.imageryNote || 'All imagery tiles are confirmed and ready to view.';
+      enrichmentEl.textContent = 'Enrichment active';
+      enrichmentNoteEl.textContent = 'Context layers are being attached. Results unlock when enrichment completes.';
+      exportsEl.textContent = 'Finalising exports';
+      exportsNoteEl.textContent = 'Export packages are being finalised. They will unlock shortly.';
+      return;
+    }
+
+    // Default / unknown phase
+    imageryEl.textContent = 'Pipeline running';
+    imageryNoteEl.textContent = 'The pipeline is active. Content panels will update as each phase completes.';
+    enrichmentEl.textContent = 'In progress';
+    enrichmentNoteEl.textContent = 'Enrichment layers will appear once imagery is confirmed.';
+    exportsEl.textContent = 'Pending';
+    exportsNoteEl.textContent = 'Exports will unlock when the run completes.';
+  }
+
+  // ── updateRunDetail ───────────────────────────────────────────
+
+  function updateRunDetail(data) {
+    var submittedEl = document.getElementById('app-run-submitted');
+    var submittedNoteEl = document.getElementById('app-run-submitted-note');
+    var scopeEl = document.getElementById('app-run-scope');
+    var scopeNoteEl = document.getElementById('app-run-scope-note');
+    var deliveryEl = document.getElementById('app-run-delivery');
+    var deliveryNoteEl = document.getElementById('app-run-delivery-note');
+    var linkLabelEl = document.getElementById('app-run-link-label');
+    var linkEl = document.getElementById('app-run-link');
+    if (!submittedEl || !submittedNoteEl || !scopeEl || !scopeNoteEl || !deliveryEl || !deliveryNoteEl || !linkLabelEl || !linkEl) return;
+
+    var appBase = _d.getAppBase ? _d.getAppBase() : '/app/';
+    if (!data) {
+      submittedEl.textContent = '\u2014';
+      submittedNoteEl.textContent = 'Run details restore here after reload.';
+      scopeEl.textContent = '\u2014';
+      scopeNoteEl.textContent = 'Feature and AOI counts appear when known.';
+      deliveryEl.textContent = '\u2014';
+      deliveryNoteEl.textContent = 'Failure counts and tracked artifacts will appear here.';
+      linkLabelEl.textContent = 'Dashboard state';
+      linkEl.href = appBase;
+      linkEl.textContent = 'Open dashboard';
+      document.querySelectorAll('[data-export-format]').forEach(function (button) {
+        button.disabled = true;
+      });
+      return;
+    }
+
+    var runtimeStatus = data.runtimeStatus || 'Pending';
+    var timing = _summarizeRunTiming(data);
+    var scopeSummary = [
+      _formatCountLabel(data.featureCount, 'feature'),
+      _formatCountLabel(data.aoiCount, 'AOI'),
+      data.processingMode,
+    ].filter(Boolean).join(' \u2022 ');
+    var scopeNote = [
+      data.maxSpreadKm != null ? 'Spread ' + _formatDistance(data.maxSpreadKm) : null,
+      data.totalAreaHa != null ? 'Area ' + _formatHectares(data.totalAreaHa) : null,
+      _providerLabel(data.providerName),
+    ].filter(Boolean).join(' \u2022 ');
+    var failureSummary = _summarizeFailureCounts(data.partialFailures);
+    var artifactCount = data.artifactCount || 0;
+
+    submittedEl.textContent = _formatHistoryTimestamp(data.submittedAt || data.createdTime);
+    submittedNoteEl.textContent = timing.sinceUpdate
+      ? 'Last backend update ' + timing.sinceUpdate + ' ago.'
+      : 'Your run history preserves this state across reloads.';
+    scopeEl.textContent = scopeSummary || 'Scope loading';
+    scopeNoteEl.textContent = scopeNote || 'Preflight detail appears when the run metadata is available.';
+
+    if (runtimeStatus === 'Completed') {
+      deliveryEl.textContent = artifactCount ? artifactCount + ' tracked outputs' : 'Exports ready';
+      deliveryNoteEl.textContent = failureSummary || 'GeoJSON, CSV, and PDF exports are ready for this completed run.';
+    } else if (runtimeStatus === 'Failed' || runtimeStatus === 'Canceled' || runtimeStatus === 'Terminated') {
+      deliveryEl.textContent = 'Run interrupted';
+      deliveryNoteEl.textContent = failureSummary || 'This run stopped before producing a complete result set.';
+    } else {
+      deliveryEl.textContent = 'Tracking live pipeline';
+      deliveryNoteEl.textContent = failureSummary || 'Results will unlock here when the run completes.';
+    }
+
+    linkLabelEl.textContent = 'Run details';
+    var permalink = _d.selectedRunPermalink ? _d.selectedRunPermalink(data.instanceId || data.instance_id) : appBase;
+    linkEl.href = permalink;
+    linkEl.textContent = 'Copy link to this run';
+
+    document.querySelectorAll('[data-export-format]').forEach(function (button) {
+      button.disabled = runtimeStatus !== 'Completed';
+    });
+    var evidenceExportNote = document.getElementById('app-evidence-export-note');
+    if (evidenceExportNote) {
+      evidenceExportNote.textContent = runtimeStatus === 'Completed'
+        ? 'Download GeoJSON, CSV, or PDF for this completed run.'
+        : 'Exports unlock when the selected run completes.';
+    }
+  }
+
+  // ── downloadRunExport ─────────────────────────────────────────
+
+  async function downloadRunExport(format) {
+    var run = latestAnalysisRun;
+    if (!run || !(run.instanceId || run.instance_id)) {
+      if (_d.setAnalysisStatus) _d.setAnalysisStatus('Select a run first.', 'error');
+      return;
+    }
+
+    var instanceId = run.instanceId || run.instance_id;
+    if ((run.runtimeStatus || '') !== 'Completed') {
+      if (_d.setAnalysisStatus) _d.setAnalysisStatus('Exports become available once the selected run completes.', 'info');
+      return;
+    }
+
+    var button = document.querySelector('[data-export-format="' + format + '"]');
+    var originalText = button ? button.textContent : format.toUpperCase();
+    if (button) {
+      button.disabled = true;
+      button.textContent = 'Preparing\u2026';
+    }
+
+    try {
+      var apiReady = _d.getApiReady ? _d.getApiReady() : Promise.resolve();
+      await apiReady;
+      var res = await _d.apiFetch('/api/export/' + encodeURIComponent(instanceId) + '/' + format);
+      var blob = await res.blob();
+      var blobUrl = URL.createObjectURL(blob);
+      var link = document.createElement('a');
+      link.href = blobUrl;
+      link.download = _parseDownloadFilename(res, 'canopex_' + instanceId + '.' + format);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(blobUrl);
+      if (_d.setAnalysisStatus) _d.setAnalysisStatus(format.toUpperCase() + ' export downloaded for the selected run.', 'success');
+    } catch (err) {
+      if (_d.setAnalysisStatus) _d.setAnalysisStatus((err && err.message) || 'Could not download the selected export.', 'error');
+    } finally {
+      if (button) {
+        button.disabled = latestAnalysisRun && latestAnalysisRun.runtimeStatus !== 'Completed';
+        button.textContent = originalText;
+      }
+    }
+  }
+
+  // ── updateAnalysisRun ─────────────────────────────────────────
+
+  function updateAnalysisRun(data) {
+    var panel = document.getElementById('app-analysis-run');
+    latestAnalysisRun = data || null;
+    if (_d.setLatestAnalysisRun) _d.setLatestAnalysisRun(latestAnalysisRun); // keep shell copy in sync
+    if (!panel) return;
+    if (!data) {
+      panel.hidden = true;
+      if (_d.setHeroRunSummary) {
+        var readyNote = _d.getCurrentRoleConfig ? (_d.getCurrentRoleConfig().readyNote || '') : '';
+        _d.setHeroRunSummary('Ready to queue', readyNote);
+      }
+      if (_d.updateHistorySummary) _d.updateHistorySummary(null);
+      updateRunDetail(null);
+      updateContentSummary(null);
+      return;
+    }
+    panel.hidden = false;
+    var instanceId = data.instanceId || data.instance_id || '\u2014';
+    var runtimeStatus = data.runtimeStatus || 'queued';
+    var phase = _displayAnalysisPhase(data.customStatus, runtimeStatus);
+    var timing = _summarizeRunTiming(data);
+    document.getElementById('app-analysis-instance').textContent = instanceId;
+    document.getElementById('app-analysis-runtime').textContent = runtimeStatus;
+    document.getElementById('app-analysis-phase').textContent = phase;
+    if (_d.setHeroRunSummary) {
+      _d.setHeroRunSummary(
+        runtimeStatus,
+        runtimeStatus === 'Completed'
+          ? 'Pipeline finished successfully \u2014 results are ready.'
+          : 'Current phase: ' + phase + '.' + (timing.elapsed ? ' Elapsed ' + timing.elapsed + '.' : '')
+      );
+    }
+    if (_d.updateHistorySummary) _d.updateHistorySummary(data);
+    updateRunDetail(data);
+    updateContentSummary(data);
+  }
+
+  // ── applyFirstRunLayout ───────────────────────────────────────
+
+  function applyFirstRunLayout() {
+    var firstRun = document.getElementById('app-first-run-hero');
+    var evidenceHero = document.getElementById('app-evidence-hero');
+    var historyRail = document.getElementById('app-history-card');
+    var workflowStage = document.getElementById('app-workflow-stage');
+    var modePill = document.getElementById('app-hero-mode');
+    var activeRunPill = document.getElementById('app-hero-active-run');
+    if (!firstRun) return;
+
+    var historyLoaded = _d.getAnalysisHistoryLoaded ? _d.getAnalysisHistoryLoaded() : false;
+    var historyRuns = _d.getAnalysisHistoryRuns ? _d.getAnalysisHistoryRuns() : [];
+    var isEmpty = historyLoaded && historyRuns.length === 0 && !latestAnalysisRun;
+    firstRun.hidden = !isEmpty;
+    if (evidenceHero) evidenceHero.hidden = isEmpty;
+
+    // Collapse first-load noise: hide history rail + extra pills for new users
+    if (historyRail) historyRail.hidden = isEmpty;
+    if (workflowStage) workflowStage.classList.toggle('first-run', isEmpty);
+    if (modePill) modePill.closest('.app-stat-pill').hidden = isEmpty;
+    if (activeRunPill) activeRunPill.closest('.app-stat-pill').hidden = isEmpty;
+  }
+
+  // ── stopAnalysisPolling ───────────────────────────────────────
+
+  function stopAnalysisPolling() {
+    if (activeAnalysisPoll) {
+      clearInterval(activeAnalysisPoll);
+      activeAnalysisPoll = null;
+    }
+  }
+
+  // ── pollAnalysisRun ───────────────────────────────────────────
+
+  async function pollAnalysisRun(instanceId) {
+    stopAnalysisPolling();
+    const thisGeneration = ++analysisPollGeneration;
+    let consecutiveFailures = 0;
+    const MAX_CONSECUTIVE_FAILURES = 5;
+
+    async function refreshRun() {
+      // Bail out if a newer poll has started while we were awaiting.
+      if (analysisPollGeneration !== thisGeneration) return null;
+      try {
+        var res = await _d.apiFetch('/api/orchestrator/' + instanceId);
+        var data = await res.json();
+        consecutiveFailures = 0;
+        // Re-check after await — another selectAnalysisRun may have fired.
+        if (analysisPollGeneration !== thisGeneration) return null;
+        if (_d.upsertAnalysisHistoryRun) _d.upsertAnalysisHistoryRun(data);
+        updateAnalysisRun(data);
+
+        var runtime = data.runtimeStatus || '';
+        var phase = _d.mapAnalysisPhase ? _d.mapAnalysisPhase(data.customStatus, runtime) : (data.customStatus && data.customStatus.phase) || 'queued';
+        if (_d.setAnalysisProgressVisible) _d.setAnalysisProgressVisible(true);
+        if (runtime === 'Completed') {
+          stopAnalysisPolling();
+          if (_d.setAnalysisStep) _d.setAnalysisStep('complete', 'done');
+          if (_d.updateAnalysisStory) _d.updateAnalysisStory('complete', runtime, data);
+          if (_d.clearCacheKey) { _d.clearCacheKey('billing'); _d.clearCacheKey('history'); }
+          if (_d.loadBillingStatus) _d.loadBillingStatus();
+          if (_d.loadAnalysisHistory) _d.loadAnalysisHistory({ preferInstanceId: instanceId });
+          if (_d.loadRunEvidence) _d.loadRunEvidence(instanceId);
+          var evidenceHero = document.getElementById('app-evidence-hero');
+          if (evidenceHero) {
+            setTimeout(function () {
+              var scrollBehavior = 'smooth';
+              if (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+                scrollBehavior = 'auto';
+              }
+              evidenceHero.scrollIntoView({ behavior: scrollBehavior, block: 'start' });
+            }, 400);
+          }
+        } else if (runtime === 'Failed' || runtime === 'Canceled' || runtime === 'Terminated') {
+          stopAnalysisPolling();
+          if (_d.setAnalysisStep) _d.setAnalysisStep(phase, 'failed');
+          if (_d.updateAnalysisStory) _d.updateAnalysisStory(phase, runtime, data);
+          if (_d.loadAnalysisHistory) _d.loadAnalysisHistory({ preferInstanceId: instanceId });
+        } else {
+          if (_d.setAnalysisStep) _d.setAnalysisStep(phase, 'active');
+          if (_d.updateAnalysisStory) _d.updateAnalysisStory(phase, runtime || 'Pending', data);
+        }
+        return data;
+      } catch {
+        consecutiveFailures++;
+        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+          stopAnalysisPolling();
+          if (_d.setAnalysisStatus) _d.setAnalysisStatus('Connection lost \u2014 pipeline updates have stopped. Reload the page to resume.', 'error');
+        }
+        return null;
+      }
+    }
+
+    var initialData = await refreshRun();
+    if (analysisPollGeneration !== thisGeneration) return; // superseded during initial fetch
+    if (initialData) {
+      var initialRuntime = initialData.runtimeStatus || '';
+      if (initialRuntime === 'Completed' || initialRuntime === 'Failed' || initialRuntime === 'Canceled' || initialRuntime === 'Terminated') {
+        return;
+      }
+    }
+
+    activeAnalysisPoll = setInterval(function () {
+      refreshRun();
+    }, 3000);
+  }
+
+  // ── queueAnalysis ─────────────────────────────────────────────
+
+  async function queueAnalysis() {
+    var currentAccount = _d.getAccount ? _d.getAccount() : null;
+    if (!currentAccount) {
+      if (_d.login) _d.login();
+      return;
+    }
+
+    // EUDR entitlement gate: show subscribe modal when trial is exhausted.
+    // If billing hasn't loaded yet, fetch it before deciding.
+    var activeProfile = _d.getActiveProfile ? _d.getActiveProfile() : {};
+    if (activeProfile.requiresEudrBillingGate && typeof window.eudrBillingData === 'function') {
+      var billing = window.eudrBillingData();
+      if (!billing) {
+        try {
+          var apiReady0 = _d.getApiReady ? _d.getApiReady() : Promise.resolve();
+          await apiReady0;
+          var billingRes = await _d.apiFetch('/api/eudr/billing');
+          billing = await billingRes.json();
+        } catch (_) { /* proceed — server will enforce */ }
+      }
+      if (billing && !billing.subscribed && billing.trial_remaining != null && billing.trial_remaining <= 0) {
+        if (typeof window.showEudrSubscribeModal === 'function') {
+          window.showEudrSubscribeModal();
+        }
+        return;
+      }
+    }
+
+    var button = document.getElementById('app-analysis-submit-btn');
+    var textarea = document.getElementById('app-analysis-kml');
+    if (!button || !textarea) return;
+
+    var kmlContent = _parseKmlText(textarea.value);
+    if (!kmlContent) {
+      if (_d.setAnalysisStatus) _d.setAnalysisStatus('Paste KML content or load a KML/KMZ file first.', 'error');
+      updateAnalysisRun(null);
+      if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
+      return;
+    }
+
+    var preflight = (_d.getAnalysisDraftSummary ? _d.getAnalysisDraftSummary() : null) || (_d.updateAnalysisPreflight ? _d.updateAnalysisPreflight(kmlContent) : null);
+    if (preflight && preflight.error) {
+      if (_d.setAnalysisStatus) _d.setAnalysisStatus(preflight.error, 'error');
+      if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
+      return;
+    }
+
+    button.disabled = true;
+    button.textContent = 'Queueing\u2026';
+    if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
+    if (_d.setAnalysisProgressVisible) _d.setAnalysisProgressVisible(true);
+    if (_d.setAnalysisStep) _d.setAnalysisStep('submit', 'active');
+    if (_d.updateAnalysisStory) _d.updateAnalysisStory('submit', 'Pending', null);
+    updateAnalysisRun(null);
+
+    var workspaceRole = _d.getWorkspaceRole ? _d.getWorkspaceRole() : 'conservation';
+    var workspacePreference = _d.getWorkspacePreference ? _d.getWorkspacePreference() : 'investigate';
+
+    try {
+      var apiReady = _d.getApiReady ? _d.getApiReady() : Promise.resolve();
+      await apiReady;
+      var submissionContext = null;
+      if (preflight) {
+        submissionContext = {
+          feature_count: preflight.featureCount,
+          aoi_count: preflight.aoiCount,
+          max_spread_km: preflight.maxSpreadKm,
+          total_area_ha: preflight.totalAreaHa,
+          largest_area_ha: preflight.largestAreaHa,
+          processing_mode: preflight.processingMode,
+          provider_name: 'planetary_computer',
+          workspace_role: workspaceRole,
+          workspace_preference: workspacePreference
+        };
+      }
+
+      // Step 1: Get SAS token from Container Apps FA.
+      // apiFetch handles cross-origin routing and auth forwarding.
+      var tokenBody = {};
+      if (submissionContext) {
+        tokenBody.provider_name = submissionContext.provider_name;
+        tokenBody.submission_context = submissionContext;
+      }
+
+      // EUDR compliance mode (#600)
+      var eudrCheckbox = document.getElementById('app-eudr-mode');
+      if (eudrCheckbox && eudrCheckbox.checked) {
+        tokenBody.eudr_mode = true;
+      }
+
+      var tokenRes;
+      try {
+        tokenRes = await _d.apiFetch('/api/upload/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(tokenBody)
+        });
+      } catch (tokenFetchErr) {
+        // 401 is handled centrally by apiFetch (clears session, shows re-login prompt).
+        if (tokenFetchErr.status === 401) {
+          if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
+          return;
+        }
+        if (_d.setAnalysisStatus) _d.setAnalysisStatus((tokenFetchErr.body && tokenFetchErr.body.error) || 'Could not prepare upload. Please try again.', 'error');
+        updateContentSummary(null);
+        if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
+        return;
+      }
+
+      var tokenData = await tokenRes.json();
+      var submissionId = tokenData.submissionId || tokenData.submission_id;
+      var sasUrl = tokenData.sasUrl || tokenData.sas_url;
+
+      // Step 2: Upload KML directly to blob storage via SAS URL
+      button.textContent = 'Uploading\u2026';
+      if (_d.setAnalysisStep) _d.setAnalysisStep('submit', 'active');
+
+      var kmlBytes = new TextEncoder().encode(kmlContent);
+      var uploadRes = await fetch(sasUrl, {
+        method: 'PUT',
+        headers: {
+          'x-ms-blob-type': 'BlockBlob',
+          'Content-Type': 'application/vnd.google-earth.kml+xml'
+        },
+        body: kmlBytes
+      });
+      if (!uploadRes || !uploadRes.ok) {
+        if (_d.setAnalysisStatus) _d.setAnalysisStatus('Upload failed. Please try again.', 'error');
+        if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
+        return;
+      }
+
+      // Step 3: Track the submission
+      if (_d.clearCacheKey) { _d.clearCacheKey('history'); _d.clearCacheKey('billing'); }
+      var data = { instance_id: submissionId };
+      if (_d.setAnalysisHistoryLoaded) _d.setAnalysisHistoryLoaded(true);
+      applyFirstRunLayout();
+      var queuedAt = new Date().toISOString();
+      if (_d.upsertAnalysisHistoryRun) {
+        _d.upsertAnalysisHistoryRun({
+          instanceId: data.instance_id,
+          submittedAt: queuedAt,
+          createdTime: queuedAt,
+          lastUpdatedTime: queuedAt,
+          runtimeStatus: 'Pending',
+          customStatus: { phase: 'queued' },
+          providerName: 'planetary_computer',
+          featureCount: preflight && preflight.featureCount,
+          aoiCount: preflight && preflight.aoiCount,
+          processingMode: preflight && preflight.processingMode,
+          maxSpreadKm: preflight && preflight.maxSpreadKm,
+          totalAreaHa: preflight && preflight.totalAreaHa,
+          largestAreaHa: preflight && preflight.largestAreaHa,
+          workspaceRole: workspaceRole,
+          workspacePreference: workspacePreference
+        });
+      }
+      if (_d.selectAnalysisRun) _d.selectAnalysisRun(data.instance_id, { resume: true });
+      if (_d.setAnalysisStatus) _d.setAnalysisStatus('Analysis queued. The app will walk through each stage as the pipeline advances.', 'info');
+      if (_d.loadBillingStatus) _d.loadBillingStatus();
+    } catch (err) {
+      console.error('queueAnalysis failed:', err);
+      if (_d.setAnalysisStatus) _d.setAnalysisStatus('Could not queue analysis request.', 'error');
+      if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
+    } finally {
+      button.disabled = false;
+      var draftSummary = _d.getAnalysisDraftSummary ? _d.getAnalysisDraftSummary() : null;
+      button.textContent = draftSummary && !draftSummary.error ? 'Confirm & Queue' : 'Queue Analysis';
+    }
+  }
+
+  // ── Public API ────────────────────────────────────────────────
+
+  window.CanopexRunLifecycle = {
+    init: init,
+    getLatestRun: getLatestRun,
+    updateContentSummary: updateContentSummary,
+    updateRunDetail: updateRunDetail,
+    downloadRunExport: downloadRunExport,
+    updateAnalysisRun: updateAnalysisRun,
+    applyFirstRunLayout: applyFirstRunLayout,
+    stopAnalysisPolling: stopAnalysisPolling,
+    pollAnalysisRun: pollAnalysisRun,
+    queueAnalysis: queueAnalysis,
+  };
+})();

--- a/website/js/app-run-lifecycle.js
+++ b/website/js/app-run-lifecycle.js
@@ -83,6 +83,20 @@
 
   function getLatestRun() { return latestAnalysisRun; }
 
+  function upsertHistoryRun(run) {
+    if (!_d.getAnalysisHistoryRuns || !_d.setAnalysisHistoryRuns || !_d.renderAnalysisHistoryList) return;
+    var appRuns = window.CanopexAppRuns || {};
+    if (typeof appRuns.upsertRun !== 'function') return;
+    var helpers = window.CanopexHelpers || {};
+    var parseTimestamp = typeof helpers.parseStatusTimestamp === 'function'
+      ? helpers.parseStatusTimestamp
+      : function (value) { return value; };
+    var nextRuns = appRuns.upsertRun(_d.getAnalysisHistoryRuns(), run, parseTimestamp);
+    _d.setAnalysisHistoryRuns(nextRuns);
+    _d.renderAnalysisHistoryList();
+    if (_d.applyFirstRunLayout) _d.applyFirstRunLayout();
+  }
+
   // ── updateContentSummary ──────────────────────────────────────
 
   function updateContentSummary(data) {
@@ -309,7 +323,6 @@
   function updateAnalysisRun(data) {
     var panel = document.getElementById('app-analysis-run');
     latestAnalysisRun = data || null;
-    if (_d.setLatestAnalysisRun) _d.setLatestAnalysisRun(latestAnalysisRun); // keep shell copy in sync
     if (!panel) return;
     if (!data) {
       panel.hidden = true;
@@ -393,7 +406,7 @@
         consecutiveFailures = 0;
         // Re-check after await — another selectAnalysisRun may have fired.
         if (analysisPollGeneration !== thisGeneration) return null;
-        if (_d.upsertAnalysisHistoryRun) _d.upsertAnalysisHistoryRun(data);
+        upsertHistoryRun(data);
         updateAnalysisRun(data);
 
         var runtime = data.runtimeStatus || '';
@@ -591,25 +604,23 @@
       if (_d.setAnalysisHistoryLoaded) _d.setAnalysisHistoryLoaded(true);
       applyFirstRunLayout();
       var queuedAt = new Date().toISOString();
-      if (_d.upsertAnalysisHistoryRun) {
-        _d.upsertAnalysisHistoryRun({
-          instanceId: data.instance_id,
-          submittedAt: queuedAt,
-          createdTime: queuedAt,
-          lastUpdatedTime: queuedAt,
-          runtimeStatus: 'Pending',
-          customStatus: { phase: 'queued' },
-          providerName: 'planetary_computer',
-          featureCount: preflight && preflight.featureCount,
-          aoiCount: preflight && preflight.aoiCount,
-          processingMode: preflight && preflight.processingMode,
-          maxSpreadKm: preflight && preflight.maxSpreadKm,
-          totalAreaHa: preflight && preflight.totalAreaHa,
-          largestAreaHa: preflight && preflight.largestAreaHa,
-          workspaceRole: workspaceRole,
-          workspacePreference: workspacePreference
-        });
-      }
+      upsertHistoryRun({
+        instanceId: data.instance_id,
+        submittedAt: queuedAt,
+        createdTime: queuedAt,
+        lastUpdatedTime: queuedAt,
+        runtimeStatus: 'Pending',
+        customStatus: { phase: 'queued' },
+        providerName: 'planetary_computer',
+        featureCount: preflight && preflight.featureCount,
+        aoiCount: preflight && preflight.aoiCount,
+        processingMode: preflight && preflight.processingMode,
+        maxSpreadKm: preflight && preflight.maxSpreadKm,
+        totalAreaHa: preflight && preflight.totalAreaHa,
+        largestAreaHa: preflight && preflight.largestAreaHa,
+        workspaceRole: workspaceRole,
+        workspacePreference: workspacePreference
+      });
       if (_d.selectAnalysisRun) _d.selectAnalysisRun(data.instance_id, { resume: true });
       if (_d.setAnalysisStatus) _d.setAnalysisStatus('Analysis queued. The app will walk through each stage as the pipeline advances.', 'info');
       if (_d.loadBillingStatus) _d.loadBillingStatus();

--- a/website/js/app-runs.js
+++ b/website/js/app-runs.js
@@ -121,6 +121,39 @@
     };
   }
 
+  function readRunSelectionFromLocation() {
+    try {
+      var params = new URLSearchParams(window.location.search || '');
+      return { instanceId: params.get('run') || '' };
+    } catch (_) {
+      return { instanceId: '' };
+    }
+  }
+
+  function selectedRunPermalink(instanceId, appBase) {
+    try {
+      var url = new URL(window.location.href);
+      if (instanceId) {
+        url.searchParams.set('run', instanceId);
+      } else {
+        url.searchParams.delete('run');
+      }
+      url.searchParams.delete('focus');
+      var nextPath = url.pathname;
+      var nextSearch = url.searchParams.toString();
+      return nextSearch ? nextPath + '?' + nextSearch : nextPath;
+    } catch (_) {
+      return appBase || '/app/';
+    }
+  }
+
+  function updateRunSelectionLocation(instanceId, appBase) {
+    if (!window.history || typeof window.history.replaceState !== 'function') return;
+    try {
+      window.history.replaceState({}, '', selectedRunPermalink(instanceId, appBase));
+    } catch (_) { /* ignore */ }
+  }
+
   window.CanopexAppRuns = {
     normalizeRun: normalizeRun,
     sortRuns: sortRuns,
@@ -128,5 +161,8 @@
     mapPhase: mapPhase,
     upsertRun: upsertRun,
     applyHistoryPayload: applyHistoryPayload,
+    readRunSelectionFromLocation: readRunSelectionFromLocation,
+    selectedRunPermalink: selectedRunPermalink,
+    updateRunSelectionLocation: updateRunSelectionLocation,
   };
 })();

--- a/website/js/app-runs.js
+++ b/website/js/app-runs.js
@@ -7,6 +7,12 @@
 (function () {
   'use strict';
 
+  var _d = {};
+
+  function init(deps) {
+    _d = deps || {};
+  }
+
   function normalizeRun(run) {
     if (!run) return null;
     var normalized = Object.assign({}, run);
@@ -154,7 +160,51 @@
     } catch (_) { /* ignore */ }
   }
 
+  async function loadHistory(options) {
+    var opts = options || {};
+    var apiReady = _d.getApiReady ? _d.getApiReady() : Promise.resolve();
+    await apiReady;
+
+    var currentAccount = _d.getAccount ? _d.getAccount() : null;
+    var authEnabled = _d.authEnabled ? _d.authEnabled() : true;
+    if (!currentAccount && authEnabled) return;
+
+    var activeProfile = _d.getActiveProfile ? _d.getActiveProfile() : {};
+    var historyScope = activeProfile.historyScope || 'user';
+    var historyCacheKey = historyScope === 'org' ? 'history-org' : 'history';
+    var cached = _d.readCache ? _d.readCache(historyCacheKey) : null;
+    var historyLoaded = _d.getAnalysisHistoryLoaded ? _d.getAnalysisHistoryLoaded() : false;
+
+    if (cached && !historyLoaded) {
+      if (_d.setAnalysisHistoryLoaded) _d.setAnalysisHistoryLoaded(true);
+      if (_d.applyAnalysisHistory) _d.applyAnalysisHistory(cached, opts);
+      if (_d.applyFirstRunLayout) _d.applyFirstRunLayout();
+    }
+
+    try {
+      var apiFetch = _d.apiFetch || function () { return Promise.reject(new Error('apiFetch unavailable')); };
+      var res = await apiFetch('/api/analysis/history?limit=6&scope=' + encodeURIComponent(historyScope));
+      var data = await res.json();
+      if (_d.writeCache) _d.writeCache(historyCacheKey, data, _d.historyCacheTtlMs);
+      if (_d.setAnalysisHistoryLoaded) _d.setAnalysisHistoryLoaded(true);
+      if (_d.applyAnalysisHistory) _d.applyAnalysisHistory(data, opts);
+      if (_d.applyFirstRunLayout) _d.applyFirstRunLayout();
+    } catch (_) {
+      if (_d.setAnalysisHistoryLoaded) _d.setAnalysisHistoryLoaded(true);
+      var analysisHistoryRuns = _d.getAnalysisHistoryRuns ? _d.getAnalysisHistoryRuns() : [];
+      var latestAnalysisRun = _d.getLatestAnalysisRun ? _d.getLatestAnalysisRun() : null;
+      if (!cached && !analysisHistoryRuns.length && !latestAnalysisRun) {
+        if (_d.setAnalysisHistoryRuns) _d.setAnalysisHistoryRuns([]);
+        if (_d.setSelectedAnalysisRunId) _d.setSelectedAnalysisRunId(null);
+        if (_d.renderAnalysisHistoryList) _d.renderAnalysisHistoryList();
+        if (_d.updateHistorySummary) _d.updateHistorySummary(null);
+      }
+      if (_d.applyFirstRunLayout) _d.applyFirstRunLayout();
+    }
+  }
+
   window.CanopexAppRuns = {
+    init: init,
     normalizeRun: normalizeRun,
     sortRuns: sortRuns,
     isRunActive: isRunActive,
@@ -164,5 +214,6 @@
     readRunSelectionFromLocation: readRunSelectionFromLocation,
     selectedRunPermalink: selectedRunPermalink,
     updateRunSelectionLocation: updateRunSelectionLocation,
+    loadHistory: loadHistory,
   };
 })();

--- a/website/js/app-runs.js
+++ b/website/js/app-runs.js
@@ -1,0 +1,132 @@
+/**
+ * app-runs.js - Shared run lifecycle helpers.
+ *
+ * This module holds data-shaping and lifecycle primitives that are reused
+ * across app surfaces while keeping UI rendering in app-shell for now.
+ */
+(function () {
+  'use strict';
+
+  function normalizeRun(run) {
+    if (!run) return null;
+    var normalized = Object.assign({}, run);
+    normalized.instanceId = normalized.instanceId || normalized.instance_id || '';
+    normalized.submissionId = normalized.submissionId || normalized.submission_id || normalized.instanceId;
+    normalized.submittedAt = normalized.submittedAt || normalized.submitted_at || normalized.createdTime || '';
+    normalized.submissionPrefix = normalized.submissionPrefix || normalized.submission_prefix || 'analysis';
+    normalized.providerName = normalized.providerName || normalized.provider_name || 'planetary_computer';
+    normalized.featureCount = normalized.featureCount != null ? normalized.featureCount : normalized.feature_count;
+    normalized.aoiCount = normalized.aoiCount != null ? normalized.aoiCount : normalized.aoi_count;
+    normalized.processingMode = normalized.processingMode || normalized.processing_mode;
+    normalized.maxSpreadKm = normalized.maxSpreadKm != null ? normalized.maxSpreadKm : normalized.max_spread_km;
+    normalized.totalAreaHa = normalized.totalAreaHa != null ? normalized.totalAreaHa : normalized.total_area_ha;
+    normalized.largestAreaHa = normalized.largestAreaHa != null ? normalized.largestAreaHa : normalized.largest_area_ha;
+    normalized.workspaceRole = normalized.workspaceRole || normalized.workspace_role;
+    normalized.workspacePreference = normalized.workspacePreference || normalized.workspace_preference;
+
+    if (normalized.output) {
+      if (normalized.featureCount == null && normalized.output.featureCount != null) normalized.featureCount = normalized.output.featureCount;
+      if (normalized.aoiCount == null && normalized.output.aoiCount != null) normalized.aoiCount = normalized.output.aoiCount;
+      if (normalized.artifactCount == null && normalized.output.artifacts) normalized.artifactCount = Object.keys(normalized.output.artifacts).length;
+      if (!normalized.partialFailures) {
+        normalized.partialFailures = {
+          imagery: normalized.output.imageryFailed || 0,
+          downloads: normalized.output.downloadsFailed || 0,
+          postProcess: normalized.output.postProcessFailed || 0,
+        };
+      }
+    }
+
+    return normalized.instanceId ? normalized : null;
+  }
+
+  function historyRunSortValue(run, parseTimestamp) {
+    var parser = typeof parseTimestamp === 'function' ? parseTimestamp : function () { return null; };
+    return parser((run && (run.submittedAt || run.createdTime || run.lastUpdatedTime)) || '') || 0;
+  }
+
+  function sortRuns(runs, parseTimestamp) {
+    return (runs || [])
+      .map(normalizeRun)
+      .filter(Boolean)
+      .sort(function (a, b) {
+        return historyRunSortValue(b, parseTimestamp) - historyRunSortValue(a, parseTimestamp);
+      });
+  }
+
+  function isRunActive(run) {
+    var runtimeStatus = String((run && run.runtimeStatus) || '').trim().toLowerCase();
+    return ['completed', 'failed', 'terminated', 'canceled'].indexOf(runtimeStatus) === -1;
+  }
+
+  function mapPhase(customStatus, runtimeStatus, validPhases) {
+    if (runtimeStatus === 'Completed') return 'complete';
+    if (customStatus && customStatus.phase && Array.isArray(validPhases) && validPhases.indexOf(customStatus.phase) > -1) {
+      return customStatus.phase;
+    }
+    return 'submit';
+  }
+
+  function upsertRun(existingRuns, run, parseTimestamp) {
+    var normalized = normalizeRun(run);
+    if (!normalized) return sortRuns(existingRuns || [], parseTimestamp);
+
+    var replaced = false;
+    var nextRuns = (existingRuns || []).map(function (existing) {
+      var existingId = existing.instanceId || existing.instance_id;
+      if (existingId !== normalized.instanceId) return existing;
+      replaced = true;
+      return Object.assign({}, existing, normalized);
+    });
+    if (!replaced) nextRuns.unshift(normalized);
+    return sortRuns(nextRuns, parseTimestamp);
+  }
+
+  function applyHistoryPayload(payload, options, currentSelectionId, latestRun, locationInstanceId, parseTimestamp) {
+    var opts = options || {};
+    var normalizedActiveRun = normalizeRun(payload && payload.activeRun);
+    var nextRuns = sortRuns(payload && payload.runs, parseTimestamp);
+
+    if (normalizedActiveRun && !nextRuns.some(function (run) { return run.instanceId === normalizedActiveRun.instanceId; })) {
+      nextRuns.unshift(normalizedActiveRun);
+      nextRuns = sortRuns(nextRuns, parseTimestamp);
+    }
+
+    if (opts.preferInstanceId && latestRun &&
+        (latestRun.instanceId || latestRun.instance_id) === opts.preferInstanceId &&
+        !nextRuns.some(function (run) { return run.instanceId === opts.preferInstanceId; })) {
+      var preserved = normalizeRun(latestRun);
+      if (preserved) {
+        nextRuns.unshift(preserved);
+        nextRuns = sortRuns(nextRuns, parseTimestamp);
+      }
+    }
+
+    var nextSelectedId = opts.preferInstanceId || currentSelectionId || locationInstanceId || '';
+    if (nextSelectedId && !nextRuns.some(function (run) { return run.instanceId === nextSelectedId; })) {
+      nextSelectedId = '';
+    }
+    if (!nextSelectedId && normalizedActiveRun) nextSelectedId = normalizedActiveRun.instanceId;
+    if (!nextSelectedId && nextRuns[0]) nextSelectedId = nextRuns[0].instanceId;
+
+    return {
+      runs: nextRuns,
+      selectedId: nextSelectedId || null,
+      portfolioSummary: {
+        scope: payload && payload.scope,
+        orgId: payload && payload.orgId,
+        memberCount: payload && payload.memberCount,
+        stats: payload && payload.stats
+      }
+    };
+  }
+
+  window.CanopexAppRuns = {
+    normalizeRun: normalizeRun,
+    sortRuns: sortRuns,
+    isRunActive: isRunActive,
+    mapPhase: mapPhase,
+    upsertRun: upsertRun,
+    applyHistoryPayload: applyHistoryPayload,
+  };
+})();

--- a/website/js/app-runtime.js
+++ b/website/js/app-runtime.js
@@ -1,0 +1,119 @@
+(function () {
+  'use strict';
+
+  let deps = {};
+  const state = {
+    account: null,
+    latestPortfolioSummary: null,
+    analysisHistoryRuns: [],
+    analysisHistoryLoaded: false,
+    selectedAnalysisRunId: null,
+    analysisDraftSummary: null,
+  };
+
+  function init(nextDeps) {
+    deps = nextDeps || {};
+  }
+
+  function getAccount() {
+    return state.account;
+  }
+
+  function setAccount(account) {
+    state.account = account || null;
+    return state.account;
+  }
+
+  function getLatestPortfolioSummary() {
+    return state.latestPortfolioSummary;
+  }
+
+  function setLatestPortfolioSummary(summary) {
+    state.latestPortfolioSummary = summary || null;
+    return state.latestPortfolioSummary;
+  }
+
+  function getAnalysisHistoryRuns() {
+    return state.analysisHistoryRuns;
+  }
+
+  function setAnalysisHistoryRuns(runs) {
+    state.analysisHistoryRuns = Array.isArray(runs) ? runs : [];
+    return state.analysisHistoryRuns;
+  }
+
+  function getAnalysisHistoryLoaded() {
+    return state.analysisHistoryLoaded;
+  }
+
+  function setAnalysisHistoryLoaded(value) {
+    state.analysisHistoryLoaded = !!value;
+    return state.analysisHistoryLoaded;
+  }
+
+  function getSelectedAnalysisRunId() {
+    return state.selectedAnalysisRunId;
+  }
+
+  function setSelectedAnalysisRunId(instanceId) {
+    state.selectedAnalysisRunId = instanceId || null;
+    return state.selectedAnalysisRunId;
+  }
+
+  function getAnalysisDraftSummary() {
+    return state.analysisDraftSummary;
+  }
+
+  function setAnalysisDraftSummary(summary) {
+    state.analysisDraftSummary = summary || null;
+    return state.analysisDraftSummary;
+  }
+
+  function readCache(key) {
+    if (!deps.readScopedCache) return null;
+    return deps.readScopedCache(deps.cachePrefix, state.account && state.account.userId, key);
+  }
+
+  function writeCache(key, data, ttlMs) {
+    if (!deps.writeScopedCache) return false;
+    return deps.writeScopedCache(deps.cachePrefix, state.account && state.account.userId, key, data, ttlMs);
+  }
+
+  function clearCacheKey(key) {
+    if (!deps.clearScopedCacheKey) return false;
+    return deps.clearScopedCacheKey(deps.cachePrefix, state.account && state.account.userId, key);
+  }
+
+  function clearAllCache() {
+    if (!deps.clearAllScopedCache) return false;
+    return deps.clearAllScopedCache(deps.cachePrefix);
+  }
+
+  function clearAnalysisState() {
+    state.analysisHistoryRuns = [];
+    state.analysisHistoryLoaded = false;
+    state.selectedAnalysisRunId = null;
+    state.latestPortfolioSummary = null;
+  }
+
+  window.CanopexRuntime = {
+    init: init,
+    getAccount: getAccount,
+    setAccount: setAccount,
+    getLatestPortfolioSummary: getLatestPortfolioSummary,
+    setLatestPortfolioSummary: setLatestPortfolioSummary,
+    getAnalysisHistoryRuns: getAnalysisHistoryRuns,
+    setAnalysisHistoryRuns: setAnalysisHistoryRuns,
+    getAnalysisHistoryLoaded: getAnalysisHistoryLoaded,
+    setAnalysisHistoryLoaded: setAnalysisHistoryLoaded,
+    getSelectedAnalysisRunId: getSelectedAnalysisRunId,
+    setSelectedAnalysisRunId: setSelectedAnalysisRunId,
+    getAnalysisDraftSummary: getAnalysisDraftSummary,
+    setAnalysisDraftSummary: setAnalysisDraftSummary,
+    readCache: readCache,
+    writeCache: writeCache,
+    clearCacheKey: clearCacheKey,
+    clearAllCache: clearAllCache,
+    clearAnalysisState: clearAnalysisState,
+  };
+})();

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -58,150 +58,12 @@
   var runLifecycleModule = window.CanopexRunLifecycle || {};
   var historyUiModule = window.CanopexHistoryUi || {};
   var summaryUiModule = window.CanopexSummaryUi || {};
+  var workspaceModule = window.CanopexWorkspace || {};
   var _apiClient = window.CanopexApiClient ? window.CanopexApiClient.createClient() : null;
 
   const POST_LOGIN_DESTINATION_KEY = 'canopex-post-login';
   const WORKSPACE_ROLE_STORAGE_KEY = 'canopex-workspace-role';
   const WORKSPACE_PREFERENCE_STORAGE_KEY = 'canopex-workspace-preference';
-  const WORKSPACE_ROLES = {
-    conservation: {
-      label: 'Conservation',
-      tag: 'Field evidence',
-      title: 'Conservation monitoring',
-      summary: 'Built for protected-area coordinators who need rapid, plain-English evidence they can take to rangers, directors, or donors.',
-      outcome: 'Evidence packs',
-      risk: 'No silent fallback',
-      rhythm: 'Monthly watchlist',
-      historyCopy: 'Keep the most recent incident visible while you compare new reports against what already ran.',
-      runCopy: 'Queue an analysis for a protected area or reported clearing.',
-      contentCopy: 'Use this rail to understand what evidence is being assembled and what will be ready for a field or donor brief.',
-      runLensTitle: 'Conservation analysis',
-      runLensNote: 'Frame this run around vegetation change, weather context, and plain-English proof.',
-      readyNote: 'Ready to run a conservation analysis.',
-      emptyHistoryNote: 'Your next submission will appear here.',
-      activeHistoryContext: 'field evidence',
-      completedHistoryOutcome: 'shareable evidence brief',
-      activePath: 'Tracking evidence build',
-      completedPath: 'Review results',
-      runLabel: 'Start analysis',
-      reviewLabel: 'Review latest incident',
-      deliverableLabel: 'Open evidence rail',
-      emptyContent: {
-        imageryTitle: 'Waiting for a run',
-        imageryNote: 'Before/after imagery and NDVI layers will appear here as the evidence stack forms.',
-        enrichmentTitle: 'Context pending',
-        enrichmentNote: 'Weather and narrative context will follow once the imagery pipeline is stable.',
-        exportsTitle: 'Evidence pack next',
-        exportsNote: 'Saved maps, narrative, and donor-ready exports will land here once run detail is wired.'
-      },
-      completedContent: {
-        exportsTitle: 'Evidence pack next',
-        exportsNote: 'Maps, narrative, and a field-ready evidence pack will be available after results load.'
-      }
-    },
-    eudr: {
-      label: 'EUDR',
-      tag: 'Audit trail',
-      title: 'EUDR due diligence',
-      summary: 'Support compliance teams that need post-2020 evidence, clear audit language, and no ambiguity about what the product actually processed.',
-      outcome: 'Due diligence dossier',
-      risk: 'Audit-ready trust',
-      rhythm: 'Quarterly refresh cadence',
-      historyCopy: 'Keep the most recent assessment visible while you decide whether another supplier plot needs review.',
-      runCopy: 'Queue a due diligence run with explicit product-path status.',
-      contentCopy: 'Use this rail to understand what audit evidence is forming before it becomes a saved due diligence dossier.',
-      runLensTitle: 'EUDR compliance check',
-      runLensNote: 'Keep baseline integrity, plain-English findings, and product-path reliability front and center.',
-      readyNote: 'Ready to run a due diligence check.',
-      emptyHistoryNote: 'Your next submission will appear here.',
-      activeHistoryContext: 'audit context',
-      completedHistoryOutcome: 'due diligence dossier',
-      activePath: 'Tracking audit evidence',
-      completedPath: 'Prepare audit dossier',
-      runLabel: 'Start due diligence run',
-      reviewLabel: 'Review latest assessment',
-      deliverableLabel: 'Open dossier rail',
-      emptyContent: {
-        imageryTitle: 'Awaiting baseline review',
-        imageryNote: 'Before/after imagery will anchor the post-2020 evidence trail once you queue a run.',
-        enrichmentTitle: 'Assessment pending',
-        enrichmentNote: 'Narrative findings and methodology framing follow after imagery is stable.',
-        exportsTitle: 'Audit dossier next',
-        exportsNote: 'Saved evidence packages with coordinates, methods, and narrative will land here once run detail is wired.'
-      },
-      completedContent: {
-        exportsTitle: 'Audit dossier next',
-        exportsNote: 'Coordinates, methods, and exportable due diligence evidence will be available after results load.'
-      }
-    },
-    portfolio: {
-      label: 'Portfolio Ops',
-      tag: 'Batch triage',
-      title: 'Portfolio operations',
-      summary: 'Support advisors, insurers, and ops teams who need to scan many parcels quickly, keep batch context visible, and decide what needs follow-up.',
-      outcome: 'Batch triage',
-      risk: 'Scale without guesswork',
-      rhythm: 'Event-driven review',
-      historyCopy: 'Keep the most recent batch visible so you can triage new uploads against what already moved.',
-      runCopy: 'Queue a batch-style analysis and keep scale warnings visible.',
-      contentCopy: 'Use this rail to understand what the current run is building before you reopen it as a parcel-level review.',
-      runLensTitle: 'Portfolio triage run',
-      runLensNote: 'Bias the workspace toward batch readiness, AOI spread, and which runs need deeper follow-up.',
-      readyNote: 'Ready to run a batch analysis.',
-      emptyHistoryNote: 'Your next submission will appear here.',
-      activeHistoryContext: 'batch context',
-      completedHistoryOutcome: 'triage summary',
-      activePath: 'Tracking batch progress',
-      completedPath: 'Open triage summary',
-      runLabel: 'Start batch triage run',
-      reviewLabel: 'Review latest batch',
-      deliverableLabel: 'Open triage rail',
-      emptyContent: {
-        imageryTitle: 'Awaiting parcel stack',
-        imageryNote: 'Imagery layers will appear here as batch-ready AOIs begin resolving into usable review outputs.',
-        enrichmentTitle: 'Triage context pending',
-        enrichmentNote: 'Context layers follow once the imagery stack shows where deeper review is needed.',
-        exportsTitle: 'Triage summary next',
-        exportsNote: 'Saved parcel review packs and export actions will land here once run detail is wired.'
-      },
-      completedContent: {
-        exportsTitle: 'Triage summary next',
-        exportsNote: 'Parcel-level review and export actions will be available after results load.'
-      }
-    }
-  };
-  const WORKSPACE_PREFERENCES = {
-    investigate: {
-      label: 'Investigate',
-      tag: 'Run-first',
-      title: 'Investigate suspicious change',
-      summary: 'Stay centered on the live run while you prove what changed, why it changed, and what to do next.',
-      deliverable: 'Operator brief',
-      stance: 'Prove the change before escalation',
-      primaryTarget: 'run',
-      secondaryTarget: 'history'
-    },
-    monitor: {
-      label: 'Monitor',
-      tag: 'Queue-first',
-      title: 'Monitor for movement over time',
-      summary: 'Bias the workspace toward what changed recently so recurring reviews and follow-up runs stay efficient.',
-      deliverable: 'Monitoring cadence',
-      stance: 'Spot movement early and repeat',
-      primaryTarget: 'history',
-      secondaryTarget: 'run'
-    },
-    report: {
-      label: 'Report',
-      tag: 'Deliverable-first',
-      title: 'Package findings for action',
-      summary: 'Focus on outputs, evidence language, and what to deliver next.',
-      deliverable: 'Decision packet',
-      stance: 'Translate signal into action',
-      primaryTarget: 'content',
-      secondaryTarget: 'run'
-    }
-  };
 
   const activeProfile = (typeof appProfiles.resolveActiveProfile === 'function')
     ? appProfiles.resolveActiveProfile()
@@ -257,8 +119,6 @@
   let analysisHistoryLoaded = false;
   let selectedAnalysisRunId = null;
   let analysisDraftSummary = null;
-  let workspaceRole = 'conservation';
-  let workspacePreference = 'investigate';
   let activeAnalysisPoll = null;
   let analysisPollGeneration = 0; // incremented on each pollAnalysisRun call to detect stale callbacks
   const ANALYSIS_PHASES = ['submit', 'ingestion', 'acquisition', 'fulfilment', 'enrichment', 'complete'];
@@ -375,11 +235,11 @@
   }
 
   function currentRoleConfig() {
-    return WORKSPACE_ROLES[workspaceRole] || WORKSPACE_ROLES.conservation;
+    return workspaceModule.currentRoleConfig ? workspaceModule.currentRoleConfig() : {};
   }
 
   function currentPreferenceConfig() {
-    return WORKSPACE_PREFERENCES[workspacePreference] || WORKSPACE_PREFERENCES.investigate;
+    return workspaceModule.currentPreferenceConfig ? workspaceModule.currentPreferenceConfig() : {};
   }
 
   function actionLabelForTarget(target) {
@@ -403,19 +263,11 @@
   }
 
   function setWorkspaceRole(roleKey, options) {
-    if (!WORKSPACE_ROLES[roleKey]) return;
-    workspaceRole = roleKey;
-    if (typeof coreState.set === 'function') coreState.set('workspaceRole', roleKey);
-    if (!options || options.persist !== false) storeUiValue(WORKSPACE_ROLE_STORAGE_KEY, roleKey);
-    renderWorkspaceGuidance();
+    if (workspaceModule.setRole) workspaceModule.setRole(roleKey, options);
   }
 
   function setWorkspacePreference(preferenceKey, options) {
-    if (!WORKSPACE_PREFERENCES[preferenceKey]) return;
-    workspacePreference = preferenceKey;
-    if (typeof coreState.set === 'function') coreState.set('workspacePreference', preferenceKey);
-    if (!options || options.persist !== false) storeUiValue(WORKSPACE_PREFERENCE_STORAGE_KEY, preferenceKey);
-    renderWorkspaceGuidance();
+    if (workspaceModule.setPreference) workspaceModule.setPreference(preferenceKey, options);
   }
 
   function updateHeroSummary(data) {
@@ -689,18 +541,29 @@
   initModule(evidenceDisplayModule, {
     apiFetch: apiFetch,
     getApiReady: function () { return apiDiscoveryReady; },
-    getWorkspaceRole: function () { return workspaceRole; },
+    getWorkspaceRole: function () { return workspaceModule.getRole ? workspaceModule.getRole() : 'conservation'; },
     getLatestBillingStatus: function () { return latestBillingStatus; },
   });
 
   initModule(preflightModule, {
     apiFetch: apiFetch,
     getApiReady: function () { return apiDiscoveryReady; },
-    getWorkspaceRole: function () { return workspaceRole; },
+    getWorkspaceRole: function () { return workspaceModule.getRole ? workspaceModule.getRole() : 'conservation'; },
     getActiveProfile: function () { return activeProfile; },
     getLatestBillingStatus: function () { return latestBillingStatus; },
     getWorkspaceRoleConfig: function () { return currentRoleConfig(); },
     onPreflightUpdate: function (preflight) { analysisDraftSummary = preflight; },
+  });
+
+  initModule(workspaceModule, {
+    readStoredValue: readStoredUiValue,
+    storeValue: storeUiValue,
+    setCoreState: function (key, value) {
+      if (typeof coreState.set === 'function') coreState.set(key, value);
+    },
+    roleStorageKey: WORKSPACE_ROLE_STORAGE_KEY,
+    preferenceStorageKey: WORKSPACE_PREFERENCE_STORAGE_KEY,
+    onChange: renderWorkspaceGuidance,
   });
 
   initModule(appRuns, {
@@ -738,8 +601,8 @@
       getAccount: function () { return currentAccount; },
       login: login,
       getActiveProfile: function () { return activeProfile; },
-      getWorkspaceRole: function () { return workspaceRole; },
-      getWorkspacePreference: function () { return workspacePreference; },
+      getWorkspaceRole: function () { return workspaceModule.getRole ? workspaceModule.getRole() : 'conservation'; },
+      getWorkspacePreference: function () { return workspaceModule.getPreference ? workspaceModule.getPreference() : 'investigate'; },
       getAnalysisDraftSummary: function () { return analysisDraftSummary; },
       setLatestAnalysisRun: function (d) { latestAnalysisRun = d; },
       setAnalysisStatus: setAnalysisStatus,
@@ -802,8 +665,8 @@
       currentRoleConfig: currentRoleConfig,
       currentPreferenceConfig: currentPreferenceConfig,
       setText: setText,
-      getWorkspaceRole: function () { return workspaceRole; },
-      getWorkspacePreference: function () { return workspacePreference; },
+      getWorkspaceRole: function () { return workspaceModule.getRole ? workspaceModule.getRole() : 'conservation'; },
+      getWorkspacePreference: function () { return workspaceModule.getPreference ? workspaceModule.getPreference() : 'investigate'; },
       getLatestAnalysisRun: function () { return latestAnalysisRun; },
       getAnalysisHistoryLoaded: function () { return analysisHistoryLoaded; },
       getAccount: function () { return currentAccount; },
@@ -853,16 +716,8 @@
   }
 
   initAuth();
-  if (EUDR_LOCKED) {
-    workspaceRole = activeProfile.defaultRole || 'eudr';
-    workspacePreference = activeProfile.defaultPreference || 'report';
-  } else {
-    workspaceRole = readStoredUiValue(WORKSPACE_ROLE_STORAGE_KEY) || workspaceRole;
-    workspacePreference = readStoredUiValue(WORKSPACE_PREFERENCE_STORAGE_KEY) || workspacePreference;
-  }
-  if (typeof coreState.set === 'function') {
-    coreState.set('workspaceRole', workspaceRole);
-    coreState.set('workspacePreference', workspacePreference);
+  if (workspaceModule.bootstrap) {
+    workspaceModule.bootstrap(activeProfile, EUDR_LOCKED);
   }
   renderWorkspaceGuidance();
 

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -337,25 +337,15 @@
   }
 
   function setAnalysisStatus(message, tone) {
-    var status = document.getElementById('app-analysis-status');
-    if (!status) return;
-    if (!message) {
-      status.hidden = true;
-      status.textContent = '';
-      status.removeAttribute('data-tone');
-      return;
+    if (typeof coreDom.setAnalysisStatus === 'function') {
+      return coreDom.setAnalysisStatus(message, tone);
     }
-    status.hidden = false;
-    status.textContent = message;
-    status.setAttribute('data-tone', tone || 'info');
   }
 
   function setHeroRunSummary(title, note) {
-    var titleEl = document.getElementById('app-hero-active-run');
-    var noteEl = document.getElementById('app-hero-active-run-note');
-    if (!titleEl || !noteEl) return;
-    titleEl.textContent = title || 'Ready to queue';
-    noteEl.textContent = note || 'Ready to run an analysis.';
+    if (typeof coreDom.setHeroRunSummary === 'function') {
+      return coreDom.setHeroRunSummary(title, note);
+    }
   }
 
   function readRunSelectionFromLocation() {

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -57,6 +57,7 @@
   var bindingsModule = window.CanopexBindings || {};
   var runLifecycleModule = window.CanopexRunLifecycle || {};
   var historyUiModule = window.CanopexHistoryUi || {};
+  var summaryUiModule = window.CanopexSummaryUi || {};
   var _apiClient = window.CanopexApiClient ? window.CanopexApiClient.createClient() : null;
 
   const POST_LOGIN_DESTINATION_KEY = 'canopex-post-login';
@@ -447,83 +448,23 @@
   }
 
   function actionLabelForTarget(target) {
+    if (typeof summaryUiModule.actionLabelForTarget === 'function') {
+      return summaryUiModule.actionLabelForTarget(target);
+    }
     var role = currentRoleConfig();
-    if (target === 'history') return role.reviewLabel;
-    if (target === 'content') return role.deliverableLabel;
-    return role.runLabel;
+    return target === 'history' ? role.reviewLabel : target === 'content' ? role.deliverableLabel : role.runLabel;
   }
 
   function revealWorkflowTarget(target) {
-    var cardId = target === 'history'
-      ? 'app-history-card'
-      : target === 'content'
-        ? 'app-content-card'
-        : 'app-analysis-card';
-    var card = document.getElementById(cardId);
-    if (card) card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    if (typeof summaryUiModule.revealWorkflowTarget === 'function') {
+      return summaryUiModule.revealWorkflowTarget(target);
+    }
   }
 
   function renderWorkspaceGuidance() {
-    var role = currentRoleConfig();
-    var preference = currentPreferenceConfig();
-    var dashboard = document.getElementById('app-dashboard');
-    if (dashboard) {
-      dashboard.setAttribute('data-role', workspaceRole);
-      dashboard.setAttribute('data-preference', workspacePreference);
+    if (typeof summaryUiModule.renderWorkspaceGuidance === 'function') {
+      return summaryUiModule.renderWorkspaceGuidance();
     }
-
-    document.querySelectorAll('[data-role-choice]').forEach(function(button) {
-      button.setAttribute('aria-pressed', button.getAttribute('data-role-choice') === workspaceRole ? 'true' : 'false');
-    });
-    document.querySelectorAll('[data-preference-choice]').forEach(function(button) {
-      button.setAttribute('aria-pressed', button.getAttribute('data-preference-choice') === workspacePreference ? 'true' : 'false');
-    });
-
-    setText('app-role-title', role.title);
-    setText('app-role-tag', role.tag);
-    setText('app-role-summary', role.summary);
-    setText('app-role-outcome', role.outcome);
-    setText('app-role-risk', role.risk);
-    setText('app-role-rhythm', role.rhythm);
-
-    setText('app-preference-title', preference.title);
-    setText('app-preference-tag', preference.tag);
-    setText('app-preference-summary', preference.summary);
-    setText('app-guided-deliverable', preference.deliverable);
-    setText('app-guided-stance', preference.stance);
-
-    var primaryButton = document.getElementById('app-guided-primary-btn');
-    var secondaryButton = document.getElementById('app-guided-secondary-btn');
-    if (primaryButton) {
-      primaryButton.textContent = actionLabelForTarget(preference.primaryTarget);
-      primaryButton.setAttribute('data-target', preference.primaryTarget);
-    }
-    if (secondaryButton) {
-      secondaryButton.textContent = actionLabelForTarget(preference.secondaryTarget);
-      secondaryButton.setAttribute('data-target', preference.secondaryTarget);
-    }
-
-    setText('app-history-copy', role.historyCopy);
-    setText('app-run-copy', role.runCopy);
-    setText('app-content-copy', role.contentCopy);
-    var lensTitle = document.getElementById('app-analysis-lens-title');
-    var lensNote = document.getElementById('app-analysis-lens-note');
-    if (lensTitle) lensTitle.textContent = role.runLensTitle;
-    if (lensNote) lensNote.textContent = role.runLensNote + ' ' + preference.summary;
-
-    if (!latestAnalysisRun) {
-      if (!analysisHistoryLoaded && currentAccount) {
-        setHeroRunSummary('Checking recent runs', 'Loading your recent runs.');
-      } else {
-        setHeroRunSummary('Ready to queue', role.readyNote);
-      }
-    }
-    if (latestBillingStatus) updateHeroSummary(latestBillingStatus);
-    updateHistorySummary(latestAnalysisRun);
-    renderAnalysisHistoryList();
-    updateContentSummary(latestAnalysisRun);
-    var draftTextarea = document.getElementById('app-analysis-kml');
-    updateAnalysisPreflight(draftTextarea ? draftTextarea.value : '');
   }
 
   function setWorkspaceRole(roleKey, options) {
@@ -543,112 +484,21 @@
   }
 
   function updateHeroSummary(data) {
-    var role = currentRoleConfig();
-    var preference = currentPreferenceConfig();
-    var caps = data.capabilities || {};
-    var planEl = document.getElementById('app-hero-plan');
-    var planNoteEl = document.getElementById('app-hero-plan-note');
-    var runsEl = document.getElementById('app-hero-runs');
-    var runsNoteEl = document.getElementById('app-hero-runs-note');
-    var modeEl = document.getElementById('app-hero-mode');
-    var modeNoteEl = document.getElementById('app-hero-mode-note');
-    if (!planEl || !planNoteEl || !runsEl || !runsNoteEl || !modeEl || !modeNoteEl) return;
-
-    if (data.preview_mode) {
-      planEl.textContent = 'Free plan preview';
-      planNoteEl.textContent = 'Sign in to turn this preview into a real workspace.';
-      runsEl.textContent = data.runs_remaining == null ? '—' : String(data.runs_remaining);
-      runsNoteEl.textContent = 'Free-plan limits shown here only activate after sign-in.';
-      modeEl.textContent = capabilityHeadline(caps);
-      modeNoteEl.textContent = role.label + ' • ' + preference.label + ' • Preview mode only until you authenticate.';
-      return;
+    if (typeof summaryUiModule.updateHeroSummary === 'function') {
+      return summaryUiModule.updateHeroSummary(data);
     }
-
-    planEl.textContent = (caps.label || data.tier || 'Free') + (data.tier_source === 'emulated' ? ' (emulated)' : '');
-    planNoteEl.textContent = data.tier_source === 'emulated'
-      ? 'Local override for product testing.'
-      : 'Based on your account.';
-    runsEl.textContent = data.runs_remaining == null ? '—' : String(data.runs_remaining);
-    runsNoteEl.textContent = data.runs_remaining == null
-      ? 'Quota unavailable in this environment.'
-      : 'Remaining analyses before the current limit is reached.';
-    modeEl.textContent = capabilityHeadline(caps);
-    modeNoteEl.textContent = role.label + ' • ' + preference.label + ' • Retention ' + formatRetention(caps.retention_days) + ' • ' + (caps.api_access ? 'API enabled' : 'API not included');
   }
 
   function updateHistorySummary(data) {
-    var role = currentRoleConfig();
-    var statusEl = document.getElementById('app-history-latest-status');
-    var noteEl = document.getElementById('app-history-latest-note');
-    var instanceEl = document.getElementById('app-history-latest-instance');
-    var phaseEl = document.getElementById('app-history-latest-phase');
-    var pathEl = document.getElementById('app-history-latest-path');
-    if (!statusEl || !noteEl || !instanceEl || !phaseEl || !pathEl) return;
-
-    renderPortfolioSummary();
-
-    if (!data) {
-      if (!analysisHistoryLoaded && currentAccount) {
-        statusEl.textContent = 'Loading recent runs';
-        noteEl.textContent = 'Loading your history and checking for active runs.';
-        instanceEl.textContent = '…';
-        phaseEl.textContent = 'loading';
-        pathEl.textContent = role.activePath;
-        return;
-      }
-      statusEl.textContent = 'No runs yet';
-      noteEl.textContent = role.emptyHistoryNote;
-      instanceEl.textContent = '—';
-      phaseEl.textContent = '—';
-      pathEl.textContent = role.completedPath;
-      return;
+    if (typeof summaryUiModule.updateHistorySummary === 'function') {
+      return summaryUiModule.updateHistorySummary(data);
     }
-
-    var instanceId = data.instanceId || data.instance_id || '—';
-    var runtimeStatus = data.runtimeStatus || 'Pending';
-    var phase = displayAnalysisPhase(data.customStatus, runtimeStatus);
-    var timing = summarizeRunTiming(data);
-    var summaryLabel = analysisHistoryRuns.length > 1 && selectedAnalysisRunId
-      ? 'Selected analysis'
-      : 'Latest analysis';
-    statusEl.textContent = runtimeStatus;
-    noteEl.textContent = runtimeStatus === 'Completed'
-      ? summaryLabel + ' completed and is ready to become a ' + role.completedHistoryOutcome + '.'
-      : summaryLabel + ' is active. This rail keeps ' + role.activeHistoryContext + ' visible while you stay centered on the run.';
-    if (runtimeStatus !== 'Completed' && timing.sinceUpdate) {
-      noteEl.textContent += ' Last backend update ' + timing.sinceUpdate + ' ago.';
-    }
-    instanceEl.textContent = instanceId;
-    phaseEl.textContent = phase;
-    pathEl.textContent = runtimeStatus === 'Completed' ? role.completedPath : role.activePath;
   }
 
   function renderPortfolioSummary() {
-    var summaryEl = document.getElementById('app-portfolio-summary');
-    if (!summaryEl) return;
-
-    var scope = latestPortfolioSummary && latestPortfolioSummary.scope;
-    var stats = latestPortfolioSummary && latestPortfolioSummary.stats;
-    if (scope !== 'org' || !stats) {
-      summaryEl.hidden = true;
-      return;
+    if (typeof summaryUiModule.renderPortfolioSummary === 'function') {
+      return summaryUiModule.renderPortfolioSummary();
     }
-
-    summaryEl.hidden = false;
-    setText('app-portfolio-total-runs', String(stats.totalRuns || 0));
-    setText('app-portfolio-active-runs', String(stats.activeRuns || 0));
-    setText('app-portfolio-completed-runs', String(stats.completedRuns || 0));
-    setText('app-portfolio-total-parcels', String(stats.totalParcels || 0));
-
-    var memberCount = latestPortfolioSummary.memberCount || 1;
-    var scopeNote = memberCount > 1
-      ? 'Org portfolio view (' + memberCount + ' members)'
-      : 'Org portfolio view';
-    setText('app-portfolio-scope-note', scopeNote);
-
-    // Show the summary export button when org scope is active (#674)
-    var exportRow = document.getElementById('app-summary-export-row');
-    if (exportRow) exportRow.hidden = false;
   }
 
   /* ---- History UI — delegated to app-history-ui.js ---- */
@@ -1076,6 +926,31 @@
       normalizeAnalysisRun: normalizeAnalysisRun,
       sortAnalysisHistoryRuns: sortAnalysisHistoryRuns,
       parseStatusTimestamp: parseStatusTimestamp,
+    });
+  }
+
+  if (typeof summaryUiModule.init === 'function') {
+    summaryUiModule.init({
+      currentRoleConfig: currentRoleConfig,
+      currentPreferenceConfig: currentPreferenceConfig,
+      setText: setText,
+      getWorkspaceRole: function () { return workspaceRole; },
+      getWorkspacePreference: function () { return workspacePreference; },
+      getLatestAnalysisRun: function () { return latestAnalysisRun; },
+      getAnalysisHistoryLoaded: function () { return analysisHistoryLoaded; },
+      getAccount: function () { return currentAccount; },
+      getLatestBillingStatus: function () { return latestBillingStatus; },
+      getAnalysisHistoryRuns: function () { return analysisHistoryRuns; },
+      getSelectedAnalysisRunId: function () { return selectedAnalysisRunId; },
+      getLatestPortfolioSummary: function () { return latestPortfolioSummary; },
+      setHeroRunSummary: setHeroRunSummary,
+      renderAnalysisHistoryList: renderAnalysisHistoryList,
+      updateContentSummary: updateContentSummary,
+      updateAnalysisPreflight: updateAnalysisPreflight,
+      capabilityHeadline: capabilityHeadline,
+      formatRetention: formatRetention,
+      displayAnalysisPhase: displayAnalysisPhase,
+      summarizeRunTiming: summarizeRunTiming,
     });
   }
 

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -56,6 +56,7 @@
   var authModule = window.CanopexAuth || {};
   var bindingsModule = window.CanopexBindings || {};
   var runLifecycleModule = window.CanopexRunLifecycle || {};
+  var historyUiModule = window.CanopexHistoryUi || {};
   var _apiClient = window.CanopexApiClient ? window.CanopexApiClient.createClient() : null;
 
   const POST_LOGIN_DESTINATION_KEY = 'canopex-post-login';
@@ -650,6 +651,8 @@
     if (exportRow) exportRow.hidden = false;
   }
 
+  /* ---- History UI — delegated to app-history-ui.js ---- */
+
   function normalizeAnalysisRun(run) {
     if (typeof appRuns.normalizeRun === 'function') {
       return appRuns.normalizeRun(run);
@@ -684,10 +687,6 @@
     return normalized.instanceId ? normalized : null;
   }
 
-  function historyRunSortValue(run) {
-    return parseStatusTimestamp((run && (run.submittedAt || run.createdTime || run.lastUpdatedTime)) || '') || 0;
-  }
-
   function sortAnalysisHistoryRuns(runs) {
     if (typeof appRuns.sortRuns === 'function') {
       return appRuns.sortRuns(runs, parseStatusTimestamp);
@@ -696,107 +695,17 @@
       .map(normalizeAnalysisRun)
       .filter(Boolean)
       .sort(function(a, b) {
-        return historyRunSortValue(b) - historyRunSortValue(a);
+        return parseStatusTimestamp((b && (b.submittedAt || b.createdTime || b.lastUpdatedTime)) || '') - parseStatusTimestamp((a && (a.submittedAt || a.createdTime || a.lastUpdatedTime)) || '');
       });
-  }
-
-  function historyRunIsActive(run) {
-    if (typeof appRuns.isRunActive === 'function') {
-      return appRuns.isRunActive(run);
-    }
-    var runtimeStatus = String(run && run.runtimeStatus || '').trim().toLowerCase();
-    return ['completed', 'failed', 'terminated', 'canceled'].indexOf(runtimeStatus) === -1;
   }
 
   function renderAnalysisHistoryList() {
-    var container = document.getElementById('app-history-list');
-    if (!container) return;
-
-    container.replaceChildren();
-    if (!analysisHistoryLoaded && currentAccount) {
-      var loading = document.createElement('div');
-      loading.className = 'app-history-empty';
-      loading.textContent = 'Loading your history…';
-      container.appendChild(loading);
-      return;
-    }
-    if (!analysisHistoryRuns.length) {
-      var empty = document.createElement('div');
-      empty.className = 'app-history-empty';
-      empty.textContent = currentRoleConfig().emptyHistoryNote;
-      container.appendChild(empty);
-      return;
-    }
-
-    analysisHistoryRuns.forEach(function(run) {
-      var instanceId = run.instanceId || run.instance_id;
-      var runtimeStatus = run.runtimeStatus || 'Pending';
-      var phase = displayAnalysisPhase(run.customStatus, runtimeStatus);
-      var button = document.createElement('button');
-      var header = document.createElement('div');
-      var title = document.createElement('strong');
-      var status = document.createElement('span');
-      var meta = document.createElement('div');
-      var submitted = document.createElement('span');
-      var phaseMeta = document.createElement('span');
-      var scopeMeta = document.createElement('span');
-      var note = document.createElement('div');
-
-      button.type = 'button';
-      button.className = 'app-history-item';
-      button.setAttribute('data-selected', instanceId === selectedAnalysisRunId ? 'true' : 'false');
-      button.addEventListener('click', function(event) {
-        event.stopPropagation();
-        selectAnalysisRun(instanceId, { resume: historyRunIsActive(run) });
-      });
-
-      header.className = 'app-history-item-header';
-      title.className = 'app-history-item-title';
-      var titleParts = [];
-      if (run.aoiCount) titleParts.push(formatCountLabel(run.aoiCount, 'AOI'));
-      if (run.totalAreaHa) titleParts.push(Number(run.totalAreaHa).toFixed(1) + ' ha');
-      var titleLabel = titleParts.length ? titleParts.join(' · ') : shortInstanceId(instanceId);
-      title.textContent = (historyRunIsActive(run) ? 'Resume: ' : '') + titleLabel;
-      status.className = 'app-history-item-status';
-      status.textContent = runtimeStatus;
-      header.appendChild(title);
-      header.appendChild(status);
-
-      meta.className = 'app-history-item-meta';
-      submitted.textContent = formatHistoryTimestamp(run.submittedAt || run.createdTime);
-      phaseMeta.textContent = 'Phase ' + phase;
-      scopeMeta.textContent = [formatCountLabel(run.aoiCount, 'AOI'), providerLabel(run.providerName)].filter(Boolean).join(' • ') || 'Tracked run';
-      meta.appendChild(submitted);
-      meta.appendChild(phaseMeta);
-      meta.appendChild(scopeMeta);
-
-      note.className = 'app-history-item-note';
-      if (historyRunIsActive(run)) {
-        note.textContent = 'Resume this run from ' + phase + '.';
-      } else if (runtimeStatus === 'Completed') {
-        note.textContent = 'View completed results and download exports.';
-      } else {
-        note.textContent = 'Review this run state.';
-      }
-
-      button.appendChild(header);
-      button.appendChild(meta);
-      button.appendChild(note);
-      container.appendChild(button);
-    });
+    if (typeof historyUiModule.renderAnalysisHistoryList === 'function') return historyUiModule.renderAnalysisHistoryList();
   }
 
   function upsertAnalysisHistoryRun(run) {
-    if (typeof appRuns.upsertRun === 'function') {
-      analysisHistoryRuns = appRuns.upsertRun(analysisHistoryRuns, run, parseStatusTimestamp);
-      renderAnalysisHistoryList();
-      applyFirstRunLayout();
-      return;
-    }
-
     var normalized = normalizeAnalysisRun(run);
     if (!normalized) return;
-
     var replaced = false;
     analysisHistoryRuns = analysisHistoryRuns.map(function(existing) {
       var existingId = existing.instanceId || existing.instance_id;
@@ -811,123 +720,11 @@
   }
 
   function selectAnalysisRun(instanceId, options) {
-    options = options || {};
-    var run = analysisHistoryRuns.find(function(entry) {
-      return (entry.instanceId || entry.instance_id) === instanceId;
-    });
-    if (!run) return;
-
-    selectedAnalysisRunId = instanceId;
-    renderAnalysisHistoryList();
-    updateRunSelectionLocation(instanceId);
-
-    stopAnalysisPolling();
-    // Stop any running timelapse animation from a previous run.
-    if (typeof evidenceDisplayModule.stopPlay === 'function') evidenceDisplayModule.stopPlay();
-    updateAnalysisRun(run);
-    resetAnalysisProgress();
-    setAnalysisProgressVisible(true);
-
-    var runtimeStatus = run.runtimeStatus || 'Pending';
-    var phase = mapAnalysisPhase(run.customStatus, runtimeStatus);
-    if (runtimeStatus === 'Completed') {
-      setAnalysisStep('complete', 'done');
-      updateAnalysisStory('complete', runtimeStatus, run);
-      loadRunEvidence(instanceId);
-      return;
-    }
-    if (runtimeStatus === 'Failed' || runtimeStatus === 'Canceled' || runtimeStatus === 'Terminated') {
-      setAnalysisStep(phase, 'failed');
-      updateAnalysisStory(phase, runtimeStatus, run);
-      return;
-    }
-
-    setAnalysisStep(phase, 'active');
-    updateAnalysisStory(phase, runtimeStatus || 'Pending', run);
-    if (options.resume !== false) pollAnalysisRun(instanceId);
+    if (typeof historyUiModule.selectAnalysisRun === 'function') return historyUiModule.selectAnalysisRun(instanceId, options);
   }
 
   function applyAnalysisHistory(payload, options) {
-    options = options || {};
-    var locationSelection = readRunSelectionFromLocation();
-
-    if (typeof appRuns.applyHistoryPayload === 'function') {
-      var applied = appRuns.applyHistoryPayload(
-        payload,
-        options,
-        selectedAnalysisRunId,
-        latestAnalysisRun,
-        locationSelection.instanceId,
-        parseStatusTimestamp
-      );
-
-      latestPortfolioSummary = applied.portfolioSummary;
-      analysisHistoryRuns = applied.runs;
-
-      if (!applied.selectedId) {
-        selectedAnalysisRunId = null;
-        updateRunSelectionLocation('');
-        stopAnalysisPolling();
-        resetAnalysisProgress();
-        renderAnalysisHistoryList();
-        updateAnalysisRun(null);
-        updateHistorySummary(null);
-        return;
-      }
-
-      var selectedRun = analysisHistoryRuns.find(function(run) { return run.instanceId === applied.selectedId; });
-      selectAnalysisRun(applied.selectedId, { resume: historyRunIsActive(selectedRun) });
-      return;
-    }
-
-    latestPortfolioSummary = {
-      scope: payload && payload.scope,
-      orgId: payload && payload.orgId,
-      memberCount: payload && payload.memberCount,
-      stats: payload && payload.stats
-    };
-
-    var normalizedActiveRun = normalizeAnalysisRun(payload && payload.activeRun);
-    analysisHistoryRuns = sortAnalysisHistoryRuns(payload && payload.runs);
-    if (normalizedActiveRun && !analysisHistoryRuns.some(function(run) {
-      return run.instanceId === normalizedActiveRun.instanceId;
-    })) {
-      analysisHistoryRuns.unshift(normalizedActiveRun);
-      analysisHistoryRuns = sortAnalysisHistoryRuns(analysisHistoryRuns);
-    }
-
-    // If the history API hasn't propagated a just-completed run yet,
-    // preserve it from latestAnalysisRun so the UI doesn't flash to empty.
-    if (options.preferInstanceId && latestAnalysisRun &&
-        (latestAnalysisRun.instanceId || latestAnalysisRun.instance_id) === options.preferInstanceId &&
-        !analysisHistoryRuns.some(function(run) { return run.instanceId === options.preferInstanceId; })) {
-      var preserved = normalizeAnalysisRun(latestAnalysisRun);
-      if (preserved) {
-        analysisHistoryRuns.unshift(preserved);
-        analysisHistoryRuns = sortAnalysisHistoryRuns(analysisHistoryRuns);
-      }
-    }
-
-    var nextSelectedId = options.preferInstanceId || selectedAnalysisRunId || locationSelection.instanceId;
-    if (nextSelectedId && !analysisHistoryRuns.some(function(run) { return run.instanceId === nextSelectedId; })) {
-      nextSelectedId = null;
-    }
-    if (!nextSelectedId && normalizedActiveRun) nextSelectedId = normalizedActiveRun.instanceId;
-    if (!nextSelectedId && analysisHistoryRuns[0]) nextSelectedId = analysisHistoryRuns[0].instanceId;
-
-    if (!nextSelectedId) {
-      selectedAnalysisRunId = null;
-      updateRunSelectionLocation('');
-      stopAnalysisPolling();
-      resetAnalysisProgress();
-      renderAnalysisHistoryList();
-      updateAnalysisRun(null);
-      updateHistorySummary(null);
-      return;
-    }
-
-    var selectedRun = analysisHistoryRuns.find(function(run) { return run.instanceId === nextSelectedId; });
-    selectAnalysisRun(nextSelectedId, { resume: historyRunIsActive(selectedRun) });
+    if (typeof historyUiModule.applyAnalysisHistory === 'function') return historyUiModule.applyAnalysisHistory(payload, options);
   }
 
   /* ------------------------------------------------------------------ */
@@ -1245,6 +1042,40 @@
       updateAnalysisStory: updateAnalysisStory,
       mapAnalysisPhase: mapAnalysisPhase,
       updateAnalysisPreflight: updateAnalysisPreflight,
+    });
+  }
+
+  if (typeof historyUiModule.init === 'function') {
+    historyUiModule.init({
+      getAnalysisHistoryLoaded: function () { return analysisHistoryLoaded; },
+      getAccount: function () { return currentAccount; },
+      getSelectedAnalysisRunId: function () { return selectedAnalysisRunId; },
+      setSelectedAnalysisRunId: function (id) { selectedAnalysisRunId = id; },
+      getAnalysisHistoryRuns: function () { return analysisHistoryRuns; },
+      setAnalysisHistoryRuns: function (runs) { analysisHistoryRuns = runs; },
+      getLatestAnalysisRun: function () { return latestAnalysisRun; },
+      setLatestPortfolioSummary: function (summary) { latestPortfolioSummary = summary; },
+      currentRoleConfig: currentRoleConfig,
+      displayAnalysisPhase: displayAnalysisPhase,
+      formatCountLabel: formatCountLabel,
+      formatHistoryTimestamp: formatHistoryTimestamp,
+      providerLabel: providerLabel,
+      readRunSelectionFromLocation: readRunSelectionFromLocation,
+      updateRunSelectionLocation: updateRunSelectionLocation,
+      stopAnalysisPolling: stopAnalysisPolling,
+      stopPlay: function () { if (typeof evidenceDisplayModule.stopPlay === 'function') evidenceDisplayModule.stopPlay(); },
+      updateAnalysisRun: updateAnalysisRun,
+      resetAnalysisProgress: resetAnalysisProgress,
+      setAnalysisProgressVisible: setAnalysisProgressVisible,
+      setAnalysisStep: setAnalysisStep,
+      updateAnalysisStory: updateAnalysisStory,
+      mapAnalysisPhase: mapAnalysisPhase,
+      loadRunEvidence: loadRunEvidence,
+      updateHistorySummary: updateHistorySummary,
+      pollAnalysisRun: pollAnalysisRun,
+      normalizeAnalysisRun: normalizeAnalysisRun,
+      sortAnalysisHistoryRuns: sortAnalysisHistoryRuns,
+      parseStatusTimestamp: parseStatusTimestamp,
     });
   }
 

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -184,13 +184,8 @@
     try {
       return await _apiClient.fetch(path, opts);
     } catch (err) {
-      if (err.status === 401 && authEnabled()) {
-        // Session expired — clear local auth state and prompt re-login.
-        currentAccount = null;
-        _apiClient.clearAuth();
-        updateAuthUI();
-        setAnalysisStatus('Your session has expired. Please sign in again.', 'error');
-        stopAnalysisPolling();
+      if (typeof authModule.handleApiError === 'function') {
+        authModule.handleApiError(err);
       }
       throw err;
     }
@@ -349,83 +344,9 @@
     if (typeof evidenceDisplayModule.collapse === 'function') return evidenceDisplayModule.collapse();
   }
 
-  function showEvidenceFrame(idx) {
-    if (typeof evidenceDisplayModule.showFrame === 'function') return evidenceDisplayModule.showFrame(idx);
-  }
-
-  function setEvidenceLayerMode(mode) {
-    if (typeof evidenceDisplayModule.setLayerMode === 'function') return evidenceDisplayModule.setLayerMode(mode);
-  }
-
-  function toggleCompareView() {
-    if (typeof evidenceDisplayModule.toggleCompare === 'function') return evidenceDisplayModule.toggleCompare();
-  }
-
-  function toggleEvidencePlay() {
-    if (typeof evidenceDisplayModule.togglePlay === 'function') return evidenceDisplayModule.togglePlay();
-  }
-
-  function requestAiAnalysis() {
-    if (typeof evidenceDisplayModule.requestAi === 'function') return evidenceDisplayModule.requestAi();
-  }
-
-  function requestEudrAssessment() {
-    if (typeof evidenceDisplayModule.requestEudr === 'function') return evidenceDisplayModule.requestEudr();
-  }
-
   /* ---- Parcel notes (#669) — delegated to app-evidence-panels.js ---- */
 
-  var currentNoteParcelKey = null;
-
-  function parcelKeyForIndex(idx) {
-    if (typeof evidencePanelsModule.parcelKeyForIndex === 'function') return evidencePanelsModule.parcelKeyForIndex(idx);
-    return String(idx);
-  }
-
-  function renderParcelNotes(parcelKey) {
-    if (typeof evidencePanelsModule.renderParcelNotes === 'function') return evidencePanelsModule.renderParcelNotes(parcelKey);
-  }
-
-  function showNoteEditor() {
-    if (typeof evidencePanelsModule.showNoteEditor === 'function') return evidencePanelsModule.showNoteEditor();
-  }
-
-  function hideNoteEditor() {
-    if (typeof evidencePanelsModule.hideNoteEditor === 'function') return evidencePanelsModule.hideNoteEditor();
-  }
-
-  async function saveParcelNote() {
-    if (typeof evidencePanelsModule.saveParcelNote === 'function') return evidencePanelsModule.saveParcelNote();
-  }
-
   /* ---- Human override (#672) — delegated to app-evidence-panels.js ---- */
-
-  var currentOverrideParcelKey = null;
-  var currentOverrideAoiData = null;
-
-  function renderParcelOverride(parcelKey, aoiData) {
-    if (typeof evidencePanelsModule.renderParcelOverride === 'function') return evidencePanelsModule.renderParcelOverride(parcelKey, aoiData);
-  }
-
-  function openOverrideModal(parcelKey, aoiData) {
-    if (typeof evidencePanelsModule.openOverrideModal === 'function') return evidencePanelsModule.openOverrideModal(parcelKey, aoiData);
-  }
-
-  function closeOverrideModal() {
-    if (typeof evidencePanelsModule.closeOverrideModal === 'function') return evidencePanelsModule.closeOverrideModal();
-  }
-
-  function onOverrideReasonInput() {
-    if (typeof evidencePanelsModule.onOverrideReasonInput === 'function') return evidencePanelsModule.onOverrideReasonInput();
-  }
-
-  async function confirmOverride() {
-    if (typeof evidencePanelsModule.confirmOverride === 'function') return evidencePanelsModule.confirmOverride();
-  }
-
-  async function revertOverride() {
-    if (typeof evidencePanelsModule.revertOverride === 'function') return evidencePanelsModule.revertOverride();
-  }
 
   /* ------------------------------------------------------------------ */
   /*  END Evidence surface                                               */
@@ -454,35 +375,6 @@
   }
   async function queueAnalysis() {
     if (typeof runLifecycleModule.queueAnalysis === 'function') return runLifecycleModule.queueAnalysis();
-  }
-  async function manageBilling() {
-    if (typeof billingModule.manage === 'function') return billingModule.manage();
-    // fallback: redirect to interest mailto
-    window.location.href = 'mailto:hello@canopex.io';
-  }
-
-  // updateCapabilityFields and renderTierEmulation are internal to app-billing.js
-
-  function applyBillingStatus(data) {
-    if (typeof billingModule.apply === 'function') return billingModule.apply(data);
-    // fallback: update shell state only
-    latestBillingStatus = data;
-    updateHeroSummary(data);
-  }
-
-  async function saveTierEmulation() {
-    if (typeof billingModule.saveEmulation === 'function') return billingModule.saveEmulation();
-  }
-
-  async function loadBillingStatus() {
-    if (typeof billingModule.load === 'function') return billingModule.load();
-  }
-
-  /* ---- EUDR usage dashboard (#670) ---- */
-
-  async function loadEudrUsage() {
-    if (typeof eudrModule.loadUsage === 'function') return eudrModule.loadUsage();
-    // fallback: silently skip when module not loaded
   }
 
   async function loadAnalysisHistory(options) {
@@ -617,7 +509,7 @@
       setAnalysisHistoryLoaded: function (v) { analysisHistoryLoaded = v; },
       upsertAnalysisHistoryRun: upsertAnalysisHistoryRun,
       selectAnalysisRun: selectAnalysisRun,
-      loadBillingStatus: loadBillingStatus,
+      loadBillingStatus: billingModule.load,
       loadAnalysisHistory: loadAnalysisHistory,
       loadRunEvidence: loadRunEvidence,
       showEvidenceSurface: showEvidenceSurface,
@@ -695,8 +587,8 @@
       apiFetch: apiFetch,
       getAppBase: function () { return APP_BASE; },
       loadAnalysisHistory: loadAnalysisHistory,
-      loadBillingStatus: loadBillingStatus,
-      loadEudrUsage: loadEudrUsage,
+      loadBillingStatus: billingModule.load,
+      loadEudrUsage: eudrModule.loadUsage,
       setHeroRunSummary: setHeroRunSummary,
       updateHistorySummary: updateHistorySummary,
       renderAnalysisHistoryList: renderAnalysisHistoryList,
@@ -706,7 +598,9 @@
       getAnalysisHistoryLoaded: function () { return analysisHistoryLoaded; },
       getLatestAnalysisRun: function () { return latestAnalysisRun; },
       clearAllCache: clearAllCache,
+      clearClientAuth: function () { if (_apiClient) _apiClient.clearAuth(); },
       postLoginDestinationKey: POST_LOGIN_DESTINATION_KEY,
+      setAnalysisStatus: setAnalysisStatus,
       clearAnalysisState: function () {
         analysisHistoryRuns = [];
         analysisHistoryLoaded = false;
@@ -727,8 +621,8 @@
       // auth
       login: login,
       logout: logout,
-      manageBilling: manageBilling,
-      saveTierEmulation: saveTierEmulation,
+      manageBilling: billingModule.manage,
+      saveTierEmulation: billingModule.saveEmulation,
       // workspace guidance
       setWorkspaceRole: setWorkspaceRole,
       setWorkspacePreference: setWorkspacePreference,
@@ -742,26 +636,26 @@
       switchInputTab: switchInputTab,
       convertCSVToKml: convertCSVToKml,
       // evidence surface
-      toggleEvidencePlay: toggleEvidencePlay,
-      showEvidenceFrame: showEvidenceFrame,
-      setEvidenceLayerMode: setEvidenceLayerMode,
-      requestAiAnalysis: requestAiAnalysis,
-      requestEudrAssessment: requestEudrAssessment,
+      toggleEvidencePlay: evidenceDisplayModule.togglePlay,
+      showEvidenceFrame: evidenceDisplayModule.showFrame,
+      setEvidenceLayerMode: evidenceDisplayModule.setLayerMode,
+      requestAiAnalysis: evidenceDisplayModule.requestAi,
+      requestEudrAssessment: evidenceDisplayModule.requestEudr,
       expandEvidenceMap: expandEvidenceMap,
       collapseEvidenceMap: collapseEvidenceMap,
-      toggleCompareView: toggleCompareView,
+      toggleCompareView: evidenceDisplayModule.toggleCompare,
       getOverrideContext: function () {
         return evidenceDisplayModule.getOverrideContext ? evidenceDisplayModule.getOverrideContext() : {};
       },
       // parcel notes / override
-      showNoteEditor: showNoteEditor,
-      hideNoteEditor: hideNoteEditor,
-      saveParcelNote: saveParcelNote,
-      openOverrideModal: openOverrideModal,
-      closeOverrideModal: closeOverrideModal,
-      confirmOverride: confirmOverride,
-      revertOverride: revertOverride,
-      onOverrideReasonInput: onOverrideReasonInput,
+      showNoteEditor: evidencePanelsModule.showNoteEditor,
+      hideNoteEditor: evidencePanelsModule.hideNoteEditor,
+      saveParcelNote: evidencePanelsModule.saveParcelNote,
+      openOverrideModal: evidencePanelsModule.openOverrideModal,
+      closeOverrideModal: evidencePanelsModule.closeOverrideModal,
+      confirmOverride: evidencePanelsModule.confirmOverride,
+      revertOverride: evidencePanelsModule.revertOverride,
+      onOverrideReasonInput: evidencePanelsModule.onOverrideReasonInput,
       // API access for export
       apiFetch: apiFetch,
     });

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -45,6 +45,7 @@
   var coreDom = window.CanopexCoreDom || {};
   var coreState = window.CanopexCoreState || {};
   var appProfiles = window.CanopexAppProfiles || {};
+  var runtimeModule = window.CanopexRuntime || {};
   var appRuns = window.CanopexAppRuns || {};
   var evidenceMapModule = window.CanopexEvidenceMap || {};
   var eudrModule = window.CanopexEudr || {};
@@ -111,16 +112,6 @@
   // Container Apps FA: API calls go cross-origin to the Function App
   // hostname discovered from /api-config.json (injected at deploy time).
   // Auth state managed by CanopexApiClient (canopex-api-client.js).
-  let currentAccount = null;   // populated by /.auth/me
-  let latestBillingStatus = null;
-  let latestAnalysisRun = null;
-  let latestPortfolioSummary = null;
-  let analysisHistoryRuns = [];
-  let analysisHistoryLoaded = false;
-  let selectedAnalysisRunId = null;
-  let analysisDraftSummary = null;
-  let activeAnalysisPoll = null;
-  let analysisPollGeneration = 0; // incremented on each pollAnalysisRun call to detect stale callbacks
   const ANALYSIS_PHASES = ['submit', 'ingestion', 'acquisition', 'fulfilment', 'enrichment', 'complete'];
   const ANALYSIS_PHASE_DETAILS = {
     submit: 'Uploading your KML and reserving a pipeline worker for this run.',
@@ -139,30 +130,6 @@
   const CACHE_PREFIX = 'canopex:';
   const CACHE_TTL_HISTORY = 5 * 60 * 1000;   // 5 min
   const CACHE_TTL_BILLING = 30 * 60 * 1000;  // 30 min
-
-  function readCache(key) {
-    return coreState.readScopedCache
-      ? coreState.readScopedCache(CACHE_PREFIX, currentAccount && currentAccount.userId, key)
-      : null;
-  }
-
-  function writeCache(key, data, ttlMs) {
-    if (coreState.writeScopedCache) {
-      coreState.writeScopedCache(CACHE_PREFIX, currentAccount && currentAccount.userId, key, data, ttlMs);
-    }
-  }
-
-  function clearCacheKey(key) {
-    if (coreState.clearScopedCacheKey) {
-      coreState.clearScopedCacheKey(CACHE_PREFIX, currentAccount && currentAccount.userId, key);
-    }
-  }
-
-  function clearAllCache() {
-    if (coreState.clearAllScopedCache) {
-      coreState.clearAllScopedCache(CACHE_PREFIX);
-    }
-  }
 
   function authEnabled() {
     return typeof authModule.authEnabled === 'function' ? authModule.authEnabled() : true;
@@ -229,60 +196,6 @@
     if (coreState.storeValue) coreState.storeValue(key, value);
   }
 
-  function currentRoleConfig() {
-    return workspaceModule.currentRoleConfig ? workspaceModule.currentRoleConfig() : {};
-  }
-
-  function currentPreferenceConfig() {
-    return workspaceModule.currentPreferenceConfig ? workspaceModule.currentPreferenceConfig() : {};
-  }
-
-  function actionLabelForTarget(target) {
-    if (typeof summaryUiModule.actionLabelForTarget === 'function') {
-      return summaryUiModule.actionLabelForTarget(target);
-    }
-    var role = currentRoleConfig();
-    return target === 'history' ? role.reviewLabel : target === 'content' ? role.deliverableLabel : role.runLabel;
-  }
-
-  function revealWorkflowTarget(target) {
-    if (typeof summaryUiModule.revealWorkflowTarget === 'function') {
-      return summaryUiModule.revealWorkflowTarget(target);
-    }
-  }
-
-  function renderWorkspaceGuidance() {
-    if (typeof summaryUiModule.renderWorkspaceGuidance === 'function') {
-      return summaryUiModule.renderWorkspaceGuidance();
-    }
-  }
-
-  function setWorkspaceRole(roleKey, options) {
-    if (workspaceModule.setRole) workspaceModule.setRole(roleKey, options);
-  }
-
-  function setWorkspacePreference(preferenceKey, options) {
-    if (workspaceModule.setPreference) workspaceModule.setPreference(preferenceKey, options);
-  }
-
-  function updateHeroSummary(data) {
-    if (typeof summaryUiModule.updateHeroSummary === 'function') {
-      return summaryUiModule.updateHeroSummary(data);
-    }
-  }
-
-  function updateHistorySummary(data) {
-    if (typeof summaryUiModule.updateHistorySummary === 'function') {
-      return summaryUiModule.updateHistorySummary(data);
-    }
-  }
-
-  function renderPortfolioSummary() {
-    if (typeof summaryUiModule.renderPortfolioSummary === 'function') {
-      return summaryUiModule.renderPortfolioSummary();
-    }
-  }
-
   /* ---- History UI — delegated to app-history-ui.js ---- */
 
   function normalizeAnalysisRun(run) {
@@ -293,56 +206,13 @@
     return appRuns.sortRuns ? appRuns.sortRuns(runs, parseStatusTimestamp) : [];
   }
 
-  function renderAnalysisHistoryList() {
-    if (typeof historyUiModule.renderAnalysisHistoryList === 'function') return historyUiModule.renderAnalysisHistoryList();
-  }
-
-  function upsertAnalysisHistoryRun(run) {
-    if (!appRuns.upsertRun) return;
-    analysisHistoryRuns = appRuns.upsertRun(analysisHistoryRuns, run, parseStatusTimestamp);
-    renderAnalysisHistoryList();
-    applyFirstRunLayout();
-  }
-
-  function selectAnalysisRun(instanceId, options) {
-    if (typeof historyUiModule.selectAnalysisRun === 'function') return historyUiModule.selectAnalysisRun(instanceId, options);
-  }
-
-  function applyAnalysisHistory(payload, options) {
-    if (typeof historyUiModule.applyAnalysisHistory === 'function') return historyUiModule.applyAnalysisHistory(payload, options);
-  }
-
   /* ------------------------------------------------------------------ */
   /*  First-run layout — toggle onboarding vs standard dashboard        */
   /* ------------------------------------------------------------------ */
 
-  function applyFirstRunLayout() {
-    if (typeof runLifecycleModule.applyFirstRunLayout === 'function') return runLifecycleModule.applyFirstRunLayout();
-  }
-
   /* ------------------------------------------------------------------ */
   /*  Evidence surface — delegated to app-evidence-display.js           */
   /* ------------------------------------------------------------------ */
-
-  function loadRunEvidence(instanceId) {
-    if (typeof evidenceDisplayModule.load === 'function') return evidenceDisplayModule.load(instanceId);
-  }
-
-  function clearEvidencePanels() {
-    if (typeof evidenceDisplayModule.clear === 'function') return evidenceDisplayModule.clear();
-  }
-
-  function showEvidenceSurface(visible) {
-    if (typeof evidenceDisplayModule.showSurface === 'function') return evidenceDisplayModule.showSurface(visible);
-  }
-
-  function expandEvidenceMap() {
-    if (typeof evidenceDisplayModule.expand === 'function') return evidenceDisplayModule.expand();
-  }
-
-  function collapseEvidenceMap() {
-    if (typeof evidenceDisplayModule.collapse === 'function') return evidenceDisplayModule.collapse();
-  }
 
   /* ---- Parcel notes (#669) — delegated to app-evidence-panels.js ---- */
 
@@ -355,41 +225,7 @@
 
   /* ---- Run lifecycle — delegated to app-run-lifecycle.js ---- */
 
-  function updateContentSummary(data) {
-    if (typeof runLifecycleModule.updateContentSummary === 'function') return runLifecycleModule.updateContentSummary(data);
-  }
-  function updateRunDetail(data) {
-    if (typeof runLifecycleModule.updateRunDetail === 'function') return runLifecycleModule.updateRunDetail(data);
-  }
-  async function downloadRunExport(format) {
-    if (typeof runLifecycleModule.downloadRunExport === 'function') return runLifecycleModule.downloadRunExport(format);
-  }
-  function updateAnalysisRun(data) {
-    if (typeof runLifecycleModule.updateAnalysisRun === 'function') return runLifecycleModule.updateAnalysisRun(data);
-  }
-  function stopAnalysisPolling() {
-    if (typeof runLifecycleModule.stopAnalysisPolling === 'function') return runLifecycleModule.stopAnalysisPolling();
-  }
-  async function pollAnalysisRun(instanceId) {
-    if (typeof runLifecycleModule.pollAnalysisRun === 'function') return runLifecycleModule.pollAnalysisRun(instanceId);
-  }
-  async function queueAnalysis() {
-    if (typeof runLifecycleModule.queueAnalysis === 'function') return runLifecycleModule.queueAnalysis();
-  }
-
-  async function loadAnalysisHistory(options) {
-    if (typeof appRuns.loadHistory === 'function') return appRuns.loadHistory(options);
-  }
-
   /* ---- Auth UI + bootstrap — delegated to app-auth.js ---- */
-
-  function updateAuthUI() {
-    if (typeof authModule.updateAuthUI === 'function') return authModule.updateAuthUI();
-  }
-
-  function initAuth() {
-    if (typeof authModule.initAuth === 'function') return authModule.initAuth();
-  }
 
   function initModule(moduleRef, deps) {
     if (moduleRef && typeof moduleRef.init === 'function') {
@@ -399,19 +235,24 @@
 
   apiDiscoveryReady = discoverApiBase();
 
+  initModule(runtimeModule, {
+    cachePrefix: CACHE_PREFIX,
+    readScopedCache: coreState.readScopedCache,
+    writeScopedCache: coreState.writeScopedCache,
+    clearScopedCacheKey: coreState.clearScopedCacheKey,
+    clearAllScopedCache: coreState.clearAllScopedCache,
+  });
+
   // Initialise billing module before auth so loadBillingStatus works on first sign-in.
   initModule(billingModule, {
     apiFetch: apiFetch,
     getApiReady: function () { return apiDiscoveryReady; },
-    getAccount: function () { return currentAccount; },
+    getAccount: runtimeModule.getAccount,
     login: login,
-    readCache: readCache,
-    writeCache: writeCache,
-    clearCacheKey: clearCacheKey,
-    onStatusChange: function (data) {
-      latestBillingStatus = data;
-      updateHeroSummary(data);
-    },
+    readCache: runtimeModule.readCache,
+    writeCache: runtimeModule.writeCache,
+    clearCacheKey: runtimeModule.clearCacheKey,
+    onStatusChange: summaryUiModule.updateHeroSummary,
     onLoadError: function () {
       setHeroRunSummary('Ready to queue', 'Billing is unavailable, but analysis can still be launched locally.');
     }
@@ -420,7 +261,7 @@
   initModule(eudrModule, {
     apiFetch: apiFetch,
     getApiReady: function () { return apiDiscoveryReady; },
-    getAccount: function () { return currentAccount; },
+    getAccount: runtimeModule.getAccount,
   });
 
   initModule(evidencePanelsModule, {
@@ -434,7 +275,7 @@
     apiFetch: apiFetch,
     getApiReady: function () { return apiDiscoveryReady; },
     getWorkspaceRole: function () { return workspaceModule.getRole ? workspaceModule.getRole() : 'conservation'; },
-    getLatestBillingStatus: function () { return latestBillingStatus; },
+    getLatestBillingStatus: billingModule.getStatus,
   });
 
   initModule(preflightModule, {
@@ -442,9 +283,9 @@
     getApiReady: function () { return apiDiscoveryReady; },
     getWorkspaceRole: function () { return workspaceModule.getRole ? workspaceModule.getRole() : 'conservation'; },
     getActiveProfile: function () { return activeProfile; },
-    getLatestBillingStatus: function () { return latestBillingStatus; },
-    getWorkspaceRoleConfig: function () { return currentRoleConfig(); },
-    onPreflightUpdate: function (preflight) { analysisDraftSummary = preflight; },
+    getLatestBillingStatus: billingModule.getStatus,
+    getWorkspaceRoleConfig: workspaceModule.currentRoleConfig,
+    onPreflightUpdate: runtimeModule.setAnalysisDraftSummary,
   });
 
   initModule(workspaceModule, {
@@ -455,28 +296,28 @@
     },
     roleStorageKey: WORKSPACE_ROLE_STORAGE_KEY,
     preferenceStorageKey: WORKSPACE_PREFERENCE_STORAGE_KEY,
-    onChange: renderWorkspaceGuidance,
+    onChange: summaryUiModule.renderWorkspaceGuidance,
   });
 
   initModule(appRuns, {
     apiFetch: apiFetch,
     getApiReady: function () { return apiDiscoveryReady; },
-    getAccount: function () { return currentAccount; },
+    getAccount: runtimeModule.getAccount,
     authEnabled: authEnabled,
     getActiveProfile: function () { return activeProfile; },
-    readCache: readCache,
-    writeCache: writeCache,
+    readCache: runtimeModule.readCache,
+    writeCache: runtimeModule.writeCache,
     historyCacheTtlMs: CACHE_TTL_HISTORY,
-    getAnalysisHistoryLoaded: function () { return analysisHistoryLoaded; },
-    setAnalysisHistoryLoaded: function (value) { analysisHistoryLoaded = value; },
-    getAnalysisHistoryRuns: function () { return analysisHistoryRuns; },
-    setAnalysisHistoryRuns: function (runs) { analysisHistoryRuns = runs; },
-    getLatestAnalysisRun: function () { return latestAnalysisRun; },
-    setSelectedAnalysisRunId: function (id) { selectedAnalysisRunId = id; },
-    applyAnalysisHistory: applyAnalysisHistory,
-    applyFirstRunLayout: applyFirstRunLayout,
-    renderAnalysisHistoryList: renderAnalysisHistoryList,
-    updateHistorySummary: updateHistorySummary,
+    getAnalysisHistoryLoaded: runtimeModule.getAnalysisHistoryLoaded,
+    setAnalysisHistoryLoaded: runtimeModule.setAnalysisHistoryLoaded,
+    getAnalysisHistoryRuns: runtimeModule.getAnalysisHistoryRuns,
+    setAnalysisHistoryRuns: runtimeModule.setAnalysisHistoryRuns,
+    getLatestAnalysisRun: runLifecycleModule.getLatestRun,
+    setSelectedAnalysisRunId: runtimeModule.setSelectedAnalysisRunId,
+    applyAnalysisHistory: historyUiModule.applyAnalysisHistory,
+    applyFirstRunLayout: runLifecycleModule.applyFirstRunLayout,
+    renderAnalysisHistoryList: historyUiModule.renderAnalysisHistoryList,
+    updateHistorySummary: summaryUiModule.updateHistorySummary,
   });
 
   initModule(progressModule, {
@@ -490,86 +331,87 @@
   initModule(runLifecycleModule, {
       apiFetch: apiFetch,
       getApiReady: function () { return apiDiscoveryReady; },
-      getAccount: function () { return currentAccount; },
+      getAccount: runtimeModule.getAccount,
       login: login,
       getActiveProfile: function () { return activeProfile; },
       getWorkspaceRole: function () { return workspaceModule.getRole ? workspaceModule.getRole() : 'conservation'; },
       getWorkspacePreference: function () { return workspaceModule.getPreference ? workspaceModule.getPreference() : 'investigate'; },
-      getAnalysisDraftSummary: function () { return analysisDraftSummary; },
-      setLatestAnalysisRun: function (d) { latestAnalysisRun = d; },
+      getAnalysisDraftSummary: runtimeModule.getAnalysisDraftSummary,
       setAnalysisStatus: setAnalysisStatus,
       setHeroRunSummary: setHeroRunSummary,
-      updateHistorySummary: updateHistorySummary,
-      getCurrentRoleConfig: currentRoleConfig,
+      updateHistorySummary: summaryUiModule.updateHistorySummary,
+      getCurrentRoleConfig: workspaceModule.currentRoleConfig,
       selectedRunPermalink: selectedRunPermalink,
       getAppBase: function () { return APP_BASE; },
-      clearCacheKey: clearCacheKey,
-      getAnalysisHistoryLoaded: function () { return analysisHistoryLoaded; },
-      getAnalysisHistoryRuns: function () { return analysisHistoryRuns; },
-      setAnalysisHistoryLoaded: function (v) { analysisHistoryLoaded = v; },
-      upsertAnalysisHistoryRun: upsertAnalysisHistoryRun,
-      selectAnalysisRun: selectAnalysisRun,
+      clearCacheKey: runtimeModule.clearCacheKey,
+      getAnalysisHistoryLoaded: runtimeModule.getAnalysisHistoryLoaded,
+      getAnalysisHistoryRuns: runtimeModule.getAnalysisHistoryRuns,
+      setAnalysisHistoryRuns: runtimeModule.setAnalysisHistoryRuns,
+      setAnalysisHistoryLoaded: runtimeModule.setAnalysisHistoryLoaded,
+      selectAnalysisRun: historyUiModule.selectAnalysisRun,
       loadBillingStatus: billingModule.load,
-      loadAnalysisHistory: loadAnalysisHistory,
-      loadRunEvidence: loadRunEvidence,
-      showEvidenceSurface: showEvidenceSurface,
-      resetAnalysisProgress: resetAnalysisProgress,
-      setAnalysisProgressVisible: setAnalysisProgressVisible,
-      setAnalysisStep: setAnalysisStep,
-      updateAnalysisStory: updateAnalysisStory,
-      mapAnalysisPhase: mapAnalysisPhase,
-      updateAnalysisPreflight: updateAnalysisPreflight,
+      loadAnalysisHistory: appRuns.loadHistory,
+      loadRunEvidence: evidenceDisplayModule.load,
+      showEvidenceSurface: evidenceDisplayModule.showSurface,
+      renderAnalysisHistoryList: historyUiModule.renderAnalysisHistoryList,
+      applyFirstRunLayout: runLifecycleModule.applyFirstRunLayout,
+      resetAnalysisProgress: progressModule.reset,
+      setAnalysisProgressVisible: progressModule.setVisible,
+      setAnalysisStep: progressModule.setStep,
+      updateAnalysisStory: progressModule.updateStory,
+      mapAnalysisPhase: progressModule.mapPhase,
+      updateAnalysisPreflight: preflightModule.updateAnalysisPreflight,
     });
 
   initModule(historyUiModule, {
-      getAnalysisHistoryLoaded: function () { return analysisHistoryLoaded; },
-      getAccount: function () { return currentAccount; },
-      getSelectedAnalysisRunId: function () { return selectedAnalysisRunId; },
-      setSelectedAnalysisRunId: function (id) { selectedAnalysisRunId = id; },
-      getAnalysisHistoryRuns: function () { return analysisHistoryRuns; },
-      setAnalysisHistoryRuns: function (runs) { analysisHistoryRuns = runs; },
-      getLatestAnalysisRun: function () { return latestAnalysisRun; },
-      setLatestPortfolioSummary: function (summary) { latestPortfolioSummary = summary; },
-      currentRoleConfig: currentRoleConfig,
+      getAnalysisHistoryLoaded: runtimeModule.getAnalysisHistoryLoaded,
+      getAccount: runtimeModule.getAccount,
+      getSelectedAnalysisRunId: runtimeModule.getSelectedAnalysisRunId,
+      setSelectedAnalysisRunId: runtimeModule.setSelectedAnalysisRunId,
+      getAnalysisHistoryRuns: runtimeModule.getAnalysisHistoryRuns,
+      setAnalysisHistoryRuns: runtimeModule.setAnalysisHistoryRuns,
+      getLatestAnalysisRun: runLifecycleModule.getLatestRun,
+      setLatestPortfolioSummary: runtimeModule.setLatestPortfolioSummary,
+      currentRoleConfig: workspaceModule.currentRoleConfig,
       displayAnalysisPhase: displayAnalysisPhase,
       formatCountLabel: formatCountLabel,
       formatHistoryTimestamp: formatHistoryTimestamp,
       providerLabel: providerLabel,
       readRunSelectionFromLocation: readRunSelectionFromLocation,
       updateRunSelectionLocation: updateRunSelectionLocation,
-      stopAnalysisPolling: stopAnalysisPolling,
-      stopPlay: function () { if (typeof evidenceDisplayModule.stopPlay === 'function') evidenceDisplayModule.stopPlay(); },
-      updateAnalysisRun: updateAnalysisRun,
-      resetAnalysisProgress: resetAnalysisProgress,
-      setAnalysisProgressVisible: setAnalysisProgressVisible,
-      setAnalysisStep: setAnalysisStep,
-      updateAnalysisStory: updateAnalysisStory,
-      mapAnalysisPhase: mapAnalysisPhase,
-      loadRunEvidence: loadRunEvidence,
-      updateHistorySummary: updateHistorySummary,
-      pollAnalysisRun: pollAnalysisRun,
+      stopAnalysisPolling: runLifecycleModule.stopAnalysisPolling,
+      stopPlay: evidenceDisplayModule.stopPlay,
+      updateAnalysisRun: runLifecycleModule.updateAnalysisRun,
+      resetAnalysisProgress: progressModule.reset,
+      setAnalysisProgressVisible: progressModule.setVisible,
+      setAnalysisStep: progressModule.setStep,
+      updateAnalysisStory: progressModule.updateStory,
+      mapAnalysisPhase: progressModule.mapPhase,
+      loadRunEvidence: evidenceDisplayModule.load,
+      updateHistorySummary: summaryUiModule.updateHistorySummary,
+      pollAnalysisRun: runLifecycleModule.pollAnalysisRun,
       normalizeAnalysisRun: normalizeAnalysisRun,
       sortAnalysisHistoryRuns: sortAnalysisHistoryRuns,
       parseStatusTimestamp: parseStatusTimestamp,
     });
 
   initModule(summaryUiModule, {
-      currentRoleConfig: currentRoleConfig,
-      currentPreferenceConfig: currentPreferenceConfig,
+      currentRoleConfig: workspaceModule.currentRoleConfig,
+      currentPreferenceConfig: workspaceModule.currentPreferenceConfig,
       setText: setText,
       getWorkspaceRole: function () { return workspaceModule.getRole ? workspaceModule.getRole() : 'conservation'; },
       getWorkspacePreference: function () { return workspaceModule.getPreference ? workspaceModule.getPreference() : 'investigate'; },
-      getLatestAnalysisRun: function () { return latestAnalysisRun; },
-      getAnalysisHistoryLoaded: function () { return analysisHistoryLoaded; },
-      getAccount: function () { return currentAccount; },
-      getLatestBillingStatus: function () { return latestBillingStatus; },
-      getAnalysisHistoryRuns: function () { return analysisHistoryRuns; },
-      getSelectedAnalysisRunId: function () { return selectedAnalysisRunId; },
-      getLatestPortfolioSummary: function () { return latestPortfolioSummary; },
+      getLatestAnalysisRun: runLifecycleModule.getLatestRun,
+      getAnalysisHistoryLoaded: runtimeModule.getAnalysisHistoryLoaded,
+      getAccount: runtimeModule.getAccount,
+      getLatestBillingStatus: billingModule.getStatus,
+      getAnalysisHistoryRuns: runtimeModule.getAnalysisHistoryRuns,
+      getSelectedAnalysisRunId: runtimeModule.getSelectedAnalysisRunId,
+      getLatestPortfolioSummary: runtimeModule.getLatestPortfolioSummary,
       setHeroRunSummary: setHeroRunSummary,
-      renderAnalysisHistoryList: renderAnalysisHistoryList,
-      updateContentSummary: updateContentSummary,
-      updateAnalysisPreflight: updateAnalysisPreflight,
+      renderAnalysisHistoryList: historyUiModule.renderAnalysisHistoryList,
+      updateContentSummary: runLifecycleModule.updateContentSummary,
+      updateAnalysisPreflight: preflightModule.updateAnalysisPreflight,
       capabilityHeadline: capabilityHeadline,
       formatRetention: formatRetention,
       displayAnalysisPhase: displayAnalysisPhase,
@@ -580,40 +422,36 @@
     authModule.init({
       authEnabled: authEnabled,
       getApiReady: function () { return apiDiscoveryReady; },
-      getAccount: function () { return currentAccount; },
-      setAccount: function (account) { currentAccount = account; },
+      getAccount: runtimeModule.getAccount,
+      setAccount: runtimeModule.setAccount,
       setClientPrincipal: function (p) { if (_apiClient) _apiClient.setClientPrincipal(p); },
       setSessionToken: function (t) { if (_apiClient) _apiClient.setSessionToken(t); },
       apiFetch: apiFetch,
       getAppBase: function () { return APP_BASE; },
-      loadAnalysisHistory: loadAnalysisHistory,
+      loadAnalysisHistory: appRuns.loadHistory,
       loadBillingStatus: billingModule.load,
       loadEudrUsage: eudrModule.loadUsage,
       setHeroRunSummary: setHeroRunSummary,
-      updateHistorySummary: updateHistorySummary,
-      renderAnalysisHistoryList: renderAnalysisHistoryList,
-      stopAnalysisPolling: stopAnalysisPolling,
-      resetAnalysisProgress: resetAnalysisProgress,
-      updateAnalysisRun: updateAnalysisRun,
-      getAnalysisHistoryLoaded: function () { return analysisHistoryLoaded; },
-      getLatestAnalysisRun: function () { return latestAnalysisRun; },
-      clearAllCache: clearAllCache,
+      updateHistorySummary: summaryUiModule.updateHistorySummary,
+      renderAnalysisHistoryList: historyUiModule.renderAnalysisHistoryList,
+      stopAnalysisPolling: runLifecycleModule.stopAnalysisPolling,
+      resetAnalysisProgress: progressModule.reset,
+      updateAnalysisRun: runLifecycleModule.updateAnalysisRun,
+      getAnalysisHistoryLoaded: runtimeModule.getAnalysisHistoryLoaded,
+      getLatestAnalysisRun: runLifecycleModule.getLatestRun,
+      clearAllCache: runtimeModule.clearAllCache,
       clearClientAuth: function () { if (_apiClient) _apiClient.clearAuth(); },
       postLoginDestinationKey: POST_LOGIN_DESTINATION_KEY,
       setAnalysisStatus: setAnalysisStatus,
-      clearAnalysisState: function () {
-        analysisHistoryRuns = [];
-        analysisHistoryLoaded = false;
-        selectedAnalysisRunId = null;
-      },
+      clearAnalysisState: runtimeModule.clearAnalysisState,
     });
   }
 
-  initAuth();
+  if (typeof authModule.initAuth === 'function') authModule.initAuth();
   if (workspaceModule.bootstrap) {
     workspaceModule.bootstrap(activeProfile, EUDR_LOCKED);
   }
-  renderWorkspaceGuidance();
+  if (typeof summaryUiModule.renderWorkspaceGuidance === 'function') summaryUiModule.renderWorkspaceGuidance();
 
   // All DOM event bindings — delegated to app-bindings.js
   if (typeof bindingsModule.init === 'function') {
@@ -624,25 +462,25 @@
       manageBilling: billingModule.manage,
       saveTierEmulation: billingModule.saveEmulation,
       // workspace guidance
-      setWorkspaceRole: setWorkspaceRole,
-      setWorkspacePreference: setWorkspacePreference,
-      revealWorkflowTarget: revealWorkflowTarget,
-      currentPreferenceConfig: currentPreferenceConfig,
+      setWorkspaceRole: workspaceModule.setRole,
+      setWorkspacePreference: workspaceModule.setPreference,
+      revealWorkflowTarget: summaryUiModule.revealWorkflowTarget,
+      currentPreferenceConfig: workspaceModule.currentPreferenceConfig,
       // analysis
-      queueAnalysis: queueAnalysis,
-      downloadRunExport: downloadRunExport,
-      updateAnalysisPreflight: updateAnalysisPreflight,
-      loadAnalysisFile: loadAnalysisFile,
-      switchInputTab: switchInputTab,
-      convertCSVToKml: convertCSVToKml,
+      queueAnalysis: runLifecycleModule.queueAnalysis,
+      downloadRunExport: runLifecycleModule.downloadRunExport,
+      updateAnalysisPreflight: preflightModule.updateAnalysisPreflight,
+      loadAnalysisFile: preflightModule.loadAnalysisFile,
+      switchInputTab: preflightModule.switchInputTab,
+      convertCSVToKml: preflightModule.convertCSVToKml,
       // evidence surface
       toggleEvidencePlay: evidenceDisplayModule.togglePlay,
       showEvidenceFrame: evidenceDisplayModule.showFrame,
       setEvidenceLayerMode: evidenceDisplayModule.setLayerMode,
       requestAiAnalysis: evidenceDisplayModule.requestAi,
       requestEudrAssessment: evidenceDisplayModule.requestEudr,
-      expandEvidenceMap: expandEvidenceMap,
-      collapseEvidenceMap: collapseEvidenceMap,
+      expandEvidenceMap: evidenceDisplayModule.expand,
+      collapseEvidenceMap: evidenceDisplayModule.collapse,
       toggleCompareView: evidenceDisplayModule.toggleCompare,
       getOverrideContext: function () {
         return evidenceDisplayModule.getOverrideContext ? evidenceDisplayModule.getOverrideContext() : {};

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -329,7 +329,7 @@
   }
 
   async function discoverApiBase() {
-    return apiClient.discoverApiBase();
+    if (_apiClient) return _apiClient.discoverApiBase();
   }
 
   function login() {
@@ -345,12 +345,12 @@
 
   async function apiFetch(path, opts) {
     try {
-      return await apiClient.fetch(path, opts);
+      return await _apiClient.fetch(path, opts);
     } catch (err) {
-      if (err && err.status === 401 && authEnabled()) {
+      if (err.status === 401 && authEnabled()) {
         // Session expired — clear local auth state and prompt re-login.
         currentAccount = null;
-        apiClient.clearAuth();
+        _apiClient.clearAuth();
         updateAuthUI();
         setAnalysisStatus('Your session has expired. Please sign in again.', 'error');
         stopAnalysisPolling();
@@ -3130,7 +3130,7 @@
     }).then(function(payload) {
       var principal = payload && payload.clientPrincipal;
       if (principal && principal.userId) {
-        apiClient.setClientPrincipal(principal);
+        _apiClient.setClientPrincipal(principal); // store raw for X-MS-CLIENT-PRINCIPAL forwarding
         currentAccount = {
           userId: principal.userId,
           name: principal.userDetails || '',
@@ -3142,7 +3142,7 @@
         (apiDiscoveryReady || Promise.resolve()).then(function() {
           return apiFetch('/api/auth/session', { method: 'POST' });
         }).then(function(resp) { return resp.json(); }).then(function(data) {
-          if (data && data.token) apiClient.setSessionToken(data.token);
+          if (data && data.token) _apiClient.setSessionToken(data.token);
         }).catch(function() { /* session token unavailable — backend may not enforce HMAC */ });
       }
       updateAuthUI();

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -634,37 +634,7 @@
   }
 
   async function loadAnalysisHistory(options) {
-    await apiDiscoveryReady;
-    if (!currentAccount && authEnabled()) return;
-
-    var historyScope = activeProfile.historyScope || 'user';
-    var historyCacheKey = historyScope === 'org' ? 'history-org' : 'history';
-
-    // Render cached history instantly while fetching fresh data
-    const cached = readCache(historyCacheKey);
-    if (cached && !analysisHistoryLoaded) {
-      analysisHistoryLoaded = true;
-      applyAnalysisHistory(cached, options || {});
-      applyFirstRunLayout();
-    }
-
-    try {
-      const res = await apiFetch('/api/analysis/history?limit=6&scope=' + encodeURIComponent(historyScope));
-      const data = await res.json();
-      writeCache(historyCacheKey, data, CACHE_TTL_HISTORY);
-      analysisHistoryLoaded = true;
-      applyAnalysisHistory(data, options || {});
-      applyFirstRunLayout();
-    } catch {
-      analysisHistoryLoaded = true;
-      if (!cached && !analysisHistoryRuns.length && !latestAnalysisRun) {
-        analysisHistoryRuns = [];
-        selectedAnalysisRunId = null;
-        renderAnalysisHistoryList();
-        updateHistorySummary(null);
-      }
-      applyFirstRunLayout();
-    }
+    if (typeof appRuns.loadHistory === 'function') return appRuns.loadHistory(options);
   }
 
   /* ---- Auth UI + bootstrap — delegated to app-auth.js ---- */
@@ -731,6 +701,27 @@
     getLatestBillingStatus: function () { return latestBillingStatus; },
     getWorkspaceRoleConfig: function () { return currentRoleConfig(); },
     onPreflightUpdate: function (preflight) { analysisDraftSummary = preflight; },
+  });
+
+  initModule(appRuns, {
+    apiFetch: apiFetch,
+    getApiReady: function () { return apiDiscoveryReady; },
+    getAccount: function () { return currentAccount; },
+    authEnabled: authEnabled,
+    getActiveProfile: function () { return activeProfile; },
+    readCache: readCache,
+    writeCache: writeCache,
+    historyCacheTtlMs: CACHE_TTL_HISTORY,
+    getAnalysisHistoryLoaded: function () { return analysisHistoryLoaded; },
+    setAnalysisHistoryLoaded: function (value) { analysisHistoryLoaded = value; },
+    getAnalysisHistoryRuns: function () { return analysisHistoryRuns; },
+    setAnalysisHistoryRuns: function (runs) { analysisHistoryRuns = runs; },
+    getLatestAnalysisRun: function () { return latestAnalysisRun; },
+    setSelectedAnalysisRunId: function (id) { selectedAnalysisRunId = id; },
+    applyAnalysisHistory: applyAnalysisHistory,
+    applyFirstRunLayout: applyFirstRunLayout,
+    renderAnalysisHistoryList: renderAnalysisHistoryList,
+    updateHistorySummary: updateHistorySummary,
   });
 
   initModule(progressModule, {

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -789,78 +789,71 @@
     if (typeof authModule.initAuth === 'function') return authModule.initAuth();
   }
 
+  function initModule(moduleRef, deps) {
+    if (moduleRef && typeof moduleRef.init === 'function') {
+      moduleRef.init(deps || {});
+    }
+  }
+
   apiDiscoveryReady = discoverApiBase();
 
   // Initialise billing module before auth so loadBillingStatus works on first sign-in.
-  if (typeof billingModule.init === 'function') {
-    billingModule.init({
-      apiFetch: apiFetch,
-      getApiReady: function () { return apiDiscoveryReady; },
-      getAccount: function () { return currentAccount; },
-      login: login,
-      readCache: readCache,
-      writeCache: writeCache,
-      clearCacheKey: clearCacheKey,
-      onStatusChange: function (data) {
-        latestBillingStatus = data;
-        updateHeroSummary(data);
-      },
-      onLoadError: function () {
-        setHeroRunSummary('Ready to queue', 'Billing is unavailable, but analysis can still be launched locally.');
-      }
-    });
-  }
+  initModule(billingModule, {
+    apiFetch: apiFetch,
+    getApiReady: function () { return apiDiscoveryReady; },
+    getAccount: function () { return currentAccount; },
+    login: login,
+    readCache: readCache,
+    writeCache: writeCache,
+    clearCacheKey: clearCacheKey,
+    onStatusChange: function (data) {
+      latestBillingStatus = data;
+      updateHeroSummary(data);
+    },
+    onLoadError: function () {
+      setHeroRunSummary('Ready to queue', 'Billing is unavailable, but analysis can still be launched locally.');
+    }
+  });
 
-  if (typeof eudrModule.init === 'function') {
-    eudrModule.init({
-      apiFetch: apiFetch,
-      getApiReady: function () { return apiDiscoveryReady; },
-      getAccount: function () { return currentAccount; },
-    });
-  }
+  initModule(eudrModule, {
+    apiFetch: apiFetch,
+    getApiReady: function () { return apiDiscoveryReady; },
+    getAccount: function () { return currentAccount; },
+  });
 
-  if (typeof evidencePanelsModule.init === 'function') {
-    evidencePanelsModule.init({
-      apiFetch: apiFetch,
-      getApiReady: function () { return apiDiscoveryReady; },
-      getManifest: function () { return evidenceDisplayModule.getManifest ? evidenceDisplayModule.getManifest() : null; },
-      getInstanceId: function () { return evidenceDisplayModule.getInstanceId ? evidenceDisplayModule.getInstanceId() : null; },
-    });
-  }
+  initModule(evidencePanelsModule, {
+    apiFetch: apiFetch,
+    getApiReady: function () { return apiDiscoveryReady; },
+    getManifest: function () { return evidenceDisplayModule.getManifest ? evidenceDisplayModule.getManifest() : null; },
+    getInstanceId: function () { return evidenceDisplayModule.getInstanceId ? evidenceDisplayModule.getInstanceId() : null; },
+  });
 
-  if (typeof evidenceDisplayModule.init === 'function') {
-    evidenceDisplayModule.init({
-      apiFetch: apiFetch,
-      getApiReady: function () { return apiDiscoveryReady; },
-      getWorkspaceRole: function () { return workspaceRole; },
-      getLatestBillingStatus: function () { return latestBillingStatus; },
-    });
-  }
+  initModule(evidenceDisplayModule, {
+    apiFetch: apiFetch,
+    getApiReady: function () { return apiDiscoveryReady; },
+    getWorkspaceRole: function () { return workspaceRole; },
+    getLatestBillingStatus: function () { return latestBillingStatus; },
+  });
 
-  if (typeof preflightModule.init === 'function') {
-    preflightModule.init({
-      apiFetch: apiFetch,
-      getApiReady: function () { return apiDiscoveryReady; },
-      getWorkspaceRole: function () { return workspaceRole; },
-      getActiveProfile: function () { return activeProfile; },
-      getLatestBillingStatus: function () { return latestBillingStatus; },
-      getWorkspaceRoleConfig: function () { return currentRoleConfig(); },
-      onPreflightUpdate: function (preflight) { analysisDraftSummary = preflight; },
-    });
-  }
+  initModule(preflightModule, {
+    apiFetch: apiFetch,
+    getApiReady: function () { return apiDiscoveryReady; },
+    getWorkspaceRole: function () { return workspaceRole; },
+    getActiveProfile: function () { return activeProfile; },
+    getLatestBillingStatus: function () { return latestBillingStatus; },
+    getWorkspaceRoleConfig: function () { return currentRoleConfig(); },
+    onPreflightUpdate: function (preflight) { analysisDraftSummary = preflight; },
+  });
 
-  if (typeof progressModule.init === 'function') {
-    progressModule.init({
-      setAnalysisStatus: setAnalysisStatus,
-      getActiveProfile: function () { return activeProfile; },
-      getAnalysisPhases: function () { return ANALYSIS_PHASES; },
-      getAnalysisPhaseDetails: function () { return ANALYSIS_PHASE_DETAILS; },
-      summarizeRunTiming: summarizeRunTiming,
-    });
-  }
+  initModule(progressModule, {
+    setAnalysisStatus: setAnalysisStatus,
+    getActiveProfile: function () { return activeProfile; },
+    getAnalysisPhases: function () { return ANALYSIS_PHASES; },
+    getAnalysisPhaseDetails: function () { return ANALYSIS_PHASE_DETAILS; },
+    summarizeRunTiming: summarizeRunTiming,
+  });
 
-  if (typeof runLifecycleModule.init === 'function') {
-    runLifecycleModule.init({
+  initModule(runLifecycleModule, {
       apiFetch: apiFetch,
       getApiReady: function () { return apiDiscoveryReady; },
       getAccount: function () { return currentAccount; },
@@ -893,10 +886,8 @@
       mapAnalysisPhase: mapAnalysisPhase,
       updateAnalysisPreflight: updateAnalysisPreflight,
     });
-  }
 
-  if (typeof historyUiModule.init === 'function') {
-    historyUiModule.init({
+  initModule(historyUiModule, {
       getAnalysisHistoryLoaded: function () { return analysisHistoryLoaded; },
       getAccount: function () { return currentAccount; },
       getSelectedAnalysisRunId: function () { return selectedAnalysisRunId; },
@@ -927,10 +918,8 @@
       sortAnalysisHistoryRuns: sortAnalysisHistoryRuns,
       parseStatusTimestamp: parseStatusTimestamp,
     });
-  }
 
-  if (typeof summaryUiModule.init === 'function') {
-    summaryUiModule.init({
+  initModule(summaryUiModule, {
       currentRoleConfig: currentRoleConfig,
       currentPreferenceConfig: currentPreferenceConfig,
       setText: setText,
@@ -952,7 +941,6 @@
       displayAnalysisPhase: displayAnalysisPhase,
       summarizeRunTiming: summarizeRunTiming,
     });
-  }
 
   if (typeof authModule.init === 'function') {
     authModule.init({

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -304,10 +304,8 @@
     }
   }
 
-  function authEnabled() { return true; /* SWA built-in auth — always available */ }
-
-  function rememberPostLoginDestination() {
-    try { sessionStorage.setItem(POST_LOGIN_DESTINATION_KEY, 'app'); } catch { /* ignore */ }
+  function authEnabled() {
+    return typeof authModule.authEnabled === 'function' ? authModule.authEnabled() : true;
   }
 
   async function discoverApiBase() {
@@ -315,14 +313,11 @@
   }
 
   function login() {
-    rememberPostLoginDestination();
-    window.location.href = '/.auth/login/aad';
+    if (typeof authModule.login === 'function') return authModule.login();
   }
 
   function logout() {
-    clearAllCache();
-    try { sessionStorage.removeItem(POST_LOGIN_DESTINATION_KEY); } catch { /* ignore */ }
-    window.location.href = '/.auth/logout';
+    if (typeof authModule.logout === 'function') return authModule.logout();
   }
 
   async function apiFetch(path, opts) {
@@ -866,6 +861,8 @@
       updateAnalysisRun: updateAnalysisRun,
       getAnalysisHistoryLoaded: function () { return analysisHistoryLoaded; },
       getLatestAnalysisRun: function () { return latestAnalysisRun; },
+      clearAllCache: clearAllCache,
+      postLoginDestinationKey: POST_LOGIN_DESTINATION_KEY,
       clearAnalysisState: function () {
         analysisHistoryRuns = [];
         analysisHistoryLoaded = false;

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -286,6 +286,9 @@
   }
 
   function readCache(key) {
+    if (typeof coreState.readScopedCache === 'function') {
+      return coreState.readScopedCache(CACHE_PREFIX, currentAccount && currentAccount.userId, key);
+    }
     try {
       const full = cacheKey(key);
       if (!full) return null;
@@ -301,6 +304,10 @@
   }
 
   function writeCache(key, data, ttlMs) {
+    if (typeof coreState.writeScopedCache === 'function') {
+      coreState.writeScopedCache(CACHE_PREFIX, currentAccount && currentAccount.userId, key, data, ttlMs);
+      return;
+    }
     if (!Number.isFinite(ttlMs)) return;
     try {
       const full = cacheKey(key);
@@ -313,6 +320,10 @@
   }
 
   function clearCacheKey(key) {
+    if (typeof coreState.clearScopedCacheKey === 'function') {
+      coreState.clearScopedCacheKey(CACHE_PREFIX, currentAccount && currentAccount.userId, key);
+      return;
+    }
     try {
       const full = cacheKey(key);
       if (full) localStorage.removeItem(full);
@@ -320,6 +331,10 @@
   }
 
   function clearAllCache() {
+    if (typeof coreState.clearAllScopedCache === 'function') {
+      coreState.clearAllScopedCache(CACHE_PREFIX);
+      return;
+    }
     try {
       const keys = [];
       for (let i = 0; i < localStorage.length; i++) {

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -52,6 +52,7 @@
   var evidencePanelsModule = window.CanopexEvidencePanels || {};
   var preflightModule = window.CanopexAnalysisPreflight || {};
   var progressModule = window.CanopexAnalysisProgress || {};
+  var evidenceDisplayModule = window.CanopexEvidenceDisplay || {};
   var _apiClient = window.CanopexApiClient ? window.CanopexApiClient.createClient() : null;
 
   const POST_LOGIN_DESTINATION_KEY = 'canopex-post-login';
@@ -819,7 +820,7 @@
 
     stopAnalysisPolling();
     // Stop any running timelapse animation from a previous run.
-    if (evidencePlayInterval) { clearInterval(evidencePlayInterval); evidencePlayInterval = null; }
+    if (typeof evidenceDisplayModule.stopPlay === 'function') evidenceDisplayModule.stopPlay();
     updateAnalysisRun(run);
     resetAnalysisProgress();
     setAnalysisProgressVisible(true);
@@ -951,572 +952,55 @@
   }
 
   /* ------------------------------------------------------------------ */
-  /*  Evidence surface — fetches and renders real data for completed runs */
+  /*  Evidence surface — delegated to app-evidence-display.js           */
   /* ------------------------------------------------------------------ */
 
-  let evidenceMap = null;
-  let evidenceMapLayers = [];
-  let evidenceFrameIndex = 0;
-  let evidenceLayerMode = 'rgb'; // 'rgb' | 'ndvi'
-  let evidencePlayInterval = null;
-  let evidenceManifest = null;
-  let evidenceAnalysis = null;
-  let evidenceInstanceId = null;
-  let evidenceMapExpanded = false;
-  let evidenceAoiPolygons = []; // Leaflet polygon layers for per-AOI click
-  let evidenceSelectedAoi = -1;  // -1 = aggregate, >=0 = per-AOI index
-
-  function expandEvidenceMap() {
-    var mapEl = document.getElementById('app-evidence-map');
-    var backdrop = document.getElementById('app-map-expanded-backdrop');
-    var body = document.getElementById('app-map-expanded-body');
-    if (!mapEl || !backdrop || !body || evidenceMapExpanded) return;
-
-    body.appendChild(mapEl);
-    backdrop.hidden = false;
-    evidenceMapExpanded = true;
-
-    // Sync expanded controls state
-    syncExpandedControls();
-
-    setTimeout(function() { if (evidenceMap) evidenceMap.invalidateSize(); }, 100);
-    document.addEventListener('keydown', expandedEscHandler);
-  }
-
-  function collapseEvidenceMap() {
-    var mapEl = document.getElementById('app-evidence-map');
-    var backdrop = document.getElementById('app-map-expanded-backdrop');
-    var wrap = document.getElementById('app-evidence-map-wrap');
-    if (!mapEl || !backdrop || !wrap || !evidenceMapExpanded) return;
-
-    wrap.insertBefore(mapEl, wrap.firstChild);
-    backdrop.hidden = true;
-    evidenceMapExpanded = false;
-
-    setTimeout(function() { if (evidenceMap) evidenceMap.invalidateSize(); }, 100);
-    document.removeEventListener('keydown', expandedEscHandler);
-  }
-
-  function expandedEscHandler(e) {
-    if (e.key === 'Escape') collapseEvidenceMap();
-  }
-
-  function syncExpandedControls() {
-    var slider = document.getElementById('app-map-expanded-slider');
-    var counter = document.getElementById('app-map-expanded-counter');
-    var label = document.getElementById('app-map-expanded-label');
-    var rgbBtn = document.getElementById('app-map-expanded-btn-rgb');
-    var ndviBtn = document.getElementById('app-map-expanded-btn-ndvi');
-
-    if (slider && evidenceMapLayers.length) {
-      slider.max = evidenceMapLayers.length - 1;
-      slider.value = evidenceFrameIndex;
-    }
-    if (counter) counter.textContent = (evidenceFrameIndex + 1) + '/' + evidenceMapLayers.length;
-    if (label && evidenceMapLayers[evidenceFrameIndex]) {
-      var expandedFrame = evidenceMapLayers[evidenceFrameIndex];
-      label.textContent = expandedFrame.label + ' — ' + expandedFrame.info +
-        (expandedFrame.rgbDisplayWarning ? ' — ' + expandedFrame.rgbDisplayWarning : '');
-    }
-    syncEvidenceLayerButtons(evidenceMapLayers[evidenceFrameIndex]);
-    if (rgbBtn) rgbBtn.classList.toggle('active', evidenceLayerMode === 'rgb');
-    if (ndviBtn) ndviBtn.classList.toggle('active', evidenceLayerMode === 'ndvi');
-  }
-
-  function pickEvidenceDefaultLayer(frame) {
-    if (typeof evidenceMapModule.pickDefaultLayer === 'function') {
-      return evidenceMapModule.pickDefaultLayer(frame);
-    }
-    if (!frame) return 'rgb';
-    if (frame.preferredLayer === 'ndvi' || frame.preferred_layer === 'ndvi') return 'ndvi';
-    return 'rgb';
-  }
-
-  function pickInitialEvidenceFrameIndex(frames) {
-    if (typeof evidenceMapModule.pickInitialFrameIndex === 'function') {
-      return evidenceMapModule.pickInitialFrameIndex(frames);
-    }
-    if (!Array.isArray(frames) || !frames.length) return 0;
-    return 0;
-  }
-
-  function syncEvidenceLayerButtons(frame) {
-    var rgbBtn = document.getElementById('app-map-btn-rgb');
-    var ndviBtn = document.getElementById('app-map-btn-ndvi');
-    var expandedRgbBtn = document.getElementById('app-map-expanded-btn-rgb');
-    var expandedNdviBtn = document.getElementById('app-map-expanded-btn-ndvi');
-    var rgbDisabled = !!(frame && frame.rgbDisplaySuitable === false);
-    var warning = frame && frame.rgbDisplayWarning ? frame.rgbDisplayWarning : '';
-
-    [rgbBtn, expandedRgbBtn].forEach(function(btn) {
-      if (!btn) return;
-      btn.disabled = rgbDisabled;
-      btn.title = rgbDisabled ? warning : '';
-      btn.classList.toggle('is-disabled', rgbDisabled);
-    });
-    [ndviBtn, expandedNdviBtn].forEach(function(btn) {
-      if (!btn) return;
-      btn.disabled = false;
-      btn.title = '';
-      btn.classList.remove('is-disabled');
-    });
-  }
-
-  // #646 — update layer button aria-labels and titles with per-frame
-  // collection and resolution so the picker is self-documenting.
-  function updateLayerButtonLabels(frame) {
-    var btnRgb = document.getElementById('app-map-btn-rgb');
-    var btnNdvi = document.getElementById('app-map-btn-ndvi');
-    var expRgb = document.getElementById('app-map-expanded-btn-rgb');
-    var expNdvi = document.getElementById('app-map-expanded-btn-ndvi');
-    if (!frame) return;
-    var info = frame.collectionLabel
-      ? (frame.collectionLabel + (frame.resLabel || ''))
-      : '';
-    [btnRgb, expRgb].forEach(function(btn) {
-      if (!btn) return;
-      var base = info ? 'True-colour RGB — ' + info : 'True-colour RGB';
-      // Preserve quality warning set by syncEvidenceLayerButtons when disabled.
-      if (!btn.disabled) btn.title = base;
-      btn.setAttribute('aria-label', info ? 'RGB (' + info + ')' : 'RGB');
-    });
-    [btnNdvi, expNdvi].forEach(function(btn) {
-      if (!btn) return;
-      btn.title = info ? 'Vegetation index (NDVI) — ' + info : 'Vegetation index (NDVI)';
-      btn.setAttribute('aria-label', info ? 'NDVI (' + info + ')' : 'NDVI');
-    });
-  }
-
-  // Sync the active/inactive classes on all RGB and NDVI buttons (both inline
-  // panel and expanded modal) to match the current evidenceLayerMode.
-  // Called any time evidenceLayerMode is changed programmatically so the
-  // visual state is always consistent with what is rendered on the map.
-  function syncLayerModeButtons() {
-    var isRgb = evidenceLayerMode === 'rgb';
-    ['app-map-btn-rgb', 'app-map-expanded-btn-rgb'].forEach(function(id) {
-      var btn = document.getElementById(id);
-      if (btn) btn.classList.toggle('active', isRgb);
-    });
-    ['app-map-btn-ndvi', 'app-map-expanded-btn-ndvi'].forEach(function(id) {
-      var btn = document.getElementById(id);
-      if (btn) btn.classList.toggle('active', !isRgb);
-    });
-  }
-
-  function setEvidenceLayerMode(mode) {
-    if (mode !== 'rgb' && mode !== 'ndvi') return;
-    evidenceLayerMode = mode;
-    syncLayerModeButtons();
-    showEvidenceFrame(evidenceFrameIndex);
-  }
-
-  function showEvidenceSurface(visible) {
-    var surface = document.getElementById('app-evidence-surface');
-    var phaseStatus = document.getElementById('app-content-phase-status');
-    if (surface) surface.hidden = !visible;
-    if (phaseStatus) phaseStatus.hidden = visible;
-  }
-
-  async function loadRunEvidence(instanceId) {
-    if (evidenceInstanceId === instanceId && evidenceManifest) return;
-    evidenceInstanceId = instanceId;
-    evidenceManifest = null;
-    evidenceAnalysis = null;
-    showEvidenceSurface(true);
-    clearEvidencePanels();
-
-    var shortId = instanceId.slice(0, 8);
-    var footerEl = document.getElementById('app-content-footer');
-    if (footerEl) footerEl.textContent = 'Loading evidence for run ' + shortId + '…';
-
-    try {
-      await apiDiscoveryReady;
-      var manifestRes = await apiFetch('/api/timelapse-data/' + encodeURIComponent(instanceId));
-      var manifest = await manifestRes.json();
-      // Guard: user may have switched runs while we were fetching.
-      if (evidenceInstanceId !== instanceId) return;
-      evidenceManifest = manifest;
-    } catch (err) {
-      // Retry once after a short delay — the orchestrator may have just
-      // completed and storage propagation can lag a few seconds.
-      if (err && err.status === 404 && !arguments[1]) {
-        await new Promise(function (r) { setTimeout(r, 3000); });
-        if (evidenceInstanceId !== instanceId) return;
-        return loadRunEvidence(instanceId, true);
-      }
-      if (evidenceInstanceId !== instanceId) return;
-      if (footerEl) footerEl.textContent = 'Could not load enrichment data: ' + ((err && err.message) || 'unknown error');
-      return;
-    }
-
-    renderEvidenceNdvi(evidenceManifest);
-    renderEvidenceWeather(evidenceManifest);
-    renderEvidenceChangeDetection(evidenceManifest);
-    renderResourceUsage(evidenceManifest);
-    initEvidenceMap(evidenceManifest);
-    initCompareView(evidenceManifest);  // #671 before/after compare button
-
-    // Show persistent run reference in the evidence header.
-    var runRefEl = document.getElementById('app-evidence-run-ref');
-    if (runRefEl) {
-      runRefEl.textContent = 'Run ' + shortId;
-      runRefEl.title = instanceId;
-      runRefEl.hidden = false;
-    }
-
-    // Per-AOI selector (multi-polygon runs)
-    evidenceSelectedAoi = -1;
-    populateAoiSelector(evidenceManifest.per_aoi_enrichment);
-
-    // Load saved AI analysis (non-blocking)
-    loadSavedAnalysis(instanceId);
-
-    // Show EUDR block for eudr role
-    var eudrBlock = document.getElementById('app-evidence-eudr-block');
-    if (eudrBlock) eudrBlock.hidden = (workspaceRole !== 'eudr');
-
-    // Show AI block if tier supports it
-    var aiBlock = document.getElementById('app-evidence-ai-block');
-    if (aiBlock) {
-      aiBlock.hidden = !(latestBillingStatus && latestBillingStatus.capabilities && latestBillingStatus.capabilities.ai_insights);
-    }
-
-    if (footerEl) {
-      footerEl.textContent = 'Evidence loaded for run ' + instanceId.slice(0, 8) + '.';
-    }
-  }
-
-  let evidenceCompareMode = false; // #671 before/after compare state
-  let evidenceCompareMaps = null;  // { before: L.Map, after: L.Map } | null
-
-  /* ---- Before/after comparison view (#671) ---- */
-
-  function initCompareView(manifest) {
-    var compareWrap = document.getElementById('app-evidence-compare-wrap');
-    var compareBtn = document.getElementById('app-map-btn-compare');
-    if (!compareWrap) return;
-
-    var searchIds = manifest.search_ids || [];
-    var framePlan = manifest.frame_plan || [];
-    if (searchIds.length < 2) {
-      // Not enough frames for a meaningful before/after
-      if (compareBtn) compareBtn.hidden = true;
-      return;
-    }
-
-    if (compareBtn) compareBtn.hidden = false;
-  }
-
-  function openCompareView(manifest) {
-    var mainWrap = document.getElementById('app-evidence-map-wrap');
-    var compareWrap = document.getElementById('app-evidence-compare-wrap');
-    var frameControls = document.getElementById('app-evidence-frame-controls');
-    var frameLabel = document.getElementById('app-map-frame-label');
-    var compareBtn = document.getElementById('app-map-btn-compare');
-    if (!mainWrap || !compareWrap) return;
-
-    // Stop playback
-    if (evidencePlayInterval) { clearInterval(evidencePlayInterval); evidencePlayInterval = null; }
-
-    mainWrap.hidden = true;
-    if (frameControls) frameControls.hidden = true;
-    if (frameLabel) frameLabel.textContent = '';
-    compareWrap.hidden = false;
-    evidenceCompareMode = true;
-    if (compareBtn) compareBtn.classList.add('active');
-
-    buildCompareView(manifest);
-  }
-
-  function closeCompareView() {
-    var mainWrap = document.getElementById('app-evidence-map-wrap');
-    var compareWrap = document.getElementById('app-evidence-compare-wrap');
-    var compareBtn = document.getElementById('app-map-btn-compare');
-    if (!mainWrap || !compareWrap) return;
-
-    destroyCompareMaps();
-    compareWrap.hidden = true;
-    mainWrap.hidden = false;
-    evidenceCompareMode = false;
-    if (compareBtn) compareBtn.classList.remove('active');
-
-    var frameControls = document.getElementById('app-evidence-frame-controls');
-    if (frameControls && evidenceMapLayers.length) frameControls.hidden = false;
-    showEvidenceFrame(evidenceFrameIndex);
-  }
-
-  function destroyCompareMaps() {
-    if (evidenceCompareMaps) {
-      if (evidenceCompareMaps.before) { evidenceCompareMaps.before.remove(); }
-      if (evidenceCompareMaps.after) { evidenceCompareMaps.after.remove(); }
-      evidenceCompareMaps = null;
-    }
-    var before = document.getElementById('app-evidence-compare-map-before');
-    var after = document.getElementById('app-evidence-compare-map-after');
-    if (before) before.textContent = '';
-    if (after) after.textContent = '';
-  }
-
-  function buildCompareView(manifest) {
-    destroyCompareMaps();
-
-    var searchIds = manifest.search_ids || [];
-    var framePlan = manifest.frame_plan || [];
-    var center = manifest.center || manifest.coords;
-    if (!center || !searchIds.length) return;
-
-    var lat = Array.isArray(center) ? center[0] : center.lat || center.latitude;
-    var lon = Array.isArray(center) ? center[1] : center.lon || center.longitude;
-    if (!lat || !lon) return;
-
-    var firstFrame = framePlan[0] || {};
-    var lastFrame = framePlan[framePlan.length - 1] || {};
-    var firstSid = searchIds[0];
-    var lastSid = searchIds[searchIds.length - 1];
-
-    var firstCollection = firstFrame.display_collection || firstFrame.collection || 'sentinel-2-l2a';
-    var lastCollection = lastFrame.display_collection || lastFrame.collection || 'sentinel-2-l2a';
-    var firstAsset = firstFrame.asset || (firstCollection.indexOf('naip') >= 0 ? 'image' : 'visual');
-    var lastAsset = lastFrame.asset || (lastCollection.indexOf('naip') >= 0 ? 'image' : 'visual');
-
-    var labelBefore = document.getElementById('app-evidence-compare-label-before');
-    var labelAfter = document.getElementById('app-evidence-compare-label-after');
-    if (labelBefore) labelBefore.textContent = 'Before — ' + (firstFrame.label || 'earliest');
-    if (labelAfter) labelAfter.textContent = 'After — ' + (lastFrame.label || 'most recent');
-
-    var mapOptions = { zoomControl: false, attributionControl: false };
-    var basemapUrl = 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
-
-    var beforeEl = document.getElementById('app-evidence-compare-map-before');
-    var afterEl = document.getElementById('app-evidence-compare-map-after');
-    if (!beforeEl || !afterEl) return;
-
-    var beforeMap = L.map(beforeEl, mapOptions).setView([lat, lon], 13);
-    L.tileLayer(basemapUrl, { maxZoom: 18 }).addTo(beforeMap);
-    if (firstSid) {
-      L.tileLayer(pcTileUrl(firstSid, firstCollection, firstAsset), { maxZoom: 18 }).addTo(beforeMap);
-    }
-
-    var afterMap = L.map(afterEl, mapOptions).setView([lat, lon], 13);
-    L.tileLayer(basemapUrl, { maxZoom: 18 }).addTo(afterMap);
-    if (lastSid) {
-      L.tileLayer(pcTileUrl(lastSid, lastCollection, lastAsset), { maxZoom: 18 }).addTo(afterMap);
-    }
-
-    // Keep the two maps in sync when panning/zooming
-    function syncMaps(source, target) {
-      source.on('moveend', function() {
-        target.setView(source.getCenter(), source.getZoom(), { animate: false });
-      });
-    }
-    syncMaps(beforeMap, afterMap);
-    syncMaps(afterMap, beforeMap);
-
-    evidenceCompareMaps = { before: beforeMap, after: afterMap };
-
-    // Fit to AOI bounds if available
-    var perAoi = manifest.per_aoi_enrichment || [];
-    try {
-      var allBounds = L.latLngBounds([]);
-      perAoi.forEach(function(aoi) {
-        if (!aoi.coords || !aoi.coords.length) return;
-        aoi.coords.forEach(function(c) { allBounds.extend([c[1], c[0]]); });
-      });
-      if (!allBounds.isValid() && manifest.coords && manifest.coords.length) {
-        manifest.coords.forEach(function(c) { allBounds.extend([c[1], c[0]]); });
-      }
-      if (allBounds.isValid()) {
-        beforeMap.fitBounds(allBounds.pad(0.1));
-        afterMap.fitBounds(allBounds.pad(0.1));
-      }
-    } catch (e) { /* keep default view */ }
-
-    setTimeout(function() {
-      beforeMap.invalidateSize();
-      afterMap.invalidateSize();
-    }, 150);
-  }
-
-  function toggleCompareView() {
-    if (evidenceCompareMode) {
-      closeCompareView();
-    } else if (evidenceManifest) {
-      openCompareView(evidenceManifest);
-    }
+  function loadRunEvidence(instanceId) {
+    if (typeof evidenceDisplayModule.load === 'function') return evidenceDisplayModule.load(instanceId);
   }
 
   function clearEvidencePanels() {
-    var ids = [
-      'app-evidence-ndvi-grid',
-      'app-evidence-weather-grid',
-      'app-evidence-change-list',
-      'app-evidence-ai-content',
-      'app-evidence-eudr-content',
-      'app-evidence-resources-grid'
-    ];
-    ids.forEach(function(id) { var el = document.getElementById(id); if (el) el.textContent = ''; });
-    var noteEl = document.getElementById('app-evidence-ndvi-note');
-    if (noteEl) noteEl.textContent = '';
-    var resourceNote = document.getElementById('app-evidence-resources-note');
-    if (resourceNote) resourceNote.textContent = '';
-    var resourcesBlock = document.getElementById('app-evidence-resources-block');
-    if (resourcesBlock) resourcesBlock.hidden = true;
-    var runRefEl = document.getElementById('app-evidence-run-ref');
-    if (runRefEl) { runRefEl.textContent = ''; runRefEl.title = ''; runRefEl.hidden = true; }
-    var canvases = ['app-evidence-ndvi-canvas', 'app-evidence-weather-canvas'];
-    canvases.forEach(function(id) {
-      var c = document.getElementById(id);
-      if (c) { var ctx = c.getContext('2d'); if (ctx) { ctx.clearRect(0, 0, c.width, c.height); } }
-    });
-    if (evidencePlayInterval) { clearInterval(evidencePlayInterval); evidencePlayInterval = null; }
-    evidenceAoiPolygons = [];
-    evidenceSelectedAoi = -1;
-    clearAoiDetail();
-    var aoiBlock = document.getElementById('app-evidence-aoi-block');
-    if (aoiBlock) aoiBlock.hidden = true;
-    // Reset compare mode so it doesn't persist across runs
-    destroyCompareMaps();
-    evidenceCompareMode = false;
-    var compareWrap = document.getElementById('app-evidence-compare-wrap');
-    var mainWrap = document.getElementById('app-evidence-map-wrap');
-    var compareBtn = document.getElementById('app-map-btn-compare');
-    if (compareWrap) compareWrap.hidden = true;
-    if (mainWrap) mainWrap.hidden = false;
-    if (compareBtn) { compareBtn.hidden = true; compareBtn.classList.remove('active'); }
+    if (typeof evidenceDisplayModule.clear === 'function') return evidenceDisplayModule.clear();
   }
 
-  /* ---- Map viewer ---- */
-  function initEvidenceMap(manifest) {
-    var container = document.getElementById('app-evidence-map');
-    var overlay = document.getElementById('app-evidence-map-overlay');
-    var controls = document.getElementById('app-evidence-frame-controls');
-    if (!container) return;
-
-    // Clean up old map
-    if (evidenceMap) { evidenceMap.remove(); evidenceMap = null; }
-    evidenceMapLayers = [];
-    evidenceFrameIndex = 0;
-    if (evidencePlayInterval) { clearInterval(evidencePlayInterval); evidencePlayInterval = null; }
-
-    var center = manifest.center || manifest.coords;
-    if (!center) {
-      if (overlay) overlay.textContent = 'No location data available.';
-      return;
-    }
-
-    var lat = Array.isArray(center) ? center[0] : center.lat || center.latitude;
-    var lon = Array.isArray(center) ? center[1] : center.lon || center.longitude;
-    if (!lat || !lon) {
-      if (overlay) overlay.textContent = 'Invalid coordinates in manifest.';
-      return;
-    }
-
-    evidenceMap = L.map(container, { zoomControl: true, attributionControl: false }).setView([lat, lon], 13);
-    L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
-      maxZoom: 18
-    }).addTo(evidenceMap);
-
-    // AOI polygon outlines (coords are [lon, lat] GeoJSON; Leaflet needs [lat, lon])
-    evidenceAoiPolygons = [];
-    var perAoi = manifest.per_aoi_enrichment || [];
-    if (perAoi.length > 1) {
-      // Per-AOI mode: draw each AOI polygon as interactive
-      try {
-        var allBounds = L.latLngBounds([]);
-        perAoi.forEach(function(aoi, idx) {
-          if (!aoi.coords || !aoi.coords.length) return;
-          var ll = aoi.coords.map(function(c) { return [c[1], c[0]]; });
-          var poly = L.polygon(ll, {
-            color: 'rgba(88,166,255,.7)',
-            weight: 2,
-            fillOpacity: 0.05
-          }).addTo(evidenceMap);
-          var tip = document.createElement('span');
-          tip.textContent = aoi.name || ('Parcel ' + (idx + 1));
-          poly.bindTooltip(tip, { sticky: true });
-          poly.on('click', function() { selectAoi(idx); });
-          evidenceAoiPolygons.push(poly);
-          allBounds.extend(poly.getBounds());
-        });
-        if (allBounds.isValid()) evidenceMap.fitBounds(allBounds.pad(0.1));
-      } catch (e) { /* skip polygon */ }
-    } else if (manifest.coords && Array.isArray(manifest.coords)) {
-      // Single-AOI fallback: split concatenated ring
-      try {
-        var rings = [];
-        var ringStart = 0;
-        for (var ci = ringStart + 3; ci < manifest.coords.length; ci++) {
-          if (Math.abs(manifest.coords[ci][0] - manifest.coords[ringStart][0]) < 1e-5 &&
-              Math.abs(manifest.coords[ci][1] - manifest.coords[ringStart][1]) < 1e-5) {
-            rings.push(manifest.coords.slice(ringStart, ci + 1));
-            ringStart = ci + 1;
-            ci = ringStart + 2;
-          }
-        }
-        if (ringStart < manifest.coords.length) rings.push(manifest.coords.slice(ringStart));
-        if (!rings.length) rings.push(manifest.coords);
-
-        var allBounds = L.latLngBounds([]);
-        rings.forEach(function(ring) {
-          var ll = ring.map(function(c) { return [c[1], c[0]]; });
-          L.polygon(ll, { color: 'rgba(88,166,255,.7)', weight: 2, fillOpacity: 0.05 }).addTo(evidenceMap);
-          allBounds.extend(L.polygon(ll).getBounds());
-        });
-        evidenceMap.fitBounds(allBounds.pad(0.1));
-      } catch (e) { /* skip polygon */ }
-    }
-
-    if (overlay) overlay.hidden = true;
-
-    // Add PC timelapse frames if search_ids available
-    var searchIds = manifest.search_ids || [];
-    var ndviSearchIds = manifest.ndvi_search_ids || [];
-    var framePlan = manifest.frame_plan || [];
-
-    if (searchIds.length && framePlan.length) {
-      buildEvidenceFrames(framePlan, searchIds, ndviSearchIds);
-      if (controls) controls.hidden = false;
-    } else if (controls) {
-      controls.hidden = true;
-    }
-
-    // Force resize
-    setTimeout(function() { if (evidenceMap) evidenceMap.invalidateSize(); }, 200);
+  function showEvidenceSurface(visible) {
+    if (typeof evidenceDisplayModule.showSurface === 'function') return evidenceDisplayModule.showSurface(visible);
   }
 
-  /* ---- Per-AOI selection ---- */
+  function expandEvidenceMap() {
+    if (typeof evidenceDisplayModule.expand === 'function') return evidenceDisplayModule.expand();
+  }
 
-  function populateAoiSelector(perAoi) {
-    var block = document.getElementById('app-evidence-aoi-block');
-    var list = document.getElementById('app-evidence-aoi-list');
-    var resetBtn = document.getElementById('app-evidence-aoi-reset');
-    if (!block || !list) return;
+  function collapseEvidenceMap() {
+    if (typeof evidenceDisplayModule.collapse === 'function') return evidenceDisplayModule.collapse();
+  }
 
-    if (!perAoi || perAoi.length < 2) {
-      block.hidden = true;
-      return;
-    }
+  function showEvidenceFrame(idx) {
+    if (typeof evidenceDisplayModule.showFrame === 'function') return evidenceDisplayModule.showFrame(idx);
+  }
 
-    block.hidden = false;
-    list.textContent = '';
+  function setEvidenceLayerMode(mode) {
+    if (typeof evidenceDisplayModule.setLayerMode === 'function') return evidenceDisplayModule.setLayerMode(mode);
+  }
 
-    perAoi.forEach(function(aoi, idx) {
-      var chip = document.createElement('button');
-      chip.type = 'button';
-      chip.className = 'app-evidence-aoi-chip';
-      chip.textContent = aoi.name || ('Parcel ' + (idx + 1));
-      chip.addEventListener('click', function() { selectAoi(idx); });
-      list.appendChild(chip);
-    });
+  function toggleCompareView() {
+    if (typeof evidenceDisplayModule.toggleCompare === 'function') return evidenceDisplayModule.toggleCompare();
+  }
 
-    if (resetBtn) {
-      resetBtn.addEventListener('click', function() { resetAoiSelection(); });
-    }
+  function toggleEvidencePlay() {
+    if (typeof evidenceDisplayModule.togglePlay === 'function') return evidenceDisplayModule.togglePlay();
+  }
+
+  function requestAiAnalysis() {
+    if (typeof evidenceDisplayModule.requestAi === 'function') return evidenceDisplayModule.requestAi();
+  }
+
+  function requestEudrAssessment() {
+    if (typeof evidenceDisplayModule.requestEudr === 'function') return evidenceDisplayModule.requestEudr();
   }
 
   /* ---- Parcel notes (#669) — delegated to app-evidence-panels.js ---- */
 
-  // module-level state kept as fallback when module is absent
   var currentNoteParcelKey = null;
 
   function parcelKeyForIndex(idx) {
@@ -1540,9 +1024,8 @@
     if (typeof evidencePanelsModule.saveParcelNote === 'function') return evidencePanelsModule.saveParcelNote();
   }
 
-  /* ---- Human override determination (#672) — delegated to app-evidence-panels.js ---- */
+  /* ---- Human override (#672) — delegated to app-evidence-panels.js ---- */
 
-  // module-level state kept as fallback when module is absent
   var currentOverrideParcelKey = null;
   var currentOverrideAoiData = null;
 
@@ -1570,388 +1053,10 @@
     if (typeof evidencePanelsModule.revertOverride === 'function') return evidencePanelsModule.revertOverride();
   }
 
-  function selectAoi(idx) {
-    if (!evidenceManifest || !evidenceManifest.per_aoi_enrichment) return;
-    var perAoi = evidenceManifest.per_aoi_enrichment;
-    if (idx < 0 || idx >= perAoi.length) return;
-
-    evidenceSelectedAoi = idx;
-    var aoi = perAoi[idx];
-
-    // Highlight selected polygon, dim others
-    evidenceAoiPolygons.forEach(function(poly, i) {
-      if (i === idx) {
-        poly.setStyle({ color: '#5eecc4', weight: 3, fillOpacity: 0.15 });
-      } else {
-        poly.setStyle({ color: 'rgba(88,166,255,.3)', weight: 1, fillOpacity: 0.02 });
-      }
-    });
-
-    // Zoom to selected AOI
-    if (evidenceAoiPolygons[idx] && evidenceMap) {
-      evidenceMap.fitBounds(evidenceAoiPolygons[idx].getBounds().pad(0.15));
-    }
-
-    // Update chip active state
-    var chips = document.querySelectorAll('.app-evidence-aoi-chip');
-    chips.forEach(function(chip, i) {
-      chip.className = 'app-evidence-aoi-chip' + (i === idx ? ' active' : '');
-    });
-
-    // Render per-AOI detail
-    renderAoiDetail(aoi);
-    renderParcelNotes(parcelKeyForIndex(idx));
-    renderParcelOverride(parcelKeyForIndex(idx), aoi);
-  }
-
-  function resetAoiSelection() {
-    evidenceSelectedAoi = -1;
-
-    // Reset polygon styles
-    evidenceAoiPolygons.forEach(function(poly) {
-      poly.setStyle({ color: 'rgba(88,166,255,.7)', weight: 2, fillOpacity: 0.05 });
-    });
-
-    // Zoom to fit all
-    if (evidenceAoiPolygons.length && evidenceMap) {
-      var allBounds = L.latLngBounds([]);
-      evidenceAoiPolygons.forEach(function(poly) { allBounds.extend(poly.getBounds()); });
-      if (allBounds.isValid()) evidenceMap.fitBounds(allBounds.pad(0.1));
-    }
-
-    // Clear chip active state
-    var chips = document.querySelectorAll('.app-evidence-aoi-chip');
-    chips.forEach(function(chip) { chip.className = 'app-evidence-aoi-chip'; });
-
-    // Clear per-AOI detail
-    clearAoiDetail();
-    // Clear parcel notes panel
-    currentNoteParcelKey = null;
-    var notesEl = document.getElementById('app-evidence-notes');
-    var savedEl = document.getElementById('app-evidence-notes-saved');
-    var editEl = document.getElementById('app-evidence-notes-edit');
-    var addBtn = document.getElementById('app-evidence-notes-add-btn');
-    if (savedEl) savedEl.hidden = true;
-    if (editEl) editEl.hidden = true;
-    if (addBtn) { addBtn.hidden = false; addBtn.textContent = '+ Add note'; }
-    var overrideEl = document.getElementById('app-evidence-override');
-    if (overrideEl) overrideEl.hidden = true;
-  }
-
-  function buildEvidenceFrames(framePlan, searchIds, ndviSearchIds) {
-    evidenceMapLayers = [];
-    var slider = document.getElementById('app-map-frame-slider');
-    if (slider) { slider.max = framePlan.length - 1; slider.value = 0; }
-
-    framePlan.forEach(function(frame, idx) {
-      var sid = searchIds[idx];
-      var ndviSid = ndviSearchIds[idx] || sid;
-      var collection = frame.display_collection || frame.collection || 'sentinel-2-l2a';
-      var asset = frame.asset || (collection.indexOf('naip') >= 0 ? 'image' : 'visual');
-
-      var rgbLayer = null;
-      var ndviLayer = null;
-      if (sid) {
-        rgbLayer = L.tileLayer(pcTileUrl(sid, collection, asset), { maxZoom: 18, opacity: 0 });
-        rgbLayer.addTo(evidenceMap);
-      }
-      if (ndviSid && collection.indexOf('sentinel') >= 0) {
-        ndviLayer = L.tileLayer(pcNdviTileUrl(ndviSid), { maxZoom: 18, opacity: 0 });
-        ndviLayer.addTo(evidenceMap);
-      }
-
-      // #646 — store human-readable collection label and resolution suffix so
-      // updateLayerButtonLabels can build informative button titles per frame.
-      var collectionLabel = collection.indexOf('naip') >= 0 ? 'NAIP'
-        : collection.indexOf('sentinel') >= 0 ? 'Sentinel-2'
-        : collection.indexOf('landsat') >= 0 ? 'Landsat'
-        : collection;
-      var resolutionM = (frame.provenance && frame.provenance.resolution_m)
-        || frame.display_resolution_m
-        || null;
-      var resLabel = resolutionM ? (' \u00b7 ' + resolutionM + 'm') : '';
-
-      evidenceMapLayers.push({
-        rgb: rgbLayer,
-        ndvi: ndviLayer,
-        label: frame.label || ('Frame ' + (idx + 1)),
-        info: [collection, frame.start_date, frame.end_date].filter(Boolean).join(' | '),
-        rgbDisplaySuitable: frame.rgb_display_suitable !== false,
-        rgbDisplayWarning: frame.rgb_display_warning || '',
-        preferredLayer: frame.preferred_layer || 'rgb',
-        displayResolutionM: frame.display_resolution_m || null,
-        collectionLabel: collectionLabel,
-        resLabel: resLabel
-      });
-    });
-
-    evidenceFrameIndex = pickInitialEvidenceFrameIndex(evidenceMapLayers);
-    evidenceLayerMode = pickEvidenceDefaultLayer(evidenceMapLayers[evidenceFrameIndex]);
-    syncLayerModeButtons();
-    showEvidenceFrame(evidenceFrameIndex);
-  }
-
-  function showEvidenceFrame(idx) {
-    if (idx < 0 || idx >= evidenceMapLayers.length) return;
-    evidenceFrameIndex = idx;
-    var activeFrame = evidenceMapLayers[idx];
-
-    // #646 — bidirectional mode adaptation:
-    // Fall back to rgb when the user is in ndvi mode but this frame has no ndvi layer.
-    if (evidenceLayerMode === 'ndvi' && !activeFrame.ndvi) {
-      evidenceLayerMode = 'rgb';
-    }
-    // Promote to ndvi for coarse frames where rgb is unsuitable (established in #645).
-    if (activeFrame.rgbDisplaySuitable === false && activeFrame.ndvi) {
-      evidenceLayerMode = 'ndvi';
-    }
-    // Keep button active classes in sync after any programmatic mode change.
-    syncLayerModeButtons();
-
-    evidenceMapLayers.forEach(function(frame, i) {
-      var showRgb = (i === idx && evidenceLayerMode === 'rgb');
-      var showNdvi = (i === idx && evidenceLayerMode === 'ndvi');
-      if (frame.rgb) frame.rgb.setOpacity(showRgb ? 1 : 0);
-      if (frame.ndvi) frame.ndvi.setOpacity(showNdvi ? 1 : 0);
-    });
-
-    var slider = document.getElementById('app-map-frame-slider');
-    var counter = document.getElementById('app-map-frame-counter');
-    var label = document.getElementById('app-map-frame-label');
-    if (slider) slider.value = idx;
-    if (counter) counter.textContent = (idx + 1) + '/' + evidenceMapLayers.length;
-    if (label) {
-      label.textContent = activeFrame.label + ' — ' + activeFrame.info +
-        (activeFrame.rgbDisplayWarning ? ' — ' + activeFrame.rgbDisplayWarning : '');
-    }
-    syncEvidenceLayerButtons(activeFrame);
-    updateLayerButtonLabels(activeFrame);
-
-    // Sync expanded controls if open
-    if (evidenceMapExpanded) syncExpandedControls();
-  }
-
-  function toggleEvidencePlay() {
-    var btn = document.getElementById('app-map-play-btn');
-    var expBtn = document.getElementById('app-map-expanded-play-btn');
-    if (evidencePlayInterval) {
-      clearInterval(evidencePlayInterval);
-      evidencePlayInterval = null;
-      if (btn) btn.textContent = '▶ Play';
-      if (expBtn) expBtn.textContent = '▶ Play';
-      return;
-    }
-    if (btn) btn.textContent = '⏸ Pause';
-    if (expBtn) expBtn.textContent = '⏸ Pause';
-    evidencePlayInterval = setInterval(function() {
-      var next = (evidenceFrameIndex + 1) % evidenceMapLayers.length;
-      showEvidenceFrame(next);
-    }, 1500);
-  }
-
-  /* ---- AI analysis ---- */
-  async function loadSavedAnalysis(instanceId) {
-    var aiBlock = document.getElementById('app-evidence-ai-block');
-    var content = document.getElementById('app-evidence-ai-content');
-    if (!aiBlock || !content) return;
-
-    try {
-      await apiDiscoveryReady;
-      var res = await apiFetch('/api/timelapse-analysis-load/' + encodeURIComponent(instanceId));
-      evidenceAnalysis = await res.json();
-      if (evidenceAnalysis && (evidenceAnalysis.observations || evidenceAnalysis.summary)) {
-        aiBlock.hidden = false;
-        renderEvidenceAnalysis(evidenceAnalysis);
-      }
-    } catch (e) {
-      // 404 = no saved analysis yet (expected). Other errors indicate a real problem.
-      if (e && e.status && e.status !== 404) {
-        console.warn('Failed to load saved analysis:', e.message || e);
-      }
-    }
-  }
-
-  async function requestAiAnalysis() {
-    var loading = document.getElementById('app-evidence-ai-loading');
-    var content = document.getElementById('app-evidence-ai-content');
-    var btn = document.getElementById('app-evidence-ai-btn');
-    if (!loading || !content || !evidenceManifest) return;
-
-    var originalLabel = btn ? btn.textContent : '';
-    if (btn) { btn.disabled = true; btn.textContent = 'Analyzing…'; }
-    loading.hidden = false;
-    content.textContent = '';
-
-    try {
-      await apiDiscoveryReady;
-
-      var ndviTimeseries = (evidenceManifest.ndvi_stats || []).map(function(f, i) {
-        if (!f) return null;
-        var fp = (evidenceManifest.frame_plan || [])[i] || {};
-        return { date: f.datetime || fp.label, mean: f.mean, min: f.min, max: f.max, year: fp.year, season: fp.season };
-      }).filter(Boolean);
-
-      // weather_monthly may be { labels, temp, precip } parallel arrays
-      var wm = evidenceManifest.weather_monthly;
-      var weatherTimeseries = [];
-      if (wm && wm.labels && Array.isArray(wm.labels)) {
-        weatherTimeseries = wm.labels.map(function(lbl, i) {
-          return { month_index: i, label: lbl, temperature: wm.temp ? wm.temp[i] : null, precipitation: wm.precip ? wm.precip[i] : null };
-        });
-      } else if (Array.isArray(wm)) {
-        weatherTimeseries = wm.map(function(m, i) {
-          return { month_index: i, temperature: m.temperature, precipitation: m.precipitation };
-        });
-      }
-
-      var center = evidenceManifest.center || evidenceManifest.coords;
-      var lat = Array.isArray(center) ? center[0] : (center && center.lat) || 0;
-      var lon = Array.isArray(center) ? center[1] : (center && center.lon) || 0;
-
-      var body = {
-        context: {
-          aoi_name: 'Analysis area',
-          latitude: lat,
-          longitude: lon,
-          frame_count: ndviTimeseries.length,
-          date_range_start: ndviTimeseries.length ? ndviTimeseries[0].date : '',
-          date_range_end: ndviTimeseries.length ? ndviTimeseries[ndviTimeseries.length - 1].date : '',
-          ndvi_timeseries: ndviTimeseries,
-          weather_timeseries: weatherTimeseries
-        }
-      };
-
-      var res = await apiFetch('/api/timelapse-analysis', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body)
-      });
-
-      evidenceAnalysis = await res.json();
-      renderEvidenceAnalysis(evidenceAnalysis);
-
-      // Save the analysis (non-blocking but warn user on failure)
-      apiFetch('/api/timelapse-analysis-save', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ instance_id: evidenceInstanceId, analysis: evidenceAnalysis })
-      }).catch(function() {
-        var saveWarn = document.getElementById('app-evidence-ai-content');
-        if (saveWarn) saveWarn.appendChild(createCallout('warning', 'Analysis displayed but could not be saved. It will be lost on reload.'));
-      });
-    } catch (err) {
-      content.textContent = '';
-      content.appendChild(createCallout('error', (err && err.message) || 'Could not run AI analysis.'));
-    } finally {
-      loading.hidden = true;
-      if (btn) { btn.disabled = false; btn.textContent = originalLabel; }
-    }
-  }
-
-  /* ---- EUDR assessment ---- */
-  function activeEvidenceContext() {
-    if (!evidenceManifest) return null;
-    var perAoi = evidenceManifest.per_aoi_enrichment || [];
-    if (evidenceSelectedAoi >= 0 && evidenceSelectedAoi < perAoi.length) {
-      return perAoi[evidenceSelectedAoi];
-    }
-    return evidenceManifest;
-  }
-
-  function buildEvidenceNdviTimeseries(source) {
-    if (typeof evidenceMapModule.buildNdviTimeseries === 'function') {
-      return evidenceMapModule.buildNdviTimeseries(source);
-    }
-    if (!source) return [];
-    return (source.ndvi_stats || []).map(function(f, i) {
-      if (!f) return null;
-      var fp = (source.frame_plan || [])[i] || {};
-      return {
-        date: f.datetime || f.date || fp.start || fp.label,
-        mean: f.mean,
-        min: f.min,
-        max: f.max,
-        year: f.year || fp.year,
-        season: f.season || fp.season
-      };
-    }).filter(Boolean);
-  }
-
-  function evidenceLatLon(source) {
-    if (typeof evidenceMapModule.latLon === 'function') {
-      return evidenceMapModule.latLon(source);
-    }
-    if (!source) return { lat: 0, lon: 0 };
-    var center = source.center || source.coords;
-    if (Array.isArray(center)) {
-      return { lat: center[0] || 0, lon: center[1] || 0 };
-    }
-    return {
-      lat: (center && (center.lat || center.latitude)) || 0,
-      lon: (center && (center.lon || center.longitude)) || 0
-    };
-  }
-
-  async function requestEudrAssessment() {
-    var loading = document.getElementById('app-evidence-eudr-loading');
-    var content = document.getElementById('app-evidence-eudr-content');
-    var btn = document.getElementById('app-evidence-eudr-btn');
-    if (!loading || !content || !evidenceManifest) return;
-
-    if (btn) btn.disabled = true;
-    loading.hidden = false;
-    content.textContent = '';
-
-    try {
-      await apiDiscoveryReady;
-
-      var source = activeEvidenceContext();
-      var ndviTimeseries = buildEvidenceNdviTimeseries(source);
-      var latLon = evidenceLatLon(source);
-
-      var body = {
-        context: {
-          aoi_name: source && source.name ? source.name : 'Analysis area',
-          latitude: latLon.lat,
-          longitude: latLon.lon,
-          ndvi_timeseries: ndviTimeseries,
-          reference_date: '2020-12-31'
-        }
-      };
-
-      var res = await apiFetch('/api/eudr-assessment', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body)
-      });
-
-      var result = await res.json();
-      var cls = (result.compliant || result.deforestation_free) ? 'compliant' : 'non-compliant';
-      var label = cls === 'compliant' ? '\u2713 No deforestation detected since Dec 2020' : '\u26A0 Potential deforestation detected';
-      content.textContent = '';
-      var resultDiv = document.createElement('div');
-      resultDiv.className = 'app-evidence-eudr-result ' + cls;
-      var strong = document.createElement('strong');
-      strong.textContent = label;
-      resultDiv.appendChild(strong);
-      if (result.summary) {
-        var p = document.createElement('p');
-        p.textContent = result.summary;
-        resultDiv.appendChild(p);
-      }
-      content.appendChild(resultDiv);
-    } catch (err) {
-      content.textContent = '';
-      content.appendChild(createCallout('error', (err && err.message) || 'Could not run EUDR assessment.'));
-    } finally {
-      loading.hidden = true;
-      if (btn) btn.disabled = false;
-    }
-  }
-
   /* ------------------------------------------------------------------ */
   /*  END Evidence surface                                               */
   /* ------------------------------------------------------------------ */
+
 
   function updateContentSummary(data) {
     var role = currentRoleConfig();
@@ -2709,8 +1814,17 @@
     evidencePanelsModule.init({
       apiFetch: apiFetch,
       getApiReady: function () { return apiDiscoveryReady; },
-      getManifest: function () { return evidenceManifest; },
-      getInstanceId: function () { return evidenceInstanceId; },
+      getManifest: function () { return evidenceDisplayModule.getManifest ? evidenceDisplayModule.getManifest() : null; },
+      getInstanceId: function () { return evidenceDisplayModule.getInstanceId ? evidenceDisplayModule.getInstanceId() : null; },
+    });
+  }
+
+  if (typeof evidenceDisplayModule.init === 'function') {
+    evidenceDisplayModule.init({
+      apiFetch: apiFetch,
+      getApiReady: function () { return apiDiscoveryReady; },
+      getWorkspaceRole: function () { return workspaceRole; },
+      getLatestBillingStatus: function () { return latestBillingStatus; },
     });
   }
 
@@ -2843,7 +1957,10 @@
     bindClick('app-evidence-notes-save-btn', saveParcelNote);
 
     // Override determination controls (#672)
-    bindClick('app-evidence-override-btn', function() { openOverrideModal(currentOverrideParcelKey, currentOverrideAoiData); });
+    bindClick('app-evidence-override-btn', function() {
+      var ctx = evidenceDisplayModule.getOverrideContext ? evidenceDisplayModule.getOverrideContext() : {};
+      openOverrideModal(ctx.parcelKey, ctx.aoiData);
+    });
     bindClick('app-evidence-override-revert-btn', revertOverride);
     bindClick('app-override-confirm-btn', confirmOverride);
     bindClick('app-override-cancel-btn', closeOverrideModal);

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -53,6 +53,7 @@
   var preflightModule = window.CanopexAnalysisPreflight || {};
   var progressModule = window.CanopexAnalysisProgress || {};
   var evidenceDisplayModule = window.CanopexEvidenceDisplay || {};
+  var authModule = window.CanopexAuth || {};
   var _apiClient = window.CanopexApiClient ? window.CanopexApiClient.createClient() : null;
 
   const POST_LOGIN_DESTINATION_KEY = 'canopex-post-login';
@@ -1648,136 +1649,14 @@
     }
   }
 
+  /* ---- Auth UI + bootstrap — delegated to app-auth.js ---- */
+
   function updateAuthUI() {
-    var loginBtn = document.getElementById('auth-login-btn');
-    var logoutBtn = document.getElementById('auth-logout-btn');
-    var userSpan = document.getElementById('auth-user');
-    var gate = document.getElementById('app-unauthenticated');
-    var dashboard = document.getElementById('app-dashboard');
-    var userName = document.getElementById('app-user-name');
-    var accountIdentifier = document.getElementById('app-account-identifier');
-    var accountNote = document.getElementById('app-account-note');
-    var billingBtn = document.getElementById('app-manage-billing-btn');
-
-    if (!authEnabled()) {
-      loginBtn.style.display = 'none';
-      logoutBtn.style.display = 'none';
-      userSpan.textContent = 'Local dev';
-      userSpan.style.display = 'inline';
-      gate.hidden = true;
-      dashboard.hidden = false;
-      var localAuthGate = document.getElementById('app-analysis-auth-gate');
-      var localFormFields = document.getElementById('app-analysis-form-fields');
-      if (localAuthGate) localAuthGate.hidden = true;
-      if (localFormFields) localFormFields.hidden = false;
-      userName.textContent = 'Local developer';
-      accountIdentifier.textContent = 'Authentication disabled';
-      accountNote.textContent = 'Auth is disabled in this environment, so this workspace is running in local development mode.';
-      billingBtn.style.display = 'none';
-      document.getElementById('app-tier').textContent = 'Local';
-      document.getElementById('app-subscription-status').textContent = 'disabled';
-      document.getElementById('app-runs-remaining').textContent = 'n/a';
-      document.getElementById('app-concurrency').textContent = 'n/a';
-      document.getElementById('app-ai-access').textContent = 'n/a';
-      document.getElementById('app-api-access').textContent = 'n/a';
-      document.getElementById('app-retention').textContent = 'n/a';
-      document.getElementById('app-billing-note').textContent = 'Billing is unavailable when auth is disabled';
-      document.getElementById('app-tier-emulation-card').hidden = true;
-      apiDiscoveryReady.then(function() {
-        loadAnalysisHistory();
-      });
-      return;
-    }
-
-    if (currentAccount) {
-      var displayName = currentAccount.name || currentAccount.userId || 'User';
-      var identifier = currentAccount.userId || currentAccount.name || 'Signed in';
-      userSpan.textContent = displayName;
-      userSpan.style.display = 'inline';
-      loginBtn.style.display = 'none';
-      logoutBtn.style.display = 'inline';
-      gate.hidden = true;
-      dashboard.hidden = false;
-      userName.textContent = displayName;
-      accountIdentifier.textContent = identifier;
-      accountNote.textContent = 'This is your Canopex dashboard. Choose the analysis type and work preference that match the job at hand.';
-      var analysisAuthGate = document.getElementById('app-analysis-auth-gate');
-      var analysisFormFields = document.getElementById('app-analysis-form-fields');
-      var historyCard = document.getElementById('app-history-card');
-      if (analysisAuthGate) analysisAuthGate.hidden = true;
-      if (analysisFormFields) analysisFormFields.hidden = false;
-      if (historyCard) historyCard.hidden = false;
-      if (!analysisHistoryLoaded && !latestAnalysisRun) {
-        setHeroRunSummary('Checking recent runs', 'Loading your recent runs.');
-        updateHistorySummary(null);
-        renderAnalysisHistoryList();
-      }
-      apiDiscoveryReady.then(loadBillingStatus);
-      apiDiscoveryReady.then(loadEudrUsage);
-      apiDiscoveryReady.then(function() {
-        loadAnalysisHistory();
-      });
-    } else {
-      userSpan.style.display = 'none';
-      loginBtn.style.display = 'inline';
-      logoutBtn.style.display = 'none';
-      gate.hidden = false;
-      dashboard.hidden = true;
-      billingBtn.style.display = 'none';
-      var unauthGate = document.getElementById('app-analysis-auth-gate');
-      var unauthFormFields = document.getElementById('app-analysis-form-fields');
-      if (unauthGate) unauthGate.hidden = false;
-      if (unauthFormFields) unauthFormFields.hidden = true;
-      analysisHistoryRuns = [];
-      analysisHistoryLoaded = false;
-      selectedAnalysisRunId = null;
-      stopAnalysisPolling();
-      resetAnalysisProgress();
-      renderAnalysisHistoryList();
-      updateAnalysisRun(null);
-    }
+    if (typeof authModule.updateAuthUI === 'function') return authModule.updateAuthUI();
   }
 
   function initAuth() {
-    // Strip legacy ?mode=demo from URL if present
-    try {
-      const url = new URL(window.location.href);
-      if (url.searchParams.get('mode') === 'demo') {
-        url.searchParams.delete('mode');
-        const nextUrl = url.pathname + (url.search || '') + (url.hash || '');
-        window.history.replaceState({}, '', nextUrl || APP_BASE);
-      }
-    } catch { /* ignore */ }
-
-    // SWA built-in auth: fetch /.auth/me to check if the user is signed in.
-    fetch('/.auth/me').then(function(resp) {
-      if (!resp.ok) throw new Error('auth/me failed');
-      return resp.json();
-    }).then(function(payload) {
-      var principal = payload && payload.clientPrincipal;
-      if (principal && principal.userId) {
-        _apiClient.setClientPrincipal(principal); // store raw for X-MS-CLIENT-PRINCIPAL forwarding
-        currentAccount = {
-          userId: principal.userId,
-          name: principal.userDetails || '',
-          identityProvider: principal.identityProvider || 'aad',
-          userRoles: principal.userRoles || [],
-        };
-        // Acquire HMAC session token for principal verification (#534).
-        // Waits for API base discovery so the request goes to the right host.
-        (apiDiscoveryReady || Promise.resolve()).then(function() {
-          return apiFetch('/api/auth/session', { method: 'POST' });
-        }).then(function(resp) { return resp.json(); }).then(function(data) {
-          if (data && data.token) _apiClient.setSessionToken(data.token);
-        }).catch(function() { /* session token unavailable — backend may not enforce HMAC */ });
-      }
-      updateAuthUI();
-    }).catch(function(err) {
-      console.warn('SWA auth check failed:', err);
-      // When running locally without SWA CLI, auth/me won't exist.
-      // Fall back to unauthenticated state — updateAuthUI handles it.
-      updateAuthUI();
-    });
+    if (typeof authModule.initAuth === 'function') return authModule.initAuth();
   }
 
   apiDiscoveryReady = discoverApiBase();
@@ -1847,6 +1726,35 @@
       getAnalysisPhases: function () { return ANALYSIS_PHASES; },
       getAnalysisPhaseDetails: function () { return ANALYSIS_PHASE_DETAILS; },
       summarizeRunTiming: summarizeRunTiming,
+    });
+  }
+
+  if (typeof authModule.init === 'function') {
+    authModule.init({
+      authEnabled: authEnabled,
+      getApiReady: function () { return apiDiscoveryReady; },
+      getAccount: function () { return currentAccount; },
+      setAccount: function (account) { currentAccount = account; },
+      setClientPrincipal: function (p) { if (_apiClient) _apiClient.setClientPrincipal(p); },
+      setSessionToken: function (t) { if (_apiClient) _apiClient.setSessionToken(t); },
+      apiFetch: apiFetch,
+      getAppBase: function () { return APP_BASE; },
+      loadAnalysisHistory: loadAnalysisHistory,
+      loadBillingStatus: loadBillingStatus,
+      loadEudrUsage: loadEudrUsage,
+      setHeroRunSummary: setHeroRunSummary,
+      updateHistorySummary: updateHistorySummary,
+      renderAnalysisHistoryList: renderAnalysisHistoryList,
+      stopAnalysisPolling: stopAnalysisPolling,
+      resetAnalysisProgress: resetAnalysisProgress,
+      updateAnalysisRun: updateAnalysisRun,
+      getAnalysisHistoryLoaded: function () { return analysisHistoryLoaded; },
+      getLatestAnalysisRun: function () { return latestAnalysisRun; },
+      clearAnalysisState: function () {
+        analysisHistoryRuns = [];
+        analysisHistoryLoaded = false;
+        selectedAnalysisRunId = null;
+      },
     });
   }
 

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -50,6 +50,7 @@
   var eudrModule = window.CanopexEudr || {};
   var billingModule = window.CanopexBilling || {};
   var evidencePanelsModule = window.CanopexEvidencePanels || {};
+  var _apiClient = window.CanopexApiClient ? window.CanopexApiClient.createClient() : null;
 
   const POST_LOGIN_DESTINATION_KEY = 'canopex-post-login';
   const WORKSPACE_ROLE_STORAGE_KEY = 'canopex-workspace-role';
@@ -237,6 +238,9 @@
   let apiDiscoveryReady = null;
   const apiClient = createApiClient();
 
+  // Container Apps FA: API calls go cross-origin to the Function App
+  // hostname discovered from /api-config.json (injected at deploy time).
+  // Auth state managed by CanopexApiClient (canopex-api-client.js).
   let currentAccount = null;   // populated by /.auth/me
   let latestBillingStatus = null;
   let latestAnalysisRun = null;
@@ -1340,7 +1344,6 @@
   }
 
   function clearEvidencePanels() {
-
     var ids = [
       'app-evidence-ndvi-grid',
       'app-evidence-weather-grid',

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -55,6 +55,7 @@
   var evidenceDisplayModule = window.CanopexEvidenceDisplay || {};
   var authModule = window.CanopexAuth || {};
   var bindingsModule = window.CanopexBindings || {};
+  var runLifecycleModule = window.CanopexRunLifecycle || {};
   var _apiClient = window.CanopexApiClient ? window.CanopexApiClient.createClient() : null;
 
   const POST_LOGIN_DESTINATION_KEY = 'canopex-post-login';
@@ -934,23 +935,7 @@
   /* ------------------------------------------------------------------ */
 
   function applyFirstRunLayout() {
-    var firstRun = document.getElementById('app-first-run-hero');
-    var evidenceHero = document.getElementById('app-evidence-hero');
-    var historyRail = document.getElementById('app-history-card');
-    var workflowStage = document.getElementById('app-workflow-stage');
-    var modePill = document.getElementById('app-hero-mode');
-    var activeRunPill = document.getElementById('app-hero-active-run');
-    if (!firstRun) return;
-
-    var isEmpty = analysisHistoryLoaded && analysisHistoryRuns.length === 0 && !latestAnalysisRun;
-    firstRun.hidden = !isEmpty;
-    if (evidenceHero) evidenceHero.hidden = isEmpty;
-
-    // Collapse first-load noise: hide history rail + extra pills for new users
-    if (historyRail) historyRail.hidden = isEmpty;
-    if (workflowStage) workflowStage.classList.toggle('first-run', isEmpty);
-    if (modePill) modePill.closest('.app-stat-pill').hidden = isEmpty;
-    if (activeRunPill) activeRunPill.closest('.app-stat-pill').hidden = isEmpty;
+    if (typeof runLifecycleModule.applyFirstRunLayout === 'function') return runLifecycleModule.applyFirstRunLayout();
   }
 
   /* ------------------------------------------------------------------ */
@@ -1060,532 +1045,29 @@
   /* ------------------------------------------------------------------ */
 
 
+  /* ---- Run lifecycle — delegated to app-run-lifecycle.js ---- */
+
   function updateContentSummary(data) {
-    var role = currentRoleConfig();
-    var imageryEl = document.getElementById('app-content-imagery');
-    var imageryNoteEl = document.getElementById('app-content-imagery-note');
-    var enrichmentEl = document.getElementById('app-content-enrichment');
-    var enrichmentNoteEl = document.getElementById('app-content-enrichment-note');
-    var exportsEl = document.getElementById('app-content-exports');
-    var exportsNoteEl = document.getElementById('app-content-exports-note');
-    if (!imageryEl || !imageryNoteEl || !enrichmentEl || !enrichmentNoteEl || !exportsEl || !exportsNoteEl) return;
-
-    if (!data) {
-      showEvidenceSurface(false);
-      imageryEl.textContent = role.emptyContent.imageryTitle;
-      imageryNoteEl.textContent = role.emptyContent.imageryNote;
-      enrichmentEl.textContent = role.emptyContent.enrichmentTitle;
-      enrichmentNoteEl.textContent = role.emptyContent.enrichmentNote;
-      exportsEl.textContent = role.emptyContent.exportsTitle;
-      exportsNoteEl.textContent = role.emptyContent.exportsNote;
-      return;
-    }
-
-    var runtimeStatus = data.runtimeStatus || 'Pending';
-    var phase = (data.customStatus && data.customStatus.phase) || 'queued';
-    var phaseCopy = (activeProfile.contentPhaseCopy && activeProfile.contentPhaseCopy[phase]) || {};
-
-    if (runtimeStatus === 'Completed') {
-      // Evidence surface is loaded by loadRunEvidence(), triggered from selectAnalysisRun
-      // Phase status is hidden; evidence surface is shown
-      return;
-    }
-
-    showEvidenceSurface(false);
-
-    if (runtimeStatus === 'Failed' || runtimeStatus === 'Canceled' || runtimeStatus === 'Terminated') {
-      imageryEl.textContent = 'Run interrupted';
-      imageryNoteEl.textContent = 'The pipeline stopped before the imagery stack completed.';
-      enrichmentEl.textContent = 'Context incomplete';
-      enrichmentNoteEl.textContent = 'This run needs explicit failure handling rather than silent fallback behavior.';
-      exportsEl.textContent = 'Nothing staged';
-      exportsNoteEl.textContent = 'No saved outputs should be implied when the real pipeline fails.';
-      return;
-    }
-
-    if (phase === 'ingestion' || phase === 'queued') {
-      imageryEl.textContent = 'AOIs preparing';
-      imageryNoteEl.textContent = 'The workspace is validating geometry and shaping the request for imagery search.';
-      enrichmentEl.textContent = 'Waiting on imagery';
-      enrichmentNoteEl.textContent = 'Context layers follow once the pipeline has something real to attach to.';
-      exportsEl.textContent = 'No outputs yet';
-      exportsNoteEl.textContent = 'Saved artifacts stay unavailable until a real run starts producing outputs.';
-      return;
-    }
-
-    if (phase === 'acquisition') {
-      imageryEl.textContent = 'Scene search underway';
-      imageryNoteEl.textContent = phaseCopy.imageryNote || 'NAIP and Sentinel-2 discovery is in progress so the run can pick the right source imagery.';
-      enrichmentEl.textContent = 'Queued behind acquisition';
-      enrichmentNoteEl.textContent = 'Context layers are staged after the imagery stack is selected.';
-      exportsEl.textContent = 'Awaiting artefacts';
-      exportsNoteEl.textContent = phaseCopy.exportsNote || 'There is nothing to export until imagery is actually acquired.';
-      return;
-    }
-
-    if (phase === 'fulfilment') {
-      imageryEl.textContent = 'Clipping and reprojection';
-      imageryNoteEl.textContent = phaseCopy.imageryNote || 'The pipeline is producing imagery assets for your analysis.';
-      enrichmentEl.textContent = 'Preparing next';
-      enrichmentNoteEl.textContent = phaseCopy.enrichmentNote || 'NDVI and weather context will follow immediately after fulfilment finishes.';
-      exportsEl.textContent = 'Outputs staging next';
-      exportsNoteEl.textContent = phaseCopy.exportsNote || 'The run is close enough that saved outputs should feel tangible, not hypothetical.';
-      return;
-    }
-
-    imageryEl.textContent = 'Imagery stack stabilizing';
-    imageryNoteEl.textContent = phaseCopy.imageryNote || 'Core imagery is in place and the workspace is adding the last supporting layers.';
-    enrichmentEl.textContent = 'Context packaging';
-    enrichmentNoteEl.textContent = phaseCopy.enrichmentNote || 'NDVI, weather, and derived context are being assembled for the run detail experience.';
-    exportsEl.textContent = 'Preparing results view';
-    exportsNoteEl.textContent = phaseCopy.exportsNote || 'Saved outputs, exports, and revisit paths will be available shortly.';
+    if (typeof runLifecycleModule.updateContentSummary === 'function') return runLifecycleModule.updateContentSummary(data);
   }
-
   function updateRunDetail(data) {
-    var submittedEl = document.getElementById('app-run-submitted');
-    var submittedNoteEl = document.getElementById('app-run-submitted-note');
-    var scopeEl = document.getElementById('app-run-scope');
-    var scopeNoteEl = document.getElementById('app-run-scope-note');
-    var deliveryEl = document.getElementById('app-run-delivery');
-    var deliveryNoteEl = document.getElementById('app-run-delivery-note');
-    var linkLabelEl = document.getElementById('app-run-link-label');
-    var linkEl = document.getElementById('app-run-link');
-    if (!submittedEl || !submittedNoteEl || !scopeEl || !scopeNoteEl || !deliveryEl || !deliveryNoteEl || !linkLabelEl || !linkEl) return;
-
-    if (!data) {
-      submittedEl.textContent = '—';
-      submittedNoteEl.textContent = 'Run details restore here after reload.';
-      scopeEl.textContent = '—';
-      scopeNoteEl.textContent = 'Feature and AOI counts appear when known.';
-      deliveryEl.textContent = '—';
-      deliveryNoteEl.textContent = 'Failure counts and tracked artifacts will appear here.';
-      linkLabelEl.textContent = 'Dashboard state';
-      linkEl.href = APP_BASE;
-      linkEl.textContent = 'Open dashboard';
-      document.querySelectorAll('[data-export-format]').forEach(function(button) {
-        button.disabled = true;
-      });
-      return;
-    }
-
-    var runtimeStatus = data.runtimeStatus || 'Pending';
-    var timing = summarizeRunTiming(data);
-    var scopeSummary = [
-      formatCountLabel(data.featureCount, 'feature'),
-      formatCountLabel(data.aoiCount, 'AOI'),
-      data.processingMode,
-    ].filter(Boolean).join(' • ');
-    var scopeNote = [
-      data.maxSpreadKm != null ? 'Spread ' + formatDistance(data.maxSpreadKm) : null,
-      data.totalAreaHa != null ? 'Area ' + formatHectares(data.totalAreaHa) : null,
-      providerLabel(data.providerName),
-    ].filter(Boolean).join(' • ');
-    var failureSummary = summarizeFailureCounts(data.partialFailures);
-    var artifactCount = data.artifactCount || 0;
-
-    submittedEl.textContent = formatHistoryTimestamp(data.submittedAt || data.createdTime);
-    submittedNoteEl.textContent = timing.sinceUpdate
-      ? 'Last backend update ' + timing.sinceUpdate + ' ago.'
-      : 'Your run history preserves this state across reloads.';
-    scopeEl.textContent = scopeSummary || 'Scope loading';
-    scopeNoteEl.textContent = scopeNote || 'Preflight detail appears when the run metadata is available.';
-
-    if (runtimeStatus === 'Completed') {
-      deliveryEl.textContent = artifactCount ? artifactCount + ' tracked outputs' : 'Exports ready';
-      deliveryNoteEl.textContent = failureSummary || 'GeoJSON, CSV, and PDF exports are ready for this completed run.';
-    } else if (runtimeStatus === 'Failed' || runtimeStatus === 'Canceled' || runtimeStatus === 'Terminated') {
-      deliveryEl.textContent = 'Run interrupted';
-      deliveryNoteEl.textContent = failureSummary || 'This run stopped before producing a complete result set.';
-    } else {
-      deliveryEl.textContent = 'Tracking live pipeline';
-      deliveryNoteEl.textContent = failureSummary || 'Results will unlock here when the run completes.';
-    }
-
-    linkLabelEl.textContent = 'Run details';
-    linkEl.href = selectedRunPermalink(data.instanceId || data.instance_id);
-    linkEl.textContent = 'Copy link to this run';
-
-    document.querySelectorAll('[data-export-format]').forEach(function(button) {
-      button.disabled = runtimeStatus !== 'Completed';
-    });
-    var evidenceExportNote = document.getElementById('app-evidence-export-note');
-    if (evidenceExportNote) {
-      evidenceExportNote.textContent = runtimeStatus === 'Completed'
-        ? 'Download GeoJSON, CSV, or PDF for this completed run.'
-        : 'Exports unlock when the selected run completes.';
-    }
+    if (typeof runLifecycleModule.updateRunDetail === 'function') return runLifecycleModule.updateRunDetail(data);
   }
-
   async function downloadRunExport(format) {
-    var run = latestAnalysisRun;
-    if (!run || !(run.instanceId || run.instance_id)) {
-      setAnalysisStatus('Select a run first.', 'error');
-      return;
-    }
-
-    var instanceId = run.instanceId || run.instance_id;
-    if ((run.runtimeStatus || '') !== 'Completed') {
-      setAnalysisStatus('Exports become available once the selected run completes.', 'info');
-      return;
-    }
-
-    var button = document.querySelector('[data-export-format="' + format + '"]');
-    var originalText = button ? button.textContent : format.toUpperCase();
-    if (button) {
-      button.disabled = true;
-      button.textContent = 'Preparing…';
-    }
-
-    try {
-      await apiDiscoveryReady;
-      var res = await apiFetch('/api/export/' + encodeURIComponent(instanceId) + '/' + format);
-      var blob = await res.blob();
-      var blobUrl = URL.createObjectURL(blob);
-      var link = document.createElement('a');
-      link.href = blobUrl;
-      link.download = parseDownloadFilename(res, 'canopex_' + instanceId + '.' + format);
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-      URL.revokeObjectURL(blobUrl);
-      setAnalysisStatus(format.toUpperCase() + ' export downloaded for the selected run.', 'success');
-    } catch (err) {
-      setAnalysisStatus((err && err.message) || 'Could not download the selected export.', 'error');
-    } finally {
-      if (button) {
-        button.disabled = (latestAnalysisRun && latestAnalysisRun.runtimeStatus !== 'Completed');
-        button.textContent = originalText;
-      }
-    }
+    if (typeof runLifecycleModule.downloadRunExport === 'function') return runLifecycleModule.downloadRunExport(format);
   }
-
   function updateAnalysisRun(data) {
-    var panel = document.getElementById('app-analysis-run');
-    latestAnalysisRun = data || null;
-    if (!panel) return;
-    if (!data) {
-      panel.hidden = true;
-      setHeroRunSummary('Ready to queue', currentRoleConfig().readyNote);
-      updateHistorySummary(null);
-      updateRunDetail(null);
-      updateContentSummary(null);
-      return;
-    }
-    panel.hidden = false;
-    var instanceId = data.instanceId || data.instance_id || '—';
-    var runtimeStatus = data.runtimeStatus || 'queued';
-    var phase = displayAnalysisPhase(data.customStatus, runtimeStatus);
-    var timing = summarizeRunTiming(data);
-    document.getElementById('app-analysis-instance').textContent = instanceId;
-    document.getElementById('app-analysis-runtime').textContent = runtimeStatus;
-    document.getElementById('app-analysis-phase').textContent = phase;
-    setHeroRunSummary(
-      runtimeStatus,
-      runtimeStatus === 'Completed'
-        ? 'Pipeline finished successfully — results are ready.'
-        : 'Current phase: ' + phase + '.' + (timing.elapsed ? ' Elapsed ' + timing.elapsed + '.' : '')
-    );
-    updateHistorySummary(data);
-    updateRunDetail(data);
-    updateContentSummary(data);
+    if (typeof runLifecycleModule.updateAnalysisRun === 'function') return runLifecycleModule.updateAnalysisRun(data);
   }
-
-  /* ---- Analysis progress UI — delegated to app-analysis-progress.js ---- */
-
-  function resetAnalysisProgress() {
-    if (typeof progressModule.reset === 'function') return progressModule.reset();
-  }
-
-  function setAnalysisProgressVisible(visible) {
-    if (typeof progressModule.setVisible === 'function') return progressModule.setVisible(visible);
-  }
-
-  function setAnalysisStep(phase, state) {
-    if (typeof progressModule.setStep === 'function') return progressModule.setStep(phase, state);
-  }
-
-  function mapAnalysisPhase(customStatus, runtimeStatus) {
-    if (typeof progressModule.mapPhase === 'function') return progressModule.mapPhase(customStatus, runtimeStatus);
-    if (typeof appRuns.mapPhase === 'function') return appRuns.mapPhase(customStatus, runtimeStatus, ANALYSIS_PHASES);
-    if (runtimeStatus === 'Completed') return 'complete';
-    if (customStatus && customStatus.phase && ANALYSIS_PHASES.indexOf(customStatus.phase) > -1) return customStatus.phase;
-    return 'submit';
-  }
-
-  function updateAnalysisStory(phase, runtimeStatus, data) {
-    if (typeof progressModule.updateStory === 'function') return progressModule.updateStory(phase, runtimeStatus, data);
-  }
-
-  /* ---- Analysis preflight + file input — delegated to app-analysis-preflight.js ---- */
-
-  function buildPreflightWarnings(preflight) {
-    if (typeof preflightModule.buildAnalysisPreflight === 'function') {
-      // Warnings are generated inside updateAnalysisPreflight; expose for queueAnalysis use.
-    }
-    // Fallback: basic check only — real logic is in the module.
-    return [{ tone: 'info', text: 'No warnings. This will queue as one tracked analysis run.' }];
-  }
-
-  function updateAnalysisPreflight(text) {
-    if (typeof preflightModule.updateAnalysisPreflight === 'function') return preflightModule.updateAnalysisPreflight(text);
-    return null;
-  }
-
-  function loadAnalysisFile(file) {
-    if (typeof preflightModule.loadAnalysisFile === 'function') return preflightModule.loadAnalysisFile(file);
-  }
-
-  function switchInputTab(tabName) {
-    if (typeof preflightModule.switchInputTab === 'function') return preflightModule.switchInputTab(tabName);
-  }
-
-  async function convertCSVToKml() {
-    if (typeof preflightModule.convertCSVToKml === 'function') return preflightModule.convertCSVToKml();
-  }
-
   function stopAnalysisPolling() {
-    if (activeAnalysisPoll) {
-      clearInterval(activeAnalysisPoll);
-      activeAnalysisPoll = null;
-    }
+    if (typeof runLifecycleModule.stopAnalysisPolling === 'function') return runLifecycleModule.stopAnalysisPolling();
   }
-
   async function pollAnalysisRun(instanceId) {
-    stopAnalysisPolling();
-    const thisGeneration = ++analysisPollGeneration;
-    let consecutiveFailures = 0;
-    const MAX_CONSECUTIVE_FAILURES = 5;
-
-    async function refreshRun() {
-      // Bail out if a newer poll has started while we were awaiting.
-      if (analysisPollGeneration !== thisGeneration) return null;
-      try {
-        var res = await apiFetch('/api/orchestrator/' + instanceId);
-        var data = await res.json();
-        consecutiveFailures = 0;
-        // Re-check after await — another selectAnalysisRun may have fired.
-        if (analysisPollGeneration !== thisGeneration) return null;
-        upsertAnalysisHistoryRun(data);
-        updateAnalysisRun(data);
-
-        var runtime = data.runtimeStatus || '';
-        var phase = mapAnalysisPhase(data.customStatus, runtime);
-        setAnalysisProgressVisible(true);
-        if (runtime === 'Completed') {
-          stopAnalysisPolling();
-          setAnalysisStep('complete', 'done');
-          updateAnalysisStory('complete', runtime, data);
-          clearCacheKey('billing');
-          clearCacheKey('history');
-          loadBillingStatus();
-          loadAnalysisHistory({ preferInstanceId: instanceId });
-          loadRunEvidence(instanceId);
-          var evidenceHero = document.getElementById('app-evidence-hero');
-          if (evidenceHero) {
-            setTimeout(function() {
-              var scrollBehavior = 'smooth';
-              if (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-                scrollBehavior = 'auto';
-              }
-              evidenceHero.scrollIntoView({ behavior: scrollBehavior, block: 'start' });
-            }, 400);
-          }
-        } else if (runtime === 'Failed' || runtime === 'Canceled' || runtime === 'Terminated') {
-          stopAnalysisPolling();
-          setAnalysisStep(phase, 'failed');
-          updateAnalysisStory(phase, runtime, data);
-          loadAnalysisHistory({ preferInstanceId: instanceId });
-        } else {
-          setAnalysisStep(phase, 'active');
-          updateAnalysisStory(phase, runtime || 'Pending', data);
-        }
-        return data;
-      } catch {
-        consecutiveFailures++;
-        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
-          stopAnalysisPolling();
-          setAnalysisStatus('Connection lost — pipeline updates have stopped. Reload the page to resume.', 'error');
-        }
-        return null;
-      }
-    }
-
-    var initialData = await refreshRun();
-    if (analysisPollGeneration !== thisGeneration) return; // superseded during initial fetch
-    if (initialData) {
-      var initialRuntime = initialData.runtimeStatus || '';
-      if (initialRuntime === 'Completed' || initialRuntime === 'Failed' || initialRuntime === 'Canceled' || initialRuntime === 'Terminated') {
-        return;
-      }
-    }
-
-    activeAnalysisPoll = setInterval(function() {
-      refreshRun();
-    }, 3000);
+    if (typeof runLifecycleModule.pollAnalysisRun === 'function') return runLifecycleModule.pollAnalysisRun(instanceId);
   }
-
   async function queueAnalysis() {
-    if (!currentAccount) {
-      login();
-      return;
-    }
-
-    // EUDR entitlement gate: show subscribe modal when trial is exhausted.
-    // If billing hasn't loaded yet, fetch it before deciding.
-    if (activeProfile.requiresEudrBillingGate && typeof window.eudrBillingData === 'function') {
-      var billing = window.eudrBillingData();
-      if (!billing) {
-        try {
-          await apiDiscoveryReady;
-          var billingRes = await apiFetch('/api/eudr/billing');
-          billing = await billingRes.json();
-        } catch (_) { /* proceed — server will enforce */ }
-      }
-      if (billing && !billing.subscribed && billing.trial_remaining != null && billing.trial_remaining <= 0) {
-        if (typeof window.showEudrSubscribeModal === 'function') {
-          window.showEudrSubscribeModal();
-        }
-        return;
-      }
-    }
-
-    var button = document.getElementById('app-analysis-submit-btn');
-    var textarea = document.getElementById('app-analysis-kml');
-    if (!button || !textarea) return;
-
-    var kmlContent = parseKmlText(textarea.value);
-    if (!kmlContent) {
-      setAnalysisStatus('Paste KML content or load a KML/KMZ file first.', 'error');
-      updateAnalysisRun(null);
-      resetAnalysisProgress();
-      return;
-    }
-
-    var preflight = analysisDraftSummary || updateAnalysisPreflight(kmlContent);
-    if (preflight && preflight.error) {
-      setAnalysisStatus(preflight.error, 'error');
-      resetAnalysisProgress();
-      return;
-    }
-
-    button.disabled = true;
-    button.textContent = 'Queueing…';
-    resetAnalysisProgress();
-    setAnalysisProgressVisible(true);
-    setAnalysisStep('submit', 'active');
-    updateAnalysisStory('submit', 'Pending', null);
-    updateAnalysisRun(null);
-
-    try {
-      await apiDiscoveryReady;
-      var submissionContext = null;
-      if (preflight) {
-        submissionContext = {
-          feature_count: preflight.featureCount,
-          aoi_count: preflight.aoiCount,
-          max_spread_km: preflight.maxSpreadKm,
-          total_area_ha: preflight.totalAreaHa,
-          largest_area_ha: preflight.largestAreaHa,
-          processing_mode: preflight.processingMode,
-          provider_name: 'planetary_computer',
-          workspace_role: workspaceRole,
-          workspace_preference: workspacePreference
-        };
-      }
-
-      // Step 1: Get SAS token from Container Apps FA.
-      // apiFetch handles cross-origin routing and auth forwarding.
-      var tokenBody = {};
-      if (submissionContext) {
-        tokenBody.provider_name = submissionContext.provider_name;
-        tokenBody.submission_context = submissionContext;
-      }
-
-      // EUDR compliance mode (#600)
-      var eudrCheckbox = document.getElementById('app-eudr-mode');
-      if (eudrCheckbox && eudrCheckbox.checked) {
-        tokenBody.eudr_mode = true;
-      }
-
-      var tokenRes;
-      try {
-        tokenRes = await apiFetch('/api/upload/token', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(tokenBody)
-        });
-      } catch (tokenFetchErr) {
-        // 401 is handled centrally by apiFetch (clears session, shows re-login prompt).
-        if (tokenFetchErr.status === 401) {
-          resetAnalysisProgress();
-          return;
-        }
-        setAnalysisStatus(tokenFetchErr.body && tokenFetchErr.body.error || 'Could not prepare upload. Please try again.', 'error');
-        updateContentSummary(null);
-        resetAnalysisProgress();
-        return;
-      }
-
-      var tokenData = await tokenRes.json();
-      var submissionId = tokenData.submissionId || tokenData.submission_id;
-      var sasUrl = tokenData.sasUrl || tokenData.sas_url;
-
-      // Step 2: Upload KML directly to blob storage via SAS URL
-      button.textContent = 'Uploading…';
-      setAnalysisStep('submit', 'active');
-
-      var kmlBytes = new TextEncoder().encode(kmlContent);
-      var uploadRes = await fetch(sasUrl, {
-        method: 'PUT',
-        headers: {
-          'x-ms-blob-type': 'BlockBlob',
-          'Content-Type': 'application/vnd.google-earth.kml+xml'
-        },
-        body: kmlBytes
-      });
-      if (!uploadRes || !uploadRes.ok) {
-        setAnalysisStatus('Upload failed. Please try again.', 'error');
-        resetAnalysisProgress();
-        return;
-      }
-
-      // Step 3: Track the submission
-      clearCacheKey('history');
-      clearCacheKey('billing');
-      var data = { instance_id: submissionId };
-      analysisHistoryLoaded = true;
-      applyFirstRunLayout();
-      var queuedAt = new Date().toISOString();
-      upsertAnalysisHistoryRun({
-        instanceId: data.instance_id,
-        submittedAt: queuedAt,
-        createdTime: queuedAt,
-        lastUpdatedTime: queuedAt,
-        runtimeStatus: 'Pending',
-        customStatus: { phase: 'queued' },
-        providerName: 'planetary_computer',
-        featureCount: preflight && preflight.featureCount,
-        aoiCount: preflight && preflight.aoiCount,
-        processingMode: preflight && preflight.processingMode,
-        maxSpreadKm: preflight && preflight.maxSpreadKm,
-        totalAreaHa: preflight && preflight.totalAreaHa,
-        largestAreaHa: preflight && preflight.largestAreaHa,
-        workspaceRole: workspaceRole,
-        workspacePreference: workspacePreference
-      });
-      selectAnalysisRun(data.instance_id, { resume: true });
-      setAnalysisStatus('Analysis queued. The app will walk through each stage as the pipeline advances.', 'info');
-      loadBillingStatus();
-    } catch (err) {
-      console.error('queueAnalysis failed:', err);
-      setAnalysisStatus('Could not queue analysis request.', 'error');
-      resetAnalysisProgress();
-    } finally {
-      button.disabled = false;
-      button.textContent = analysisDraftSummary && !analysisDraftSummary.error ? 'Confirm & Queue' : 'Queue Analysis';
-    }
+    if (typeof runLifecycleModule.queueAnalysis === 'function') return runLifecycleModule.queueAnalysis();
   }
-
   async function manageBilling() {
     if (typeof billingModule.manage === 'function') return billingModule.manage();
     // fallback: redirect to interest mailto
@@ -1727,6 +1209,42 @@
       getAnalysisPhases: function () { return ANALYSIS_PHASES; },
       getAnalysisPhaseDetails: function () { return ANALYSIS_PHASE_DETAILS; },
       summarizeRunTiming: summarizeRunTiming,
+    });
+  }
+
+  if (typeof runLifecycleModule.init === 'function') {
+    runLifecycleModule.init({
+      apiFetch: apiFetch,
+      getApiReady: function () { return apiDiscoveryReady; },
+      getAccount: function () { return currentAccount; },
+      login: login,
+      getActiveProfile: function () { return activeProfile; },
+      getWorkspaceRole: function () { return workspaceRole; },
+      getWorkspacePreference: function () { return workspacePreference; },
+      getAnalysisDraftSummary: function () { return analysisDraftSummary; },
+      setLatestAnalysisRun: function (d) { latestAnalysisRun = d; },
+      setAnalysisStatus: setAnalysisStatus,
+      setHeroRunSummary: setHeroRunSummary,
+      updateHistorySummary: updateHistorySummary,
+      getCurrentRoleConfig: currentRoleConfig,
+      selectedRunPermalink: selectedRunPermalink,
+      getAppBase: function () { return APP_BASE; },
+      clearCacheKey: clearCacheKey,
+      getAnalysisHistoryLoaded: function () { return analysisHistoryLoaded; },
+      getAnalysisHistoryRuns: function () { return analysisHistoryRuns; },
+      setAnalysisHistoryLoaded: function (v) { analysisHistoryLoaded = v; },
+      upsertAnalysisHistoryRun: upsertAnalysisHistoryRun,
+      selectAnalysisRun: selectAnalysisRun,
+      loadBillingStatus: loadBillingStatus,
+      loadAnalysisHistory: loadAnalysisHistory,
+      loadRunEvidence: loadRunEvidence,
+      showEvidenceSurface: showEvidenceSurface,
+      resetAnalysisProgress: resetAnalysisProgress,
+      setAnalysisProgressVisible: setAnalysisProgressVisible,
+      setAnalysisStep: setAnalysisStep,
+      updateAnalysisStory: updateAnalysisStory,
+      mapAnalysisPhase: mapAnalysisPhase,
+      updateAnalysisPreflight: updateAnalysisPreflight,
     });
   }
 

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -51,6 +51,7 @@
   var billingModule = window.CanopexBilling || {};
   var evidencePanelsModule = window.CanopexEvidencePanels || {};
   var preflightModule = window.CanopexAnalysisPreflight || {};
+  var progressModule = window.CanopexAnalysisProgress || {};
   var _apiClient = window.CanopexApiClient ? window.CanopexApiClient.createClient() : null;
 
   const POST_LOGIN_DESTINATION_KEY = 'canopex-post-login';
@@ -2182,191 +2183,30 @@
     updateContentSummary(data);
   }
 
+  /* ---- Analysis progress UI — delegated to app-analysis-progress.js ---- */
+
   function resetAnalysisProgress() {
-    var progress = document.getElementById('app-analysis-progress');
-    if (!progress) return;
-    progress.hidden = true;
-    progress.querySelectorAll('.pipeline-step').forEach(function(el) {
-      el.className = 'pipeline-step';
-      var icon = el.querySelector('.step-icon');
-      if (icon) icon.textContent = '○';
-    });
-    resetEnrichmentSubSteps();
+    if (typeof progressModule.reset === 'function') return progressModule.reset();
   }
 
   function setAnalysisProgressVisible(visible) {
-    var progress = document.getElementById('app-analysis-progress');
-    if (!progress) return;
-    progress.hidden = !visible;
+    if (typeof progressModule.setVisible === 'function') return progressModule.setVisible(visible);
   }
 
   function setAnalysisStep(phase, state) {
-    var steps = document.querySelectorAll('#app-analysis-progress .pipeline-step');
-    steps.forEach(function(el) {
-      var stepPhase = el.getAttribute('data-phase');
-      var icon = el.querySelector('.step-icon');
-      el.className = 'pipeline-step';
-
-      if (stepPhase === phase) {
-        if (state === 'failed') el.classList.add('failed');
-        else if (state === 'done') el.classList.add('done');
-        else el.classList.add('active');
-        if (!icon) return;
-        if (state === 'done') {
-          icon.textContent = '✓';
-        } else if (state === 'failed') {
-          icon.textContent = '✗';
-        } else {
-          icon.replaceChildren();
-          var spinner = document.createElement('span');
-          spinner.className = 'spinner';
-          icon.appendChild(spinner);
-        }
-        return;
-      }
-
-      if (!icon) return;
-      var stepIndex = ANALYSIS_PHASES.indexOf(stepPhase);
-      var currentIndex = ANALYSIS_PHASES.indexOf(phase);
-      if (stepIndex > -1 && currentIndex > -1 && stepIndex < currentIndex) {
-        el.classList.add('done');
-        icon.textContent = '✓';
-      } else {
-        icon.textContent = '○';
-      }
-    });
+    if (typeof progressModule.setStep === 'function') return progressModule.setStep(phase, state);
   }
 
   function mapAnalysisPhase(customStatus, runtimeStatus) {
-    if (typeof appRuns.mapPhase === 'function') {
-      return appRuns.mapPhase(customStatus, runtimeStatus, ANALYSIS_PHASES);
-    }
+    if (typeof progressModule.mapPhase === 'function') return progressModule.mapPhase(customStatus, runtimeStatus);
+    if (typeof appRuns.mapPhase === 'function') return appRuns.mapPhase(customStatus, runtimeStatus, ANALYSIS_PHASES);
     if (runtimeStatus === 'Completed') return 'complete';
-    if (customStatus && customStatus.phase && ANALYSIS_PHASES.indexOf(customStatus.phase) > -1) {
-      return customStatus.phase;
-    }
+    if (customStatus && customStatus.phase && ANALYSIS_PHASES.indexOf(customStatus.phase) > -1) return customStatus.phase;
     return 'submit';
   }
 
-  const ENRICHMENT_STEP_LABELS = {
-    data_sources_and_imagery: 'Fetching weather, flood/fire context, and registering satellite mosaics in parallel.',
-    per_aoi: 'Running per-parcel enrichment across AOIs in parallel.',
-    finalizing: 'Merging results and storing the analysis manifest.'
-  };
-
-  // Sub-step order for the enrichment phase progress UI.
-  // 'data_sources_and_imagery' maps to both data_sources_and_imagery + imagery
-  // sub-bullets since the orchestrator runs them in parallel under one status.
-  const ENRICHMENT_SUB_ORDER = ['data_sources_and_imagery', 'imagery', 'per_aoi', 'finalizing'];
-
-  function updateEnrichmentSubSteps(enrichmentStep) {
-    const container = document.querySelector('#app-analysis-progress .pipeline-step[data-phase="enrichment"] .pipeline-sub-steps');
-    if (!container) return;
-    container.hidden = false;
-    const currentIdx = ENRICHMENT_SUB_ORDER.indexOf(enrichmentStep);
-    const subs = container.querySelectorAll('.pipeline-sub-step');
-    subs.forEach(function(el) {
-      const sub = el.getAttribute('data-sub');
-      const icon = el.querySelector('.sub-icon');
-      el.className = 'pipeline-sub-step';
-      if (!icon) return;
-      const subIdx = ENRICHMENT_SUB_ORDER.indexOf(sub);
-      if (subIdx < 0) return;
-
-      // data_sources_and_imagery and imagery run in parallel — treat
-      // them as the same phase for status purposes.
-      const isParallelPair = (sub === 'imagery' && enrichmentStep === 'data_sources_and_imagery')
-        || (sub === 'data_sources_and_imagery' && enrichmentStep === 'imagery');
-
-      if (sub === enrichmentStep || isParallelPair) {
-        el.classList.add('active');
-        icon.replaceChildren();
-        const spinner = document.createElement('span');
-        spinner.className = 'spinner';
-        icon.appendChild(spinner);
-      } else if (subIdx < currentIdx) {
-        el.classList.add('done');
-        icon.textContent = '✓';
-      } else {
-        icon.textContent = '○';
-      }
-    });
-  }
-
-  function resetEnrichmentSubSteps() {
-    const container = document.querySelector('#app-analysis-progress .pipeline-step[data-phase="enrichment"] .pipeline-sub-steps');
-    if (!container) return;
-    container.hidden = true;
-    const subs = container.querySelectorAll('.pipeline-sub-step');
-    subs.forEach(function(el) {
-      el.className = 'pipeline-sub-step';
-      const icon = el.querySelector('.sub-icon');
-      if (icon) icon.textContent = '○';
-    });
-  }
-
-  function completeEnrichmentSubSteps() {
-    const container = document.querySelector('#app-analysis-progress .pipeline-step[data-phase="enrichment"] .pipeline-sub-steps');
-    if (!container) return;
-    container.hidden = false;
-    const subs = container.querySelectorAll('.pipeline-sub-step');
-    subs.forEach(function(el) {
-      el.className = 'pipeline-sub-step done';
-      const icon = el.querySelector('.sub-icon');
-      if (icon) icon.textContent = '✓';
-    });
-  }
-
   function updateAnalysisStory(phase, runtimeStatus, data) {
-    var runtime = runtimeStatus || 'Pending';
-    var phaseDetails = activeProfile.phaseDetails || ANALYSIS_PHASE_DETAILS;
-    var detail = phaseDetails[phase] || 'Working through the analysis pipeline.';
-    var timing = summarizeRunTiming(data);
-
-    if (runtime !== 'Completed' && phase === 'enrichment') {
-      var cs = data && data.customStatus;
-      var step = cs && cs.step;
-      const stepLabel = step && ENRICHMENT_STEP_LABELS[step];
-      if (stepLabel) {
-        detail = stepLabel;
-        if (step === 'per_aoi' && cs.aois) {
-          detail += ' (' + cs.aois + ' AOIs)';
-        }
-      } else {
-        detail += ' Enrichment batches weather, flood/fire checks, mosaic registration, NDVI, and change detection in parallel.';
-      }
-      if (timing.sinceUpdate) {
-        detail += ' Last backend update ' + timing.sinceUpdate + ' ago.';
-      }
-      // Drive the nested sub-step progress indicators.
-      if (step) updateEnrichmentSubSteps(step);
-    } else if (phase !== 'enrichment') {
-      // Past enrichment (complete) — mark all sub-steps done.
-      // Before enrichment — keep sub-steps hidden.
-      const enrichIdx = ANALYSIS_PHASES.indexOf('enrichment');
-      const phaseIdx = ANALYSIS_PHASES.indexOf(phase);
-      if (phaseIdx > enrichIdx) {
-        completeEnrichmentSubSteps();
-      } else {
-        resetEnrichmentSubSteps();
-      }
-      if (runtime !== 'Completed' && timing.elapsed) {
-        detail += ' Elapsed ' + timing.elapsed + '.';
-      }
-    } else {
-      // Completed while on enrichment phase — mark all sub-steps done.
-      completeEnrichmentSubSteps();
-    }
-
-    if (runtime === 'Completed') {
-      setAnalysisStatus(detail, 'success');
-      return;
-    }
-    if (runtime === 'Failed' || runtime === 'Canceled' || runtime === 'Terminated') {
-      setAnalysisStatus('Analysis stopped during ' + phase + '. ' + detail, 'error');
-      return;
-    }
-    setAnalysisStatus(detail, 'info');
+    if (typeof progressModule.updateStory === 'function') return progressModule.updateStory(phase, runtimeStatus, data);
   }
 
   /* ---- Analysis preflight + file input — delegated to app-analysis-preflight.js ---- */
@@ -2883,6 +2723,16 @@
       getLatestBillingStatus: function () { return latestBillingStatus; },
       getWorkspaceRoleConfig: function () { return currentRoleConfig(); },
       onPreflightUpdate: function (preflight) { analysisDraftSummary = preflight; },
+    });
+  }
+
+  if (typeof progressModule.init === 'function') {
+    progressModule.init({
+      setAnalysisStatus: setAnalysisStatus,
+      getActiveProfile: function () { return activeProfile; },
+      getAnalysisPhases: function () { return ANALYSIS_PHASES; },
+      getAnalysisPhaseDetails: function () { return ANALYSIS_PHASE_DETAILS; },
+      summarizeRunTiming: summarizeRunTiming,
     });
   }
 

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -12,6 +12,7 @@
   var formatDistance = CanopexGeo.formatDistance;
   var formatHectares = CanopexGeo.formatHectares;
   var determineProcessingMode = CanopexGeo.determineProcessingMode;
+  var parseCSVCoordinates = CanopexGeo.parseCSVCoordinates;
 
   // Formatting/display helpers extracted to canopex-helpers.js
   var displayAnalysisPhase = CanopexHelpers.displayAnalysisPhase;
@@ -40,6 +41,14 @@
   var renderAoiDetail = CanopexEvidenceRender.renderAoiDetail;
   var clearAoiDetail = CanopexEvidenceRender.clearAoiDetail;
   var renderResourceUsage = CanopexEvidenceRender.renderResourceUsage;
+
+  var coreDom = window.CanopexCoreDom || {};
+  var coreState = window.CanopexCoreState || {};
+  var appProfiles = window.CanopexAppProfiles || {};
+  var appRuns = window.CanopexAppRuns || {};
+  var evidenceMapModule = window.CanopexEvidenceMap || {};
+  var eudrModule = window.CanopexEudr || {};
+  var billingModule = window.CanopexBilling || {};
 
   const POST_LOGIN_DESTINATION_KEY = 'canopex-post-login';
   const WORKSPACE_ROLE_STORAGE_KEY = 'canopex-workspace-role';
@@ -184,16 +193,33 @@
     }
   };
 
-  // Detect EUDR-locked page: <body data-eudr-app> forces EUDR mode
-  // and hides the workspace role/preference switcher.
-  const EUDR_LOCKED = document.body.hasAttribute('data-eudr-app');
+  const activeProfile = (typeof appProfiles.resolveActiveProfile === 'function')
+    ? appProfiles.resolveActiveProfile()
+    : {
+      id: document.body.hasAttribute('data-eudr-app') ? 'eudr' : 'default',
+      basePath: document.body.hasAttribute('data-eudr-app') ? '/eudr/' : '/app/',
+      historyScope: document.body.hasAttribute('data-eudr-app') ? 'org' : 'user',
+      lockedWorkspace: document.body.hasAttribute('data-eudr-app'),
+      defaultRole: document.body.hasAttribute('data-eudr-app') ? 'eudr' : 'conservation',
+      defaultPreference: document.body.hasAttribute('data-eudr-app') ? 'report' : 'investigate',
+      enableParcelCostEstimate: document.body.hasAttribute('data-eudr-app'),
+      requiresEudrBillingGate: document.body.hasAttribute('data-eudr-app'),
+      phaseDetails: null,
+    };
+
+  // Resolved app lock state from profile contract.
+  const EUDR_LOCKED = !!activeProfile.lockedWorkspace;
 
   // Base path for the current app entry (/eudr/ or /app/).
-  const APP_BASE = EUDR_LOCKED ? '/eudr/' : '/app/';
+  const APP_BASE = activeProfile.basePath || (EUDR_LOCKED ? '/eudr/' : '/app/');
 
   // Null-safe DOM text setter — used when elements may not exist
   // on all pages (e.g. settings panel absent on EUDR app).
   function setText(id, value) {
+    if (typeof coreDom.setText === 'function') {
+      coreDom.setText(id, value);
+      return;
+    }
     var el = document.getElementById(id);
     if (el) el.textContent = value;
   }
@@ -230,14 +256,6 @@
     fulfilment: 'Downloading scenes, clipping to your AOIs, and reprojecting them into the output stack.',
     enrichment: 'Adding NDVI, weather context, and cached artifacts so the workspace has richer outputs ready.',
     complete: 'Analysis complete — scroll down to review satellite imagery, vegetation health, and export options.'
-  };
-  const EUDR_ANALYSIS_PHASE_DETAILS = {
-    submit: 'Uploading KML and reserving pipeline capacity for this compliance run.',
-    ingestion: 'Parsing parcels, validating geometry, and preparing the evidence request.',
-    acquisition: 'Searching post-2020 Sentinel-2 imagery and polling scene availability for each parcel.',
-    fulfilment: 'Downloading scenes, clipping to parcel boundaries, and reprojecting into the evidence stack.',
-    enrichment: 'Building NDVI time series, deforestation risk, weather, fire, and land-cover evidence layers.',
-    complete: 'Evidence pack complete — scroll down to review per-parcel determination and export compliance records.'
   };
 
   // ---------------------------------------------------------------------------
@@ -394,10 +412,17 @@
   }
 
   function readStoredUiValue(key) {
+    if (typeof coreState.readStoredValue === 'function') {
+      return coreState.readStoredValue(key);
+    }
     try { return localStorage.getItem(key); } catch { return null; }
   }
 
   function storeUiValue(key, value) {
+    if (typeof coreState.storeValue === 'function') {
+      coreState.storeValue(key, value);
+      return;
+    }
     try { localStorage.setItem(key, value); } catch { /* ignore */ }
   }
 
@@ -492,6 +517,7 @@
   function setWorkspaceRole(roleKey, options) {
     if (!WORKSPACE_ROLES[roleKey]) return;
     workspaceRole = roleKey;
+    if (typeof coreState.set === 'function') coreState.set('workspaceRole', roleKey);
     if (!options || options.persist !== false) storeUiValue(WORKSPACE_ROLE_STORAGE_KEY, roleKey);
     renderWorkspaceGuidance();
   }
@@ -499,6 +525,7 @@
   function setWorkspacePreference(preferenceKey, options) {
     if (!WORKSPACE_PREFERENCES[preferenceKey]) return;
     workspacePreference = preferenceKey;
+    if (typeof coreState.set === 'function') coreState.set('workspacePreference', preferenceKey);
     if (!options || options.persist !== false) storeUiValue(WORKSPACE_PREFERENCE_STORAGE_KEY, preferenceKey);
     renderWorkspaceGuidance();
   }
@@ -613,6 +640,9 @@
   }
 
   function normalizeAnalysisRun(run) {
+    if (typeof appRuns.normalizeRun === 'function') {
+      return appRuns.normalizeRun(run);
+    }
     if (!run) return null;
     var normalized = Object.assign({}, run);
     normalized.instanceId = normalized.instanceId || normalized.instance_id || '';
@@ -648,6 +678,9 @@
   }
 
   function sortAnalysisHistoryRuns(runs) {
+    if (typeof appRuns.sortRuns === 'function') {
+      return appRuns.sortRuns(runs, parseStatusTimestamp);
+    }
     return (runs || [])
       .map(normalizeAnalysisRun)
       .filter(Boolean)
@@ -657,6 +690,9 @@
   }
 
   function historyRunIsActive(run) {
+    if (typeof appRuns.isRunActive === 'function') {
+      return appRuns.isRunActive(run);
+    }
     var runtimeStatus = String(run && run.runtimeStatus || '').trim().toLowerCase();
     return ['completed', 'failed', 'terminated', 'canceled'].indexOf(runtimeStatus) === -1;
   }
@@ -740,6 +776,13 @@
   }
 
   function upsertAnalysisHistoryRun(run) {
+    if (typeof appRuns.upsertRun === 'function') {
+      analysisHistoryRuns = appRuns.upsertRun(analysisHistoryRuns, run, parseStatusTimestamp);
+      renderAnalysisHistoryList();
+      applyFirstRunLayout();
+      return;
+    }
+
     var normalized = normalizeAnalysisRun(run);
     if (!normalized) return;
 
@@ -796,6 +839,35 @@
   function applyAnalysisHistory(payload, options) {
     options = options || {};
     var locationSelection = readRunSelectionFromLocation();
+
+    if (typeof appRuns.applyHistoryPayload === 'function') {
+      var applied = appRuns.applyHistoryPayload(
+        payload,
+        options,
+        selectedAnalysisRunId,
+        latestAnalysisRun,
+        locationSelection.instanceId,
+        parseStatusTimestamp
+      );
+
+      latestPortfolioSummary = applied.portfolioSummary;
+      analysisHistoryRuns = applied.runs;
+
+      if (!applied.selectedId) {
+        selectedAnalysisRunId = null;
+        updateRunSelectionLocation('');
+        stopAnalysisPolling();
+        resetAnalysisProgress();
+        renderAnalysisHistoryList();
+        updateAnalysisRun(null);
+        updateHistorySummary(null);
+        return;
+      }
+
+      var selectedRun = analysisHistoryRuns.find(function(run) { return run.instanceId === applied.selectedId; });
+      selectAnalysisRun(applied.selectedId, { resume: historyRunIsActive(selectedRun) });
+      return;
+    }
 
     latestPortfolioSummary = {
       scope: payload && payload.scope,
@@ -945,55 +1017,20 @@
   }
 
   function pickEvidenceDefaultLayer(frame) {
+    if (typeof evidenceMapModule.pickDefaultLayer === 'function') {
+      return evidenceMapModule.pickDefaultLayer(frame);
+    }
     if (!frame) return 'rgb';
     if (frame.preferredLayer === 'ndvi' || frame.preferred_layer === 'ndvi') return 'ndvi';
     return 'rgb';
   }
 
   function pickInitialEvidenceFrameIndex(frames) {
+    if (typeof evidenceMapModule.pickInitialFrameIndex === 'function') {
+      return evidenceMapModule.pickInitialFrameIndex(frames);
+    }
     if (!Array.isArray(frames) || !frames.length) return 0;
-
-    var bestIndex = 0;
-    var bestScore = null;
-
-    frames.forEach(function(frame, idx) {
-      if (!frame) return;
-
-      var rgbSuitable = frame.rgbDisplaySuitable !== false;
-      var resolution = Number(frame.displayResolutionM || 9999);
-      var score = {
-        rgbSuitable: rgbSuitable ? 1 : 0,
-        resolution: Number.isFinite(resolution) ? -resolution : -9999,
-        recency: idx
-      };
-
-      if (!bestScore) {
-        bestScore = score;
-        bestIndex = idx;
-        return;
-      }
-
-      if (score.rgbSuitable > bestScore.rgbSuitable) {
-        bestScore = score;
-        bestIndex = idx;
-        return;
-      }
-
-      if (score.rgbSuitable < bestScore.rgbSuitable) return;
-
-      if (score.resolution > bestScore.resolution) {
-        bestScore = score;
-        bestIndex = idx;
-        return;
-      }
-
-      if (score.resolution === bestScore.resolution && score.recency > bestScore.recency) {
-        bestScore = score;
-        bestIndex = idx;
-      }
-    });
-
-    return bestIndex;
+    return 0;
   }
 
   function syncEvidenceLayerButtons(frame) {
@@ -1059,29 +1096,11 @@
     });
   }
 
-  // #646 — update layer button aria-labels and titles with per-frame
-  // collection and resolution so the picker is self-documenting.
-  function updateLayerButtonLabels(frame) {
-    var btnRgb = document.getElementById('app-map-btn-rgb');
-    var btnNdvi = document.getElementById('app-map-btn-ndvi');
-    var expRgb = document.getElementById('app-map-expanded-btn-rgb');
-    var expNdvi = document.getElementById('app-map-expanded-btn-ndvi');
-    if (!frame) return;
-    var info = frame.collectionLabel
-      ? (frame.collectionLabel + (frame.resLabel || ''))
-      : '';
-    [btnRgb, expRgb].forEach(function(btn) {
-      if (!btn) return;
-      var base = info ? 'True-colour RGB \u2014 ' + info : 'True-colour RGB';
-      // Preserve any quality warning appended by syncEvidenceLayerButtons.
-      if (!btn.disabled) btn.title = base;
-      btn.setAttribute('aria-label', info ? 'RGB (' + info + ')' : 'RGB');
-    });
-    [btnNdvi, expNdvi].forEach(function(btn) {
-      if (!btn) return;
-      btn.title = info ? 'Vegetation index (NDVI) \u2014 ' + info : 'Vegetation index (NDVI)';
-      btn.setAttribute('aria-label', info ? 'NDVI (' + info + ')' : 'NDVI');
-    });
+  function setEvidenceLayerMode(mode) {
+    if (mode !== 'rgb' && mode !== 'ndvi') return;
+    evidenceLayerMode = mode;
+    syncLayerModeButtons();
+    showEvidenceFrame(evidenceFrameIndex);
   }
 
   function showEvidenceSurface(visible) {
@@ -2048,6 +2067,9 @@
   }
 
   function buildEvidenceNdviTimeseries(source) {
+    if (typeof evidenceMapModule.buildNdviTimeseries === 'function') {
+      return evidenceMapModule.buildNdviTimeseries(source);
+    }
     if (!source) return [];
     return (source.ndvi_stats || []).map(function(f, i) {
       if (!f) return null;
@@ -2064,6 +2086,9 @@
   }
 
   function evidenceLatLon(source) {
+    if (typeof evidenceMapModule.latLon === 'function') {
+      return evidenceMapModule.latLon(source);
+    }
     if (!source) return { lat: 0, lon: 0 };
     var center = source.center || source.coords;
     if (Array.isArray(center)) {
@@ -2159,6 +2184,7 @@
 
     var runtimeStatus = data.runtimeStatus || 'Pending';
     var phase = (data.customStatus && data.customStatus.phase) || 'queued';
+    var phaseCopy = (activeProfile.contentPhaseCopy && activeProfile.contentPhaseCopy[phase]) || {};
 
     if (runtimeStatus === 'Completed') {
       // Evidence surface is loaded by loadRunEvidence(), triggered from selectAnalysisRun
@@ -2190,46 +2216,30 @@
 
     if (phase === 'acquisition') {
       imageryEl.textContent = 'Scene search underway';
-      imageryNoteEl.textContent = EUDR_LOCKED
-        ? 'Sentinel-2 post-2020 imagery discovery is in progress for each parcel.'
-        : 'NAIP and Sentinel-2 discovery is in progress so the run can pick the right source imagery.';
+      imageryNoteEl.textContent = phaseCopy.imageryNote || 'NAIP and Sentinel-2 discovery is in progress so the run can pick the right source imagery.';
       enrichmentEl.textContent = 'Queued behind acquisition';
       enrichmentNoteEl.textContent = 'Context layers are staged after the imagery stack is selected.';
       exportsEl.textContent = 'Awaiting artefacts';
-      exportsNoteEl.textContent = EUDR_LOCKED
-        ? 'Evidence pack exports are unavailable until imagery is acquired.'
-        : 'There is nothing to export until imagery is actually acquired.';
+      exportsNoteEl.textContent = phaseCopy.exportsNote || 'There is nothing to export until imagery is actually acquired.';
       return;
     }
 
     if (phase === 'fulfilment') {
       imageryEl.textContent = 'Clipping and reprojection';
-      imageryNoteEl.textContent = EUDR_LOCKED
-        ? 'The pipeline is clipping scenes to parcel boundaries for the evidence stack.'
-        : 'The pipeline is producing imagery assets for your analysis.';
+      imageryNoteEl.textContent = phaseCopy.imageryNote || 'The pipeline is producing imagery assets for your analysis.';
       enrichmentEl.textContent = 'Preparing next';
-      enrichmentNoteEl.textContent = EUDR_LOCKED
-        ? 'Deforestation risk, NDVI time series, and land-cover evidence will follow immediately.'
-        : 'NDVI and weather context will follow immediately after fulfilment finishes.';
+      enrichmentNoteEl.textContent = phaseCopy.enrichmentNote || 'NDVI and weather context will follow immediately after fulfilment finishes.';
       exportsEl.textContent = 'Outputs staging next';
-      exportsNoteEl.textContent = EUDR_LOCKED
-        ? 'Compliance exports are close — the evidence pack is being assembled.'
-        : 'The run is close enough that saved outputs should feel tangible, not hypothetical.';
+      exportsNoteEl.textContent = phaseCopy.exportsNote || 'The run is close enough that saved outputs should feel tangible, not hypothetical.';
       return;
     }
 
     imageryEl.textContent = 'Imagery stack stabilizing';
-    imageryNoteEl.textContent = EUDR_LOCKED
-      ? 'Sentinel-2 and land-cover layers are in place; final evidence layers being added.'
-      : 'Core imagery is in place and the workspace is adding the last supporting layers.';
+    imageryNoteEl.textContent = phaseCopy.imageryNote || 'Core imagery is in place and the workspace is adding the last supporting layers.';
     enrichmentEl.textContent = 'Context packaging';
-    enrichmentNoteEl.textContent = EUDR_LOCKED
-      ? 'Per-parcel deforestation determination, NDVI, weather, fire, and land-cover evidence are being assembled.'
-      : 'NDVI, weather, and derived context are being assembled for the run detail experience.';
+    enrichmentNoteEl.textContent = phaseCopy.enrichmentNote || 'NDVI, weather, and derived context are being assembled for the run detail experience.';
     exportsEl.textContent = 'Preparing results view';
-    exportsNoteEl.textContent = EUDR_LOCKED
-      ? 'Audit-grade PDF, GeoJSON, and CSV exports for compliance records will be available shortly.'
-      : 'Saved outputs, exports, and revisit paths will be available shortly.';
+    exportsNoteEl.textContent = phaseCopy.exportsNote || 'Saved outputs, exports, and revisit paths will be available shortly.';
   }
 
   function updateRunDetail(data) {
@@ -2437,6 +2447,9 @@
   }
 
   function mapAnalysisPhase(customStatus, runtimeStatus) {
+    if (typeof appRuns.mapPhase === 'function') {
+      return appRuns.mapPhase(customStatus, runtimeStatus, ANALYSIS_PHASES);
+    }
     if (runtimeStatus === 'Completed') return 'complete';
     if (customStatus && customStatus.phase && ANALYSIS_PHASES.indexOf(customStatus.phase) > -1) {
       return customStatus.phase;
@@ -2515,7 +2528,7 @@
 
   function updateAnalysisStory(phase, runtimeStatus, data) {
     var runtime = runtimeStatus || 'Pending';
-    var phaseDetails = EUDR_LOCKED ? EUDR_ANALYSIS_PHASE_DETAILS : ANALYSIS_PHASE_DETAILS;
+    var phaseDetails = activeProfile.phaseDetails || ANALYSIS_PHASE_DETAILS;
     var detail = phaseDetails[phase] || 'Working through the analysis pipeline.';
     var timing = summarizeRunTiming(data);
 
@@ -2580,8 +2593,8 @@
     } else if (preflight.maxSpreadKm > 25) {
       warnings.push({ tone: 'info', text: 'AOI spread is ' + formatDistance(preflight.maxSpreadKm) + '. All areas will be processed in one run.' });
     }
-    if (workspaceRole === 'eudr') {
-      warnings.push({ tone: 'info', text: 'This due diligence lens frames evidence for review and audit support. It is not a legal compliance certificate.' });
+    if (activeProfile.preflightDisclaimer) {
+      warnings.push({ tone: 'info', text: activeProfile.preflightDisclaimer });
     }
     if (workspaceRole === 'portfolio' && preflight.aoiCount > 10) {
       warnings.push({ tone: 'info', text: 'Large parcel sets work well with batch analysis. This run still enters your tracked workflow.' });
@@ -2695,27 +2708,24 @@
 
   // ── Cost estimator for EUDR preflight ────────────────────────
   function computeEudrCostEstimate(parcelCount) {
-    if (!EUDR_LOCKED || !parcelCount) return '—';
+    if (typeof eudrModule.computeCostEstimate === 'function') {
+      return eudrModule.computeCostEstimate(parcelCount, activeProfile);
+    }
+    if (!activeProfile.enableParcelCostEstimate || !parcelCount) return '—';
     var billing = typeof window.eudrBillingData === 'function' ? window.eudrBillingData() : null;
     if (!billing) return '—';
-
     if (!billing.subscribed) {
       var remaining = billing.trial_remaining != null ? billing.trial_remaining : 0;
       if (remaining > 0) return parcelCount + ' parcel' + (parcelCount !== 1 ? 's' : '') + ' · ' + remaining + ' free assessment' + (remaining !== 1 ? 's' : '') + ' left';
       return 'Subscribe to continue';
     }
-
-    // Pro subscriber — estimate only the incremental overage caused by this submission
     var used = billing.period_parcels_used || 0;
     var included = billing.included_parcels || 10;
     var remainingIncluded = Math.max(included - used, 0);
     var overageParcels = Math.max(parcelCount - remainingIncluded, 0);
-    if (overageParcels === 0) {
-      return parcelCount + ' parcel' + (parcelCount !== 1 ? 's' : '') + ' included';
-    }
+    if (overageParcels === 0) return parcelCount + ' parcel' + (parcelCount !== 1 ? 's' : '') + ' included';
     var rate = overageParcels >= 500 ? 1.80 : overageParcels >= 100 ? 2.50 : 3.00;
-    var cost = (overageParcels * rate).toFixed(2);
-    return overageParcels + ' overage × £' + rate.toFixed(2) + ' = £' + cost;
+    return overageParcels + ' overage × £' + rate.toFixed(2) + ' = £' + (overageParcels * rate).toFixed(2);
   }
 
   // ── Input tab switching (KML / CSV) ──────────────────────────
@@ -2733,41 +2743,7 @@
   }
 
   // ── CSV coordinate parsing and conversion ───────────────────
-  function parseCSVCoordinates(text) {
-    var lines = text.trim().split(/\r?\n/).filter(Boolean);
-    if (lines.length === 0) return { plots: [], errors: ['No data entered'] };
-
-    var plots = [];
-    var errors = [];
-    var startIdx = 0;
-
-    // Detect header row
-    var firstLine = lines[0].toLowerCase().replace(/\s/g, '');
-    if (firstLine.indexOf('name') >= 0 && (firstLine.indexOf('lat') >= 0 || firstLine.indexOf('lon') >= 0)) {
-      startIdx = 1;
-    }
-
-    for (var i = startIdx; i < lines.length; i++) {
-      var parts = lines[i].split(',').map(function(s) { return s.trim(); });
-      if (parts.length < 3) {
-        errors.push('Row ' + (i + 1) + ': expected name, lat, lon — got ' + parts.length + ' columns');
-        continue;
-      }
-      var name = parts[0] || 'Parcel ' + (plots.length + 1);
-      var lat = parseFloat(parts[1]);
-      var lon = parseFloat(parts[2]);
-      if (isNaN(lat) || isNaN(lon)) {
-        errors.push('Row ' + (i + 1) + ': invalid coordinates (' + parts[1] + ', ' + parts[2] + ')');
-        continue;
-      }
-      if (lat < -90 || lat > 90 || lon < -180 || lon > 180) {
-        errors.push('Row ' + (i + 1) + ': coordinates out of range (lat: ' + lat + ', lon: ' + lon + ')');
-        continue;
-      }
-      plots.push({ name: name, lat: lat, lon: lon });
-    }
-    return { plots: plots, errors: errors };
-  }
+  // parseCSVCoordinates is extracted to canopex-geo.js — accessed via the alias at the top.
 
   async function convertCSVToKml() {
     var textarea = document.getElementById('app-csv-input');
@@ -3038,7 +3014,7 @@
 
     // EUDR entitlement gate: show subscribe modal when trial is exhausted.
     // If billing hasn't loaded yet, fetch it before deciding.
-    if (EUDR_LOCKED && typeof window.eudrBillingData === 'function') {
+    if (activeProfile.requiresEudrBillingGate && typeof window.eudrBillingData === 'function') {
       var billing = window.eudrBillingData();
       if (!billing) {
         try {
@@ -3193,171 +3169,26 @@
   }
 
   async function manageBilling() {
-    // If billing is gated for this user, redirect to express interest
-    if (latestBillingStatus && latestBillingStatus.billing_gated) {
-      window.location.href = 'mailto:hello@canopex.io';
-      return;
-    }
-
-    if (!currentAccount) {
-      login();
-      return;
-    }
-
-    await apiDiscoveryReady;
-    try {
-      var res = await apiFetch('/api/billing/portal', { method: 'POST' });
-      var data = await res.json();
-      if (data.portal_url) window.location.href = data.portal_url;
-    } catch (err) {
-      alert((err && err.message) || 'Could not open billing portal. Please try again.');
-    }
+    if (typeof billingModule.manage === 'function') return billingModule.manage();
+    // fallback: redirect to interest mailto
+    window.location.href = 'mailto:hello@canopex.io';
   }
 
-  function updateCapabilityFields(caps) {
-    document.getElementById('app-concurrency').textContent = caps.concurrency == null ? '—' : String(caps.concurrency);
-    document.getElementById('app-ai-access').textContent = caps.ai_insights ? 'Included' : 'Not included';
-    document.getElementById('app-api-access').textContent = caps.api_access ? 'Enabled' : 'Not included';
-    document.getElementById('app-retention').textContent = formatRetention(caps.retention_days);
-  }
-
-  function renderTierEmulation(data) {
-    var card = document.getElementById('app-tier-emulation-card');
-    var select = document.getElementById('app-tier-emulation-select');
-    var note = document.getElementById('app-tier-emulation-note');
-
-    if (!card || !select || !note) return;
-
-    if (!data.emulation || !data.emulation.available) {
-      card.hidden = true;
-      return;
-    }
-
-    card.hidden = false;
-    select.replaceChildren();
-
-    var actualOption = document.createElement('option');
-    actualOption.value = 'actual';
-    actualOption.textContent = 'Actual billing state';
-    select.appendChild(actualOption);
-
-    (data.emulation.tiers || []).forEach(function(tier) {
-      var option = document.createElement('option');
-      option.value = tier;
-      option.textContent = tier.charAt(0).toUpperCase() + tier.slice(1);
-      select.appendChild(option);
-    });
-
-    select.value = data.emulation.active ? data.emulation.tier : 'actual';
-    if (data.emulation.active) {
-      note.textContent = 'Currently emulating ' + (data.capabilities.label || data.tier) + ' for your account. Billing remains ' + ((data.subscription && data.subscription.tier) || 'free') + '.';
-    } else {
-      note.textContent = 'Using the actual billing state for this account.';
-    }
-  }
+  // updateCapabilityFields and renderTierEmulation are internal to app-billing.js
 
   function applyBillingStatus(data) {
-    var tierEl = document.getElementById('app-tier');
-    var statusEl = document.getElementById('app-subscription-status');
-    var remainingEl = document.getElementById('app-runs-remaining');
-    var billingNoteEl = document.getElementById('app-billing-note');
-    var billingBtn = document.getElementById('app-manage-billing-btn');
-    var accountNote = document.getElementById('app-account-note');
-    var caps = data.capabilities || {};
-
+    if (typeof billingModule.apply === 'function') return billingModule.apply(data);
+    // fallback: update shell state only
     latestBillingStatus = data;
-    tierEl.textContent = (caps.label || data.tier || 'Free') + (data.tier_source === 'emulated' ? ' (emulated)' : '');
-    statusEl.textContent = data.status || 'none';
-    remainingEl.textContent = data.runs_remaining == null ? '—' : String(data.runs_remaining);
-    var usedEl = document.getElementById('app-runs-used');
-    if (usedEl) usedEl.textContent = data.runs_used == null ? '—' : String(data.runs_used);
-    updateCapabilityFields(caps);
-
-    if (data.tier_source === 'emulated') {
-      billingNoteEl.textContent = 'Local tier override active. Real billing is ' + ((data.subscription && data.subscription.tier) || 'free') + '.';
-      billingBtn.style.display = data.billing_configured ? 'inline-block' : 'none';
-      accountNote.textContent = 'Use the role view and work preference controls to tune this workspace for the job at hand.';
-    } else if (data.billing_gated) {
-      billingNoteEl.textContent = 'Billing is not yet available for your account. Contact us to express interest.';
-      billingBtn.textContent = 'Express Interest';
-      billingBtn.style.display = 'inline-block';
-      accountNote.textContent = 'You are on the free plan. Express interest to unlock paid tiers when billing becomes available.';
-    } else if (data.billing_configured) {
-      billingNoteEl.textContent = 'Stripe customer portal available';
-      billingBtn.textContent = 'Billing';
-      billingBtn.style.display = 'inline-block';
-      accountNote.textContent = 'Use the role view and work preference controls to bias the workspace toward investigation, monitoring, or reporting.';
-    } else {
-      billingNoteEl.textContent = 'Billing is not configured in this environment';
-      billingBtn.style.display = 'none';
-      accountNote.textContent = 'Use the role view and work preference controls to bias the workspace toward investigation, monitoring, or reporting.';
-    }
-
     updateHeroSummary(data);
-    renderTierEmulation(data);
-
-    // Show EUDR toggle only for paid tiers
-    var eudrToggle = document.getElementById('app-eudr-toggle');
-    if (eudrToggle) {
-      var paidTiers = ['starter', 'pro', 'team', 'enterprise'];
-      eudrToggle.hidden = !paidTiers.includes(data.tier);
-    }
   }
 
   async function saveTierEmulation() {
-    if (!currentAccount) {
-      login();
-      return;
-    }
-
-    var button = document.getElementById('app-apply-tier-emulation-btn');
-    var select = document.getElementById('app-tier-emulation-select');
-    if (!button || !select) return;
-
-    button.disabled = true;
-    button.textContent = 'Applying…';
-    try {
-      await apiDiscoveryReady;
-      var res = await apiFetch('/api/billing/emulation', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ tier: select.value })
-      });
-      clearCacheKey('billing');
-      applyBillingStatus(await res.json());
-    } catch (err) {
-      alert((err && err.message) || 'Could not update plan emulation. Please try again.');
-    } finally {
-      button.disabled = false;
-      button.textContent = 'Apply';
-    }
+    if (typeof billingModule.saveEmulation === 'function') return billingModule.saveEmulation();
   }
 
   async function loadBillingStatus() {
-    await apiDiscoveryReady;
-    if (!currentAccount) return;
-
-    // Render cached billing data instantly while fetching fresh data
-    const cached = readCache('billing');
-    if (cached) applyBillingStatus(cached);
-
-    try {
-      const res = await apiFetch('/api/billing/status');
-      const data = await res.json();
-      writeCache('billing', data, CACHE_TTL_BILLING);
-      applyBillingStatus(data);
-    } catch {
-      // Only show error state if we had no cached data to show
-      if (!cached) {
-        document.getElementById('app-tier').textContent = 'Unknown';
-        document.getElementById('app-subscription-status').textContent = 'Unavailable';
-        document.getElementById('app-runs-remaining').textContent = '—';
-        document.getElementById('app-billing-note').textContent = 'Could not load billing state';
-        document.getElementById('app-manage-billing-btn').style.display = 'none';
-        updateCapabilityFields({});
-        setHeroRunSummary('Ready to queue', 'Billing is unavailable, but analysis can still be launched locally.');
-      }
-    }
+    if (typeof billingModule.load === 'function') return billingModule.load();
   }
 
   /* ---- EUDR usage dashboard (#670) ---- */
@@ -3421,7 +3252,7 @@
     await apiDiscoveryReady;
     if (!currentAccount && authEnabled()) return;
 
-    var historyScope = EUDR_LOCKED ? 'org' : 'user';
+    var historyScope = activeProfile.historyScope || 'user';
     var historyCacheKey = historyScope === 'org' ? 'history-org' : 'history';
 
     // Render cached history instantly while fetching fresh data
@@ -3584,13 +3415,38 @@
   }
 
   apiDiscoveryReady = discoverApiBase();
+
+  // Initialise billing module before auth so loadBillingStatus works on first sign-in.
+  if (typeof billingModule.init === 'function') {
+    billingModule.init({
+      apiFetch: apiFetch,
+      getApiReady: function () { return apiDiscoveryReady; },
+      getAccount: function () { return currentAccount; },
+      login: login,
+      readCache: readCache,
+      writeCache: writeCache,
+      clearCacheKey: clearCacheKey,
+      onStatusChange: function (data) {
+        latestBillingStatus = data;
+        updateHeroSummary(data);
+      },
+      onLoadError: function () {
+        setHeroRunSummary('Ready to queue', 'Billing is unavailable, but analysis can still be launched locally.');
+      }
+    });
+  }
+
   initAuth();
   if (EUDR_LOCKED) {
-    workspaceRole = 'eudr';
-    workspacePreference = 'report';
+    workspaceRole = activeProfile.defaultRole || 'eudr';
+    workspacePreference = activeProfile.defaultPreference || 'report';
   } else {
     workspaceRole = readStoredUiValue(WORKSPACE_ROLE_STORAGE_KEY) || workspaceRole;
     workspacePreference = readStoredUiValue(WORKSPACE_PREFERENCE_STORAGE_KEY) || workspacePreference;
+  }
+  if (typeof coreState.set === 'function') {
+    coreState.set('workspaceRole', workspaceRole);
+    coreState.set('workspacePreference', workspacePreference);
   }
   renderWorkspaceGuidance();
 
@@ -3608,6 +3464,10 @@
 
   // Bind click handlers — guarded for elements that only exist on some pages.
   function bindClick(id, handler) {
+    if (typeof coreDom.bindClick === 'function') {
+      coreDom.bindClick(id, handler);
+      return;
+    }
     var el = document.getElementById(id);
     if (el) el.addEventListener('click', handler);
   }
@@ -3672,18 +3532,8 @@
   bindClick('app-map-play-btn', toggleEvidencePlay);
   var frameSlider = document.getElementById('app-map-frame-slider');
   if (frameSlider) frameSlider.addEventListener('input', function() { showEvidenceFrame(parseInt(this.value, 10)); });
-  bindClick('app-map-btn-rgb', function() {
-    evidenceLayerMode = 'rgb';
-    document.getElementById('app-map-btn-rgb').classList.add('active');
-    document.getElementById('app-map-btn-ndvi').classList.remove('active');
-    showEvidenceFrame(evidenceFrameIndex);
-  });
-  bindClick('app-map-btn-ndvi', function() {
-    evidenceLayerMode = 'ndvi';
-    document.getElementById('app-map-btn-ndvi').classList.add('active');
-    document.getElementById('app-map-btn-rgb').classList.remove('active');
-    showEvidenceFrame(evidenceFrameIndex);
-  });
+  bindClick('app-map-btn-rgb', function() { setEvidenceLayerMode('rgb'); });
+  bindClick('app-map-btn-ndvi', function() { setEvidenceLayerMode('ndvi'); });
   bindClick('app-evidence-ai-btn', requestAiAnalysis);
   bindClick('app-evidence-eudr-btn', requestEudrAssessment);
   // Expanded map viewer controls
@@ -3740,20 +3590,6 @@
   bindClick('app-map-expanded-play-btn', toggleEvidencePlay);
   var expandedSlider = document.getElementById('app-map-expanded-slider');
   if (expandedSlider) expandedSlider.addEventListener('input', function() { showEvidenceFrame(parseInt(this.value, 10)); });
-  bindClick('app-map-expanded-btn-rgb', function() {
-    evidenceLayerMode = 'rgb';
-    document.getElementById('app-map-expanded-btn-rgb').classList.add('active');
-    document.getElementById('app-map-expanded-btn-ndvi').classList.remove('active');
-    document.getElementById('app-map-btn-rgb').classList.add('active');
-    document.getElementById('app-map-btn-ndvi').classList.remove('active');
-    showEvidenceFrame(evidenceFrameIndex);
-  });
-  bindClick('app-map-expanded-btn-ndvi', function() {
-    evidenceLayerMode = 'ndvi';
-    document.getElementById('app-map-expanded-btn-ndvi').classList.add('active');
-    document.getElementById('app-map-expanded-btn-rgb').classList.remove('active');
-    document.getElementById('app-map-btn-ndvi').classList.add('active');
-    document.getElementById('app-map-btn-rgb').classList.remove('active');
-    showEvidenceFrame(evidenceFrameIndex);
-  });
+  bindClick('app-map-expanded-btn-rgb', function() { setEvidenceLayerMode('rgb'); });
+  bindClick('app-map-expanded-btn-ndvi', function() { setEvidenceLayerMode('ndvi'); });
 })();

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -50,6 +50,7 @@
   var eudrModule = window.CanopexEudr || {};
   var billingModule = window.CanopexBilling || {};
   var evidencePanelsModule = window.CanopexEvidencePanels || {};
+  var preflightModule = window.CanopexAnalysisPreflight || {};
   var _apiClient = window.CanopexApiClient ? window.CanopexApiClient.createClient() : null;
 
   const POST_LOGIN_DESTINATION_KEY = 'canopex-post-login';
@@ -2368,351 +2369,31 @@
     setAnalysisStatus(detail, 'info');
   }
 
+  /* ---- Analysis preflight + file input — delegated to app-analysis-preflight.js ---- */
+
   function buildPreflightWarnings(preflight) {
-    var warnings = [];
-    if (preflight.aoiCount > 30) {
-      warnings.push({ tone: 'warning', text: preflight.aoiCount + ' AOIs detected. Large batches may take longer and could be split across runs.' });
-    } else if (preflight.aoiCount > 6) {
-      warnings.push({ tone: 'info', text: preflight.aoiCount + ' AOIs — this will queue as a bulk-ready run.' });
+    if (typeof preflightModule.buildAnalysisPreflight === 'function') {
+      // Warnings are generated inside updateAnalysisPreflight; expose for queueAnalysis use.
     }
-    if (preflight.largestAreaHa > 50000) {
-      warnings.push({ tone: 'warning', text: 'At least one AOI covers ' + formatHectares(preflight.largestAreaHa) + '. Very large areas may produce lower-resolution output.' });
-    }
-    if (preflight.maxSpreadKm > 100) {
-      warnings.push({ tone: 'warning', text: 'AOI spread is ' + formatDistance(preflight.maxSpreadKm) + '. Widely spread areas may need batching in a future release.' });
-    } else if (preflight.maxSpreadKm > 25) {
-      warnings.push({ tone: 'info', text: 'AOI spread is ' + formatDistance(preflight.maxSpreadKm) + '. All areas will be processed in one run.' });
-    }
-    if (activeProfile.preflightDisclaimer) {
-      warnings.push({ tone: 'info', text: activeProfile.preflightDisclaimer });
-    }
-    if (workspaceRole === 'portfolio' && preflight.aoiCount > 10) {
-      warnings.push({ tone: 'info', text: 'Large parcel sets work well with batch analysis. This run still enters your tracked workflow.' });
-    }
-    if (!warnings.length) {
-      warnings.push({ tone: 'info', text: 'No warnings. This will queue as one tracked analysis run.' });
-    }
-    return warnings;
-  }
-
-  function buildAnalysisPreflight(text) {
-    var trimmed = parseKmlText(text);
-    if (!trimmed) return null;
-
-    var parsed = parseKmlGeometry(trimmed);
-    if (parsed.error) return { error: parsed.error };
-    if (!parsed.polygons || !parsed.polygons.length) {
-      return { error: 'No polygon boundaries were detected. Canopex expects polygon AOIs.' };
-    }
-
-    var centroids = parsed.polygons.map(function(polygon) { return polygonCentroid(polygon.coords); });
-    var groupLat = centroids.reduce(function(sum, coord) { return sum + coord[0]; }, 0) / centroids.length;
-    var groupLon = centroids.reduce(function(sum, coord) { return sum + coord[1]; }, 0) / centroids.length;
-    var maxSpreadKm = centroids.reduce(function(maxDistance, coord) {
-      return Math.max(maxDistance, haversineKm(groupLat, groupLon, coord[0], coord[1]));
-    }, 0);
-    var totalAreaHa = parsed.polygons.reduce(function(sum, polygon) {
-      return sum + polygonAreaHa(polygon.coords);
-    }, 0);
-    var largestAreaHa = parsed.polygons.reduce(function(maxArea, polygon) {
-      return Math.max(maxArea, polygonAreaHa(polygon.coords));
-    }, 0);
-    var processingMode = determineProcessingMode(parsed.polygons.length, maxSpreadKm);
-    var preference = currentPreferenceConfig();
-
-    var preflight = {
-      featureCount: parsed.featureCount,
-      aoiCount: parsed.polygons.length,
-      polygons: parsed.polygons,
-      maxSpreadKm: maxSpreadKm,
-      totalAreaHa: totalAreaHa,
-      largestAreaHa: largestAreaHa,
-      processingMode: processingMode,
-      quotaImpact: latestBillingStatus && latestBillingStatus.runs_remaining != null
-        ? '1 of ' + latestBillingStatus.runs_remaining + ' runs'
-        : '1 analysis',
-      summary: parsed.featureCount + ' features across ' + parsed.polygons.length + ' AOIs covering about ' + formatHectares(totalAreaHa) + '. ' + processingMode + ' processing for this request.'
-    };
-    preflight.warnings = buildPreflightWarnings(preflight);
-    return preflight;
-  }
-
-  var preflightMap = null;
-
-  function renderPreflightMap(polygons) {
-    var wrap = document.getElementById('app-preflight-map-wrap');
-    var container = document.getElementById('app-preflight-map');
-    if (!wrap || !container) return;
-
-    if (!polygons || !polygons.length) {
-      wrap.hidden = true;
-      if (preflightMap) { preflightMap.remove(); preflightMap = null; }
-      return;
-    }
-
-    wrap.hidden = false;
-
-    if (preflightMap) { preflightMap.remove(); preflightMap = null; }
-
-    preflightMap = L.map(container, {
-      zoomControl: true,
-      attributionControl: true,
-      scrollWheelZoom: false,
-      dragging: true
-    });
-
-    L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
-      maxZoom: 19,
-      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/">CARTO</a>'
-    }).addTo(preflightMap);
-
-    var bounds = L.latLngBounds([]);
-    polygons.forEach(function(polygon) {
-      var layer = L.polygon(polygon.coords, {
-        color: '#5eecc4',
-        weight: 2,
-        fillColor: '#5eecc4',
-        fillOpacity: 0.15
-      }).addTo(preflightMap);
-      var tip = document.createElement('span');
-      tip.textContent = polygon.name;
-      layer.bindTooltip(tip, { sticky: true });
-      bounds.extend(layer.getBounds());
-    });
-
-    preflightMap.fitBounds(bounds, { padding: [24, 24], maxZoom: 15 });
-  }
-
-  function renderPreflightWarnings(items) {
-    var list = document.getElementById('app-preflight-warnings');
-    if (!list) return;
-    list.replaceChildren();
-    items.forEach(function(item) {
-      var el = document.createElement('div');
-      el.className = 'app-preflight-item';
-      el.setAttribute('data-tone', item.tone || 'info');
-      el.textContent = item.text;
-      list.appendChild(el);
-    });
-  }
-
-  // ── Cost estimator for EUDR preflight ────────────────────────
-  function computeEudrCostEstimate(parcelCount) {
-    if (typeof eudrModule.computeCostEstimate === 'function') {
-      return eudrModule.computeCostEstimate(parcelCount, activeProfile);
-    }
-    if (!activeProfile.enableParcelCostEstimate || !parcelCount) return '—';
-    var billing = typeof window.eudrBillingData === 'function' ? window.eudrBillingData() : null;
-    if (!billing) return '—';
-    if (!billing.subscribed) {
-      var remaining = billing.trial_remaining != null ? billing.trial_remaining : 0;
-      if (remaining > 0) return parcelCount + ' parcel' + (parcelCount !== 1 ? 's' : '') + ' · ' + remaining + ' free assessment' + (remaining !== 1 ? 's' : '') + ' left';
-      return 'Subscribe to continue';
-    }
-    var used = billing.period_parcels_used || 0;
-    var included = billing.included_parcels || 10;
-    var remainingIncluded = Math.max(included - used, 0);
-    var overageParcels = Math.max(parcelCount - remainingIncluded, 0);
-    if (overageParcels === 0) return parcelCount + ' parcel' + (parcelCount !== 1 ? 's' : '') + ' included';
-    var rate = overageParcels >= 500 ? 1.80 : overageParcels >= 100 ? 2.50 : 3.00;
-    return overageParcels + ' overage × £' + rate.toFixed(2) + ' = £' + (overageParcels * rate).toFixed(2);
-  }
-
-  // ── Input tab switching (KML / CSV) ──────────────────────────
-  function switchInputTab(tabName) {
-    var tabs = document.querySelectorAll('[data-input-tab]');
-    tabs.forEach(function(tab) {
-      var isActive = tab.getAttribute('data-input-tab') === tabName;
-      tab.classList.toggle('active', isActive);
-      tab.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-    });
-    var kmlPanel = document.getElementById('app-input-panel-kml');
-    var csvPanel = document.getElementById('app-input-panel-csv');
-    if (kmlPanel) kmlPanel.hidden = tabName !== 'kml';
-    if (csvPanel) csvPanel.hidden = tabName !== 'csv';
-  }
-
-  // ── CSV coordinate parsing and conversion ───────────────────
-  // parseCSVCoordinates is extracted to canopex-geo.js — accessed via the alias at the top.
-
-  async function convertCSVToKml() {
-    var textarea = document.getElementById('app-csv-input');
-    var statusEl = document.getElementById('app-csv-status');
-    var convertBtn = document.getElementById('app-csv-convert-btn');
-    if (!textarea || !statusEl) return;
-
-    var text = textarea.value.trim();
-    if (!text) {
-      statusEl.hidden = false;
-      statusEl.setAttribute('data-tone', 'error');
-      statusEl.textContent = 'Paste coordinate data first.';
-      return;
-    }
-
-    var parsed = parseCSVCoordinates(text);
-    if (parsed.errors.length > 0 && parsed.plots.length === 0) {
-      statusEl.hidden = false;
-      statusEl.setAttribute('data-tone', 'error');
-      statusEl.textContent = parsed.errors.join('; ');
-      return;
-    }
-    if (parsed.plots.length === 0) {
-      statusEl.hidden = false;
-      statusEl.setAttribute('data-tone', 'error');
-      statusEl.textContent = 'No valid coordinates found.';
-      return;
-    }
-
-    if (convertBtn) { convertBtn.disabled = true; convertBtn.textContent = 'Converting…'; }
-    statusEl.hidden = false;
-    statusEl.setAttribute('data-tone', 'info');
-    var warningText = parsed.errors.length > 0 ? ' (' + parsed.errors.length + ' rows skipped)' : '';
-    statusEl.textContent = 'Converting ' + parsed.plots.length + ' parcels…' + warningText;
-
-    try {
-      await apiDiscoveryReady;
-      var res = await apiFetch('/api/convert-coordinates', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ doc_name: 'EUDR Parcels', buffer_m: 100, plots: parsed.plots })
-      });
-      var kmlText = await res.text();
-
-      // Put converted KML into the KML textarea and switch to KML tab
-      var kmlTextarea = document.getElementById('app-analysis-kml');
-      if (kmlTextarea) {
-        kmlTextarea.value = kmlText;
-        updateAnalysisPreflight(kmlText);
-      }
-      switchInputTab('kml');
-      statusEl.hidden = true;
-
-      var fileNote = document.getElementById('app-analysis-file-note');
-      if (fileNote) fileNote.textContent = 'Generated from ' + parsed.plots.length + ' coordinate' + (parsed.plots.length !== 1 ? 's' : '') + '.';
-    } catch (err) {
-      statusEl.setAttribute('data-tone', 'error');
-      statusEl.textContent = (err.body && err.body.error) || 'Coordinate conversion failed. Check your data and try again.';
-    } finally {
-      if (convertBtn) { convertBtn.disabled = false; convertBtn.textContent = 'Convert to KML'; }
-    }
+    // Fallback: basic check only — real logic is in the module.
+    return [{ tone: 'info', text: 'No warnings. This will queue as one tracked analysis run.' }];
   }
 
   function updateAnalysisPreflight(text) {
-    var headlineEl = document.getElementById('app-preflight-headline');
-    var modeEl = document.getElementById('app-preflight-mode');
-    var summaryEl = document.getElementById('app-preflight-summary');
-    var featuresEl = document.getElementById('app-preflight-features');
-    var aoisEl = document.getElementById('app-preflight-aois');
-    var spreadEl = document.getElementById('app-preflight-spread');
-    var quotaEl = document.getElementById('app-preflight-quota');
-    var costEl = document.getElementById('app-preflight-cost');
-    if (!headlineEl || !modeEl || !summaryEl || !featuresEl || !aoisEl || !spreadEl || !quotaEl) return null;
-
-    var role = currentRoleConfig();
-    var trimmed = parseKmlText(text);
-    if (!trimmed) {
-      analysisDraftSummary = null;
-      headlineEl.textContent = 'Awaiting KML';
-      modeEl.textContent = 'No file yet';
-      summaryEl.textContent = 'Paste KML to see feature count, area spread, and guidance for the ' + role.label + ' view.';
-      featuresEl.textContent = '0';
-      aoisEl.textContent = '0';
-      spreadEl.textContent = '—';
-      quotaEl.textContent = '—';
-      if (costEl) costEl.textContent = '—';
-      renderPreflightWarnings([{ tone: 'info', text: 'Preflight will show warnings here after you paste or upload KML.' }]);
-      renderPreflightMap(null);
-      var submitBtn = document.getElementById('app-analysis-submit-btn');
-      if (submitBtn) submitBtn.textContent = 'Queue Analysis';
-      return null;
-    }
-
-    var preflight = buildAnalysisPreflight(trimmed);
-    analysisDraftSummary = preflight;
-    if (preflight && preflight.error) {
-      headlineEl.textContent = 'KML needs attention';
-      modeEl.textContent = 'Check geometry';
-      summaryEl.textContent = preflight.error;
-      featuresEl.textContent = '—';
-      aoisEl.textContent = '—';
-      spreadEl.textContent = '—';
-      quotaEl.textContent = '—';
-      if (costEl) costEl.textContent = '—';
-      renderPreflightWarnings([{ tone: 'error', text: preflight.error }]);
-      renderPreflightMap(null);
-      return preflight;
-    }
-
-    headlineEl.textContent = preflight.aoiCount + '-AOI request ready';
-    modeEl.textContent = preflight.processingMode;
-    summaryEl.textContent = preflight.summary;
-    featuresEl.textContent = String(preflight.featureCount);
-    aoisEl.textContent = String(preflight.aoiCount);
-    spreadEl.textContent = formatDistance(preflight.maxSpreadKm);
-    quotaEl.textContent = preflight.quotaImpact;
-    if (costEl) costEl.textContent = computeEudrCostEstimate(preflight.aoiCount);
-    renderPreflightWarnings(preflight.warnings);
-    renderPreflightMap(preflight.polygons);
-    var submitBtn = document.getElementById('app-analysis-submit-btn');
-    if (submitBtn) submitBtn.textContent = 'Confirm & Queue';
-    return preflight;
+    if (typeof preflightModule.updateAnalysisPreflight === 'function') return preflightModule.updateAnalysisPreflight(text);
+    return null;
   }
 
-  function readKmlFile(file) {
-    return new Promise(function(resolve, reject) {
-      var reader = new FileReader();
-      reader.onload = function(e) { resolve(String(e.target.result || '')); };
-      reader.onerror = function() { reject(new Error('Could not read KML file')); };
-      reader.readAsText(file);
-    });
+  function loadAnalysisFile(file) {
+    if (typeof preflightModule.loadAnalysisFile === 'function') return preflightModule.loadAnalysisFile(file);
   }
 
-  async function readKmzFile(file) {
-    var buffer = await file.arrayBuffer();
-    var view = new DataView(buffer);
-    var offset = 0;
-
-    while (offset < buffer.byteLength - 4) {
-      var signature = view.getUint32(offset, true);
-      if (signature !== 0x04034b50) break;
-      var compressionMethod = view.getUint16(offset + 8, true);
-      var compressedSize = view.getUint32(offset + 18, true);
-      var fileNameLength = view.getUint16(offset + 26, true);
-      var extraLength = view.getUint16(offset + 28, true);
-      var fileNameBytes = new Uint8Array(buffer, offset + 30, fileNameLength);
-      var fileName = new TextDecoder().decode(fileNameBytes);
-      var dataStart = offset + 30 + fileNameLength + extraLength;
-
-      if (fileName.toLowerCase().endsWith('.kml')) {
-        var compressed = new Uint8Array(buffer, dataStart, compressedSize);
-        if (compressionMethod === 0) {
-          return new TextDecoder().decode(compressed);
-        }
-        if (compressionMethod === 8) {
-          var stream = new Blob([compressed]).stream().pipeThrough(new DecompressionStream('deflate-raw'));
-          return await new Response(stream).text();
-        }
-      }
-      offset = dataStart + compressedSize;
-    }
-
-    throw new Error('No .kml found inside KMZ archive');
+  function switchInputTab(tabName) {
+    if (typeof preflightModule.switchInputTab === 'function') return preflightModule.switchInputTab(tabName);
   }
 
-  async function loadAnalysisFile(file) {
-    var note = document.getElementById('app-analysis-file-note');
-    var textarea = document.getElementById('app-analysis-kml');
-    if (!file || !note || !textarea) return;
-
-    try {
-      var name = file.name.toLowerCase();
-      var content = name.endsWith('.kmz') ? await readKmzFile(file) : await readKmlFile(file);
-      textarea.value = content;
-      note.textContent = 'Loaded ' + file.name + ' into the analysis form.';
-      updateAnalysisPreflight(content);
-    } catch (err) {
-      note.textContent = err.message || 'Could not read file';
-    }
+  async function convertCSVToKml() {
+    if (typeof preflightModule.convertCSVToKml === 'function') return preflightModule.convertCSVToKml();
   }
 
   function stopAnalysisPolling() {
@@ -3190,6 +2871,18 @@
       getApiReady: function () { return apiDiscoveryReady; },
       getManifest: function () { return evidenceManifest; },
       getInstanceId: function () { return evidenceInstanceId; },
+    });
+  }
+
+  if (typeof preflightModule.init === 'function') {
+    preflightModule.init({
+      apiFetch: apiFetch,
+      getApiReady: function () { return apiDiscoveryReady; },
+      getWorkspaceRole: function () { return workspaceRole; },
+      getActiveProfile: function () { return activeProfile; },
+      getLatestBillingStatus: function () { return latestBillingStatus; },
+      getWorkspaceRoleConfig: function () { return currentRoleConfig(); },
+      onPreflightUpdate: function (preflight) { analysisDraftSummary = preflight; },
     });
   }
 

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -54,6 +54,7 @@
   var progressModule = window.CanopexAnalysisProgress || {};
   var evidenceDisplayModule = window.CanopexEvidenceDisplay || {};
   var authModule = window.CanopexAuth || {};
+  var bindingsModule = window.CanopexBindings || {};
   var _apiClient = window.CanopexApiClient ? window.CanopexApiClient.createClient() : null;
 
   const POST_LOGIN_DESTINATION_KEY = 'canopex-post-login';
@@ -1772,149 +1773,49 @@
   }
   renderWorkspaceGuidance();
 
-  document.querySelectorAll('[data-role-choice]').forEach(function(button) {
-    button.addEventListener('click', function() {
-      setWorkspaceRole(button.getAttribute('data-role-choice'));
+  // All DOM event bindings — delegated to app-bindings.js
+  if (typeof bindingsModule.init === 'function') {
+    bindingsModule.init({
+      // auth
+      login: login,
+      logout: logout,
+      manageBilling: manageBilling,
+      saveTierEmulation: saveTierEmulation,
+      // workspace guidance
+      setWorkspaceRole: setWorkspaceRole,
+      setWorkspacePreference: setWorkspacePreference,
+      revealWorkflowTarget: revealWorkflowTarget,
+      currentPreferenceConfig: currentPreferenceConfig,
+      // analysis
+      queueAnalysis: queueAnalysis,
+      downloadRunExport: downloadRunExport,
+      updateAnalysisPreflight: updateAnalysisPreflight,
+      loadAnalysisFile: loadAnalysisFile,
+      switchInputTab: switchInputTab,
+      convertCSVToKml: convertCSVToKml,
+      // evidence surface
+      toggleEvidencePlay: toggleEvidencePlay,
+      showEvidenceFrame: showEvidenceFrame,
+      setEvidenceLayerMode: setEvidenceLayerMode,
+      requestAiAnalysis: requestAiAnalysis,
+      requestEudrAssessment: requestEudrAssessment,
+      expandEvidenceMap: expandEvidenceMap,
+      collapseEvidenceMap: collapseEvidenceMap,
+      toggleCompareView: toggleCompareView,
+      getOverrideContext: function () {
+        return evidenceDisplayModule.getOverrideContext ? evidenceDisplayModule.getOverrideContext() : {};
+      },
+      // parcel notes / override
+      showNoteEditor: showNoteEditor,
+      hideNoteEditor: hideNoteEditor,
+      saveParcelNote: saveParcelNote,
+      openOverrideModal: openOverrideModal,
+      closeOverrideModal: closeOverrideModal,
+      confirmOverride: confirmOverride,
+      revertOverride: revertOverride,
+      onOverrideReasonInput: onOverrideReasonInput,
+      // API access for export
+      apiFetch: apiFetch,
     });
-  });
-
-  document.querySelectorAll('[data-preference-choice]').forEach(function(button) {
-    button.addEventListener('click', function() {
-      setWorkspacePreference(button.getAttribute('data-preference-choice'));
-    });
-  });
-
-  // Bind click handlers — guarded for elements that only exist on some pages.
-  function bindClick(id, handler) {
-    if (typeof coreDom.bindClick === 'function') {
-      coreDom.bindClick(id, handler);
-      return;
-    }
-    var el = document.getElementById(id);
-    if (el) el.addEventListener('click', handler);
   }
-  bindClick('auth-login-btn', login);
-  bindClick('auth-logout-btn', logout);
-  bindClick('app-sign-in-btn', login);
-  bindClick('app-analysis-sign-in-btn', login);
-  bindClick('app-manage-billing-btn', manageBilling);
-  bindClick('app-apply-tier-emulation-btn', saveTierEmulation);
-  bindClick('app-guided-primary-btn', function() {
-    revealWorkflowTarget(this.getAttribute('data-target') || currentPreferenceConfig().primaryTarget);
-  });
-  bindClick('app-guided-secondary-btn', function() {
-    revealWorkflowTarget(this.getAttribute('data-target') || currentPreferenceConfig().secondaryTarget);
-  });
-  bindClick('app-analysis-submit-btn', queueAnalysis);
-  bindClick('app-run-link', function(event) {
-    const href = this.href;
-    if (!href) return;
-    if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
-      return; // Let normal navigation proceed
-    }
-    const fullUrl = new URL(href, window.location.origin).href;
-    event.preventDefault();
-    const el = document.getElementById('app-run-link');
-    try {
-      navigator.clipboard.writeText(fullUrl).then(function() {
-        if (el._copyTimer) clearTimeout(el._copyTimer);
-        const prev = el.textContent;
-        el.textContent = 'Link copied!';
-        el._copyTimer = setTimeout(function() {
-          if (el.textContent === 'Link copied!') el.textContent = prev;
-          el._copyTimer = null;
-        }, 1500);
-      }).catch(function() {
-        window.location.href = href;
-      });
-    } catch (_) {
-      window.location.href = href;
-    }
-  });
-  document.querySelectorAll('[data-export-format]').forEach(function(button) {
-    button.addEventListener('click', function(event) {
-      event.stopPropagation();
-      downloadRunExport(button.getAttribute('data-export-format'));
-    });
-  });
-
-  // Bind remaining controls — guarded so pages that omit elements don't crash.
-  var kmlInput = document.getElementById('app-analysis-kml');
-  if (kmlInput) kmlInput.addEventListener('input', function() { updateAnalysisPreflight(this.value); });
-  var fileInput = document.getElementById('app-analysis-file');
-  if (fileInput) fileInput.addEventListener('change', function() { if (this.files && this.files[0]) loadAnalysisFile(this.files[0]); });
-
-  // Input tab switching (KML / CSV)
-  document.querySelectorAll('[data-input-tab]').forEach(function(tab) {
-    tab.addEventListener('click', function() { switchInputTab(this.getAttribute('data-input-tab')); });
-  });
-  bindClick('app-csv-convert-btn', convertCSVToKml);
-
-  // Evidence surface controls
-  bindClick('app-map-play-btn', toggleEvidencePlay);
-  var frameSlider = document.getElementById('app-map-frame-slider');
-  if (frameSlider) frameSlider.addEventListener('input', function() { showEvidenceFrame(parseInt(this.value, 10)); });
-  bindClick('app-map-btn-rgb', function() { setEvidenceLayerMode('rgb'); });
-  bindClick('app-map-btn-ndvi', function() { setEvidenceLayerMode('ndvi'); });
-  bindClick('app-evidence-ai-btn', requestAiAnalysis);
-  bindClick('app-evidence-eudr-btn', requestEudrAssessment);
-  // Expanded map viewer controls
-    // Parcel notes (#669)
-    bindClick('app-evidence-notes-add-btn', showNoteEditor);
-    bindClick('app-evidence-notes-cancel-btn', hideNoteEditor);
-    bindClick('app-evidence-notes-save-btn', saveParcelNote);
-
-    // Override determination controls (#672)
-    bindClick('app-evidence-override-btn', function() {
-      var ctx = evidenceDisplayModule.getOverrideContext ? evidenceDisplayModule.getOverrideContext() : {};
-      openOverrideModal(ctx.parcelKey, ctx.aoiData);
-    });
-    bindClick('app-evidence-override-revert-btn', revertOverride);
-    bindClick('app-override-confirm-btn', confirmOverride);
-    bindClick('app-override-cancel-btn', closeOverrideModal);
-    var overrideBackdrop = document.getElementById('app-override-backdrop');
-    if (overrideBackdrop) overrideBackdrop.addEventListener('click', function(e) { if (e.target === this) closeOverrideModal(); });
-    var overrideReasonInput = document.getElementById('app-override-reason-input');
-    if (overrideReasonInput) overrideReasonInput.addEventListener('input', onOverrideReasonInput);
-
-    // Portfolio summary export (#674)
-    bindClick('app-summary-export-btn', function() {
-      var btn = document.getElementById('app-summary-export-btn');
-      if (btn) { btn.disabled = true; btn.textContent = 'Downloading…'; }
-      apiFetch('/api/eudr/summary-export')
-        .then(function(res) {
-          if (!res.ok) throw new Error('Export failed (' + res.status + ')');
-          return res.blob();
-        })
-        .then(function(blob) {
-          var url = URL.createObjectURL(blob);
-          var a = document.createElement('a');
-          a.href = url;
-          a.download = 'eudr_summary_export.csv';
-          document.body.appendChild(a);
-          a.click();
-          document.body.removeChild(a);
-          URL.revokeObjectURL(url);
-        })
-        .catch(function(err) {
-          console.warn('EUDR summary export error:', err);
-          var note = document.getElementById('app-summary-export-note');
-          if (note) note.textContent = 'Export failed — try again';
-        })
-        .finally(function() {
-          if (btn) { btn.disabled = false; btn.textContent = 'Export all runs (CSV)'; }
-        });
-    });
-
-    // Expanded map viewer controls
-  bindClick('app-map-expand-btn', expandEvidenceMap);
-  bindClick('app-map-collapse-btn', collapseEvidenceMap);
-  bindClick('app-map-btn-compare', toggleCompareView);  // #671 before/after comparison
-  var expandedBackdrop = document.getElementById('app-map-expanded-backdrop');
-  if (expandedBackdrop) expandedBackdrop.addEventListener('click', function(e) { if (e.target === this) collapseEvidenceMap(); });
-  bindClick('app-map-expanded-play-btn', toggleEvidencePlay);
-  var expandedSlider = document.getElementById('app-map-expanded-slider');
-  if (expandedSlider) expandedSlider.addEventListener('input', function() { showEvidenceFrame(parseInt(this.value, 10)); });
-  bindClick('app-map-expanded-btn-rgb', function() { setEvidenceLayerMode('rgb'); });
-  bindClick('app-map-expanded-btn-ndvi', function() { setEvidenceLayerMode('ndvi'); });
 })();

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -280,11 +280,6 @@
   const CACHE_TTL_HISTORY = 5 * 60 * 1000;   // 5 min
   const CACHE_TTL_BILLING = 30 * 60 * 1000;  // 30 min
 
-  function cacheKey(key) {
-    const uid = currentAccount && currentAccount.userId;
-    return uid ? CACHE_PREFIX + uid + ':' + key : null;
-  }
-
   function readCache(key) {
     return coreState.readScopedCache
       ? coreState.readScopedCache(CACHE_PREFIX, currentAccount && currentAccount.userId, key)
@@ -369,53 +364,29 @@
   }
 
   function readRunSelectionFromLocation() {
-    try {
-      const params = new URLSearchParams(window.location.search || '');
-      return {
-        instanceId: params.get('run') || ''
-      };
-    } catch {
-      return { instanceId: '' };
-    }
+    return appRuns.readRunSelectionFromLocation
+      ? appRuns.readRunSelectionFromLocation()
+      : { instanceId: '' };
   }
 
   function selectedRunPermalink(instanceId) {
-    try {
-      const url = new URL(window.location.href);
-      if (instanceId) {
-        url.searchParams.set('run', instanceId);
-      } else {
-        url.searchParams.delete('run');
-      }
-      url.searchParams.delete('focus');
-      const nextPath = url.pathname;
-      const nextSearch = url.searchParams.toString();
-      return nextSearch ? nextPath + '?' + nextSearch : nextPath;
-    } catch {
-      return APP_BASE;
-    }
+    return appRuns.selectedRunPermalink
+      ? appRuns.selectedRunPermalink(instanceId, APP_BASE)
+      : APP_BASE;
   }
 
   function updateRunSelectionLocation(instanceId) {
-    if (!window.history || typeof window.history.replaceState !== 'function') return;
-    try {
-      window.history.replaceState({}, '', selectedRunPermalink(instanceId));
-    } catch { /* ignore */ }
+    if (appRuns.updateRunSelectionLocation) {
+      appRuns.updateRunSelectionLocation(instanceId, APP_BASE);
+    }
   }
 
   function readStoredUiValue(key) {
-    if (typeof coreState.readStoredValue === 'function') {
-      return coreState.readStoredValue(key);
-    }
-    try { return localStorage.getItem(key); } catch { return null; }
+    return coreState.readStoredValue ? coreState.readStoredValue(key) : null;
   }
 
   function storeUiValue(key, value) {
-    if (typeof coreState.storeValue === 'function') {
-      coreState.storeValue(key, value);
-      return;
-    }
-    try { localStorage.setItem(key, value); } catch { /* ignore */ }
+    if (coreState.storeValue) coreState.storeValue(key, value);
   }
 
   function currentRoleConfig() {

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -286,63 +286,27 @@
   }
 
   function readCache(key) {
-    if (typeof coreState.readScopedCache === 'function') {
-      return coreState.readScopedCache(CACHE_PREFIX, currentAccount && currentAccount.userId, key);
-    }
-    try {
-      const full = cacheKey(key);
-      if (!full) return null;
-      const raw = localStorage.getItem(full);
-      if (!raw) return null;
-      const entry = JSON.parse(raw);
-      if (!entry || typeof entry.expires !== 'number' || Date.now() > entry.expires) {
-        localStorage.removeItem(full);
-        return null;
-      }
-      return entry.data;
-    } catch { return null; }
+    return coreState.readScopedCache
+      ? coreState.readScopedCache(CACHE_PREFIX, currentAccount && currentAccount.userId, key)
+      : null;
   }
 
   function writeCache(key, data, ttlMs) {
-    if (typeof coreState.writeScopedCache === 'function') {
+    if (coreState.writeScopedCache) {
       coreState.writeScopedCache(CACHE_PREFIX, currentAccount && currentAccount.userId, key, data, ttlMs);
-      return;
     }
-    if (!Number.isFinite(ttlMs)) return;
-    try {
-      const full = cacheKey(key);
-      if (!full) return;
-      localStorage.setItem(full, JSON.stringify({
-        data: data,
-        expires: Date.now() + ttlMs
-      }));
-    } catch { /* quota exceeded or private browsing — degrade gracefully */ }
   }
 
   function clearCacheKey(key) {
-    if (typeof coreState.clearScopedCacheKey === 'function') {
+    if (coreState.clearScopedCacheKey) {
       coreState.clearScopedCacheKey(CACHE_PREFIX, currentAccount && currentAccount.userId, key);
-      return;
     }
-    try {
-      const full = cacheKey(key);
-      if (full) localStorage.removeItem(full);
-    } catch { /* ignore */ }
   }
 
   function clearAllCache() {
-    if (typeof coreState.clearAllScopedCache === 'function') {
+    if (coreState.clearAllScopedCache) {
       coreState.clearAllScopedCache(CACHE_PREFIX);
-      return;
     }
-    try {
-      const keys = [];
-      for (let i = 0; i < localStorage.length; i++) {
-        const k = localStorage.key(i);
-        if (k && k.startsWith(CACHE_PREFIX)) keys.push(k);
-      }
-      keys.forEach(function(k) { localStorage.removeItem(k); });
-    } catch { /* ignore */ }
   }
 
   function authEnabled() { return true; /* SWA built-in auth — always available */ }
@@ -519,49 +483,11 @@
   /* ---- History UI — delegated to app-history-ui.js ---- */
 
   function normalizeAnalysisRun(run) {
-    if (typeof appRuns.normalizeRun === 'function') {
-      return appRuns.normalizeRun(run);
-    }
-    if (!run) return null;
-    var normalized = Object.assign({}, run);
-    normalized.instanceId = normalized.instanceId || normalized.instance_id || '';
-    normalized.submissionId = normalized.submissionId || normalized.submission_id || normalized.instanceId;
-    normalized.submittedAt = normalized.submittedAt || normalized.submitted_at || normalized.createdTime || '';
-    normalized.submissionPrefix = normalized.submissionPrefix || normalized.submission_prefix || 'analysis';
-    normalized.providerName = normalized.providerName || normalized.provider_name || 'planetary_computer';
-    normalized.featureCount = normalized.featureCount != null ? normalized.featureCount : normalized.feature_count;
-    normalized.aoiCount = normalized.aoiCount != null ? normalized.aoiCount : normalized.aoi_count;
-    normalized.processingMode = normalized.processingMode || normalized.processing_mode;
-    normalized.maxSpreadKm = normalized.maxSpreadKm != null ? normalized.maxSpreadKm : normalized.max_spread_km;
-    normalized.totalAreaHa = normalized.totalAreaHa != null ? normalized.totalAreaHa : normalized.total_area_ha;
-    normalized.largestAreaHa = normalized.largestAreaHa != null ? normalized.largestAreaHa : normalized.largest_area_ha;
-    normalized.workspaceRole = normalized.workspaceRole || normalized.workspace_role;
-    normalized.workspacePreference = normalized.workspacePreference || normalized.workspace_preference;
-    if (normalized.output) {
-      if (normalized.featureCount == null && normalized.output.featureCount != null) normalized.featureCount = normalized.output.featureCount;
-      if (normalized.aoiCount == null && normalized.output.aoiCount != null) normalized.aoiCount = normalized.output.aoiCount;
-      if (normalized.artifactCount == null && normalized.output.artifacts) normalized.artifactCount = Object.keys(normalized.output.artifacts).length;
-      if (!normalized.partialFailures) {
-        normalized.partialFailures = {
-          imagery: normalized.output.imageryFailed || 0,
-          downloads: normalized.output.downloadsFailed || 0,
-          postProcess: normalized.output.postProcessFailed || 0,
-        };
-      }
-    }
-    return normalized.instanceId ? normalized : null;
+    return appRuns.normalizeRun ? appRuns.normalizeRun(run) : null;
   }
 
   function sortAnalysisHistoryRuns(runs) {
-    if (typeof appRuns.sortRuns === 'function') {
-      return appRuns.sortRuns(runs, parseStatusTimestamp);
-    }
-    return (runs || [])
-      .map(normalizeAnalysisRun)
-      .filter(Boolean)
-      .sort(function(a, b) {
-        return parseStatusTimestamp((b && (b.submittedAt || b.createdTime || b.lastUpdatedTime)) || '') - parseStatusTimestamp((a && (a.submittedAt || a.createdTime || a.lastUpdatedTime)) || '');
-      });
+    return appRuns.sortRuns ? appRuns.sortRuns(runs, parseStatusTimestamp) : [];
   }
 
   function renderAnalysisHistoryList() {
@@ -569,17 +495,8 @@
   }
 
   function upsertAnalysisHistoryRun(run) {
-    var normalized = normalizeAnalysisRun(run);
-    if (!normalized) return;
-    var replaced = false;
-    analysisHistoryRuns = analysisHistoryRuns.map(function(existing) {
-      var existingId = existing.instanceId || existing.instance_id;
-      if (existingId !== normalized.instanceId) return existing;
-      replaced = true;
-      return Object.assign({}, existing, normalized);
-    });
-    if (!replaced) analysisHistoryRuns.unshift(normalized);
-    analysisHistoryRuns = sortAnalysisHistoryRuns(analysisHistoryRuns);
+    if (!appRuns.upsertRun) return;
+    analysisHistoryRuns = appRuns.upsertRun(analysisHistoryRuns, run, parseStatusTimestamp);
     renderAnalysisHistoryList();
     applyFirstRunLayout();
   }

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -49,6 +49,7 @@
   var evidenceMapModule = window.CanopexEvidenceMap || {};
   var eudrModule = window.CanopexEudr || {};
   var billingModule = window.CanopexBilling || {};
+  var evidencePanelsModule = window.CanopexEvidencePanels || {};
 
   const POST_LOGIN_DESTINATION_KEY = 'canopex-post-login';
   const WORKSPACE_ROLE_STORAGE_KEY = 'canopex-workspace-role';
@@ -1508,276 +1509,62 @@
     }
   }
 
-  /* ---- Parcel notes (#669) ---- */
+  /* ---- Parcel notes (#669) — delegated to app-evidence-panels.js ---- */
 
-  var currentNoteParcelKey = null; // key of AOI whose notes are currently shown
+  // module-level state kept as fallback when module is absent
+  var currentNoteParcelKey = null;
 
   function parcelKeyForIndex(idx) {
-    // Use the AOI index as a stable string key matching the backend convention.
+    if (typeof evidencePanelsModule.parcelKeyForIndex === 'function') return evidencePanelsModule.parcelKeyForIndex(idx);
     return String(idx);
   }
 
   function renderParcelNotes(parcelKey) {
-    currentNoteParcelKey = parcelKey;
-    var notesEl = document.getElementById('app-evidence-notes');
-    var savedEl = document.getElementById('app-evidence-notes-saved');
-    var textEl = document.getElementById('app-evidence-notes-text');
-    var metaEl = document.getElementById('app-evidence-notes-meta');
-    var editEl = document.getElementById('app-evidence-notes-edit');
-    var addBtn = document.getElementById('app-evidence-notes-add-btn');
-    if (!notesEl) return;
-
-    // Reset edit state
-    if (editEl) editEl.hidden = true;
-    if (addBtn) addBtn.hidden = false;
-    var input = document.getElementById('app-evidence-notes-input');
-    if (input) input.value = '';
-
-    var note = null;
-    if (evidenceManifest && evidenceManifest.parcel_notes) {
-      note = evidenceManifest.parcel_notes[parcelKey] || null;
-    }
-
-    if (note && note.text) {
-      if (savedEl) savedEl.hidden = false;
-      if (textEl) textEl.textContent = note.text;
-      if (metaEl) {
-        var when = note.updated_at ? new Date(note.updated_at).toLocaleDateString() : '';
-        metaEl.textContent = when ? 'Note — ' + when : 'Note saved';
-      }
-      if (addBtn) addBtn.textContent = 'Edit note';
-    } else {
-      if (savedEl) savedEl.hidden = true;
-      if (textEl) textEl.textContent = '';
-      if (metaEl) metaEl.textContent = '';
-      if (addBtn) addBtn.textContent = '+ Add note';
-    }
+    if (typeof evidencePanelsModule.renderParcelNotes === 'function') return evidencePanelsModule.renderParcelNotes(parcelKey);
   }
 
   function showNoteEditor() {
-    var editEl = document.getElementById('app-evidence-notes-edit');
-    var addBtn = document.getElementById('app-evidence-notes-add-btn');
-    var input = document.getElementById('app-evidence-notes-input');
-    if (!editEl) return;
-
-    // Pre-populate with existing note text
-    if (input && evidenceManifest && evidenceManifest.parcel_notes && currentNoteParcelKey) {
-      var existing = evidenceManifest.parcel_notes[currentNoteParcelKey];
-      input.value = existing ? (existing.text || '') : '';
-    }
-    if (editEl) editEl.hidden = false;
-    if (addBtn) addBtn.hidden = true;
-    if (input) input.focus();
+    if (typeof evidencePanelsModule.showNoteEditor === 'function') return evidencePanelsModule.showNoteEditor();
   }
 
   function hideNoteEditor() {
-    var editEl = document.getElementById('app-evidence-notes-edit');
-    var addBtn = document.getElementById('app-evidence-notes-add-btn');
-    if (editEl) editEl.hidden = true;
-    if (addBtn) addBtn.hidden = false;
+    if (typeof evidencePanelsModule.hideNoteEditor === 'function') return evidencePanelsModule.hideNoteEditor();
   }
 
   async function saveParcelNote() {
-    var input = document.getElementById('app-evidence-notes-input');
-    if (!input || !evidenceInstanceId || currentNoteParcelKey === null) return;
-
-    var noteText = input.value.trim();
-    var saveBtn = document.getElementById('app-evidence-notes-save-btn');
-    if (saveBtn) { saveBtn.disabled = true; saveBtn.textContent = 'Saving…'; }
-
-    try {
-      await apiDiscoveryReady;
-      var res = await apiFetch('/api/analysis/notes', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          instance_id: evidenceInstanceId,
-          parcel_key: currentNoteParcelKey,
-          note: noteText,
-        }),
-      });
-      if (!res.ok) {
-        var err = await res.json().catch(function() { return {}; });
-        console.warn('Note save failed:', err);
-        return;
-      }
-      // Update local manifest state so the note appears immediately
-      if (!evidenceManifest.parcel_notes) evidenceManifest.parcel_notes = {};
-      if (noteText) {
-        evidenceManifest.parcel_notes[currentNoteParcelKey] = {
-          text: noteText,
-          updated_at: new Date().toISOString(),
-        };
-      } else {
-        delete evidenceManifest.parcel_notes[currentNoteParcelKey];
-      }
-      hideNoteEditor();
-      renderParcelNotes(currentNoteParcelKey);
-    } catch (e) {
-      console.warn('Note save error:', e);
-    } finally {
-      if (saveBtn) { saveBtn.disabled = false; saveBtn.textContent = 'Save note'; }
-    }
+    if (typeof evidencePanelsModule.saveParcelNote === 'function') return evidencePanelsModule.saveParcelNote();
   }
 
+  /* ---- Human override determination (#672) — delegated to app-evidence-panels.js ---- */
 
-  /* ---- Human override determination (#672) ---- */
-
+  // module-level state kept as fallback when module is absent
   var currentOverrideParcelKey = null;
   var currentOverrideAoiData = null;
 
   function renderParcelOverride(parcelKey, aoiData) {
-    currentOverrideParcelKey = parcelKey;
-    currentOverrideAoiData = aoiData;
-
-    var overrideEl = document.getElementById('app-evidence-override');
-    var badgeEl = document.getElementById('app-evidence-override-badge');
-    var overrideBtn = document.getElementById('app-evidence-override-btn');
-    var revertBtn = document.getElementById('app-evidence-override-revert-btn');
-    if (!overrideEl) return;
-
-    var override = null;
-    if (evidenceManifest && evidenceManifest.parcel_overrides) {
-      override = evidenceManifest.parcel_overrides[parcelKey] || null;
-    }
-
-    var det = aoiData && aoiData.determination;
-    var isNonCompliant = det && !det.deforestation_free;
-
-    overrideEl.hidden = !(isNonCompliant || override);
-
-    if (override) {
-      if (badgeEl) {
-        badgeEl.hidden = false;
-        badgeEl.className = 'app-evidence-override-badge';
-        badgeEl.textContent = '\u2705 Compliant (overridden)';
-      }
-      if (overrideBtn) overrideBtn.hidden = true;
-      if (revertBtn) revertBtn.hidden = false;
-    } else {
-      if (badgeEl) badgeEl.hidden = true;
-      if (overrideBtn) overrideBtn.hidden = !isNonCompliant;
-      if (revertBtn) revertBtn.hidden = true;
-    }
+    if (typeof evidencePanelsModule.renderParcelOverride === 'function') return evidencePanelsModule.renderParcelOverride(parcelKey, aoiData);
   }
 
   function openOverrideModal(parcelKey, aoiData) {
-    var backdrop = document.getElementById('app-override-backdrop');
-    var reasonInput = document.getElementById('app-override-reason-input');
-    var confirmBtn = document.getElementById('app-override-confirm-btn');
-    var charCount = document.getElementById('app-override-charcount');
-    var errorEl = document.getElementById('app-override-error');
-    var originalEl = document.getElementById('app-override-original');
-    if (!backdrop) return;
-
-    if (reasonInput) reasonInput.value = '';
-    if (confirmBtn) confirmBtn.disabled = true;
-    if (charCount) charCount.textContent = '0 / 500';
-    if (errorEl) { errorEl.hidden = true; errorEl.textContent = ''; }
-    if (originalEl) {
-      var det = aoiData && aoiData.determination;
-      var reason = det && det.reason ? det.reason : 'Risk detected';
-      originalEl.textContent = 'Algorithmic determination: ' + reason;
-    }
-
-    backdrop.hidden = false;
-    if (reasonInput) reasonInput.focus();
+    if (typeof evidencePanelsModule.openOverrideModal === 'function') return evidencePanelsModule.openOverrideModal(parcelKey, aoiData);
   }
 
   function closeOverrideModal() {
-    var backdrop = document.getElementById('app-override-backdrop');
-    if (backdrop) backdrop.hidden = true;
+    if (typeof evidencePanelsModule.closeOverrideModal === 'function') return evidencePanelsModule.closeOverrideModal();
   }
 
   function onOverrideReasonInput() {
-    var reasonInput = document.getElementById('app-override-reason-input');
-    var confirmBtn = document.getElementById('app-override-confirm-btn');
-    var charCount = document.getElementById('app-override-charcount');
-    if (!reasonInput) return;
-    var len = reasonInput.value.trim().length;
-    if (charCount) charCount.textContent = len + ' / 500';
-    if (confirmBtn) confirmBtn.disabled = len < 20;
+    if (typeof evidencePanelsModule.onOverrideReasonInput === 'function') return evidencePanelsModule.onOverrideReasonInput();
   }
 
   async function confirmOverride() {
-    var reasonInput = document.getElementById('app-override-reason-input');
-    var confirmBtn = document.getElementById('app-override-confirm-btn');
-    var errorEl = document.getElementById('app-override-error');
-    if (!reasonInput || !evidenceInstanceId || currentOverrideParcelKey === null) return;
-
-    var reason = reasonInput.value.trim();
-    if (reason.length < 20) return;
-
-    var originalText = confirmBtn ? confirmBtn.textContent : 'Confirm override';
-    if (confirmBtn) { confirmBtn.disabled = true; confirmBtn.textContent = 'Saving\u2026'; }
-    if (errorEl) { errorEl.hidden = true; errorEl.textContent = ''; }
-
-    try {
-      await apiDiscoveryReady;
-      var res = await apiFetch('/api/analysis/override', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          instance_id: evidenceInstanceId,
-          parcel_key: currentOverrideParcelKey,
-          reason: reason,
-          revert: false,
-        }),
-      });
-      if (!res.ok) {
-        var err = await res.json().catch(function() { return {}; });
-        if (errorEl) {
-          errorEl.textContent = (err && err.message) || 'Failed to save override. Try again.';
-          errorEl.hidden = false;
-        }
-        return;
-      }
-      // Update local manifest state
-      if (!evidenceManifest.parcel_overrides) evidenceManifest.parcel_overrides = {};
-      evidenceManifest.parcel_overrides[currentOverrideParcelKey] = {
-        reason: reason,
-        overridden_at: new Date().toISOString(),
-        override_determination: 'compliant',
-      };
-      closeOverrideModal();
-      renderParcelOverride(currentOverrideParcelKey, currentOverrideAoiData);
-    } catch (e) {
-      if (errorEl) { errorEl.textContent = 'Failed to save override. Try again.'; errorEl.hidden = false; }
-      console.warn('Override save error:', e);
-    } finally {
-      if (confirmBtn) { confirmBtn.disabled = false; confirmBtn.textContent = originalText; }
-    }
+    if (typeof evidencePanelsModule.confirmOverride === 'function') return evidencePanelsModule.confirmOverride();
   }
 
   async function revertOverride() {
-    if (!evidenceInstanceId || currentOverrideParcelKey === null) return;
-    var revertBtn = document.getElementById('app-evidence-override-revert-btn');
-    if (revertBtn) { revertBtn.disabled = true; revertBtn.textContent = 'Reverting\u2026'; }
-
-    try {
-      await apiDiscoveryReady;
-      var res = await apiFetch('/api/analysis/override', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          instance_id: evidenceInstanceId,
-          parcel_key: currentOverrideParcelKey,
-          reason: '',
-          revert: true,
-        }),
-      });
-      if (res.ok) {
-        if (evidenceManifest.parcel_overrides) {
-          delete evidenceManifest.parcel_overrides[currentOverrideParcelKey];
-        }
-        renderParcelOverride(currentOverrideParcelKey, currentOverrideAoiData);
-      }
-    } catch (e) {
-      console.warn('Override revert error:', e);
-    } finally {
-      if (revertBtn) { revertBtn.disabled = false; revertBtn.textContent = 'Revert to algorithmic'; }
-    }
+    if (typeof evidencePanelsModule.revertOverride === 'function') return evidencePanelsModule.revertOverride();
   }
+
   function selectAoi(idx) {
     if (!evidenceManifest || !evidenceManifest.per_aoi_enrichment) return;
     var perAoi = evidenceManifest.per_aoi_enrichment;
@@ -3194,58 +2981,8 @@
   /* ---- EUDR usage dashboard (#670) ---- */
 
   async function loadEudrUsage() {
-    await apiDiscoveryReady;
-    if (!currentAccount) return;
-
-    var includedEl = document.getElementById('app-eudr-usage-included');
-    var overageEl = document.getElementById('app-eudr-usage-overage');
-    var spendEl = document.getElementById('app-eudr-usage-spend');
-    var nextTierEl = document.getElementById('app-eudr-usage-next-tier');
-    var historyListEl = document.getElementById('app-eudr-usage-history-list');
-    if (!includedEl) return;  // card not present in this build
-
-    try {
-      var res = await apiFetch('/api/eudr/usage');
-      if (!res.ok) return;
-      var data = await res.json();
-      var cur = data.current || {};
-
-      var periodUsed = cur.periodParcelsUsed || 0;
-      var included = cur.includedParcels || 0;
-      if (includedEl) includedEl.textContent = periodUsed + ' / ' + included;
-      if (overageEl) overageEl.textContent = (cur.overageParcels || 0) + ' parcels';
-      if (spendEl) {
-        var spend = cur.estimatedSpendGbp;
-        spendEl.textContent = (spend != null) ? ('£' + spend.toFixed(2)) : '—';
-      }
-      if (nextTierEl) {
-        if (cur.nextTierThreshold) {
-          var msg = cur.parcelsToNextTier + ' until next tier (£' + cur.nextTierRateGbp + '/parcel)';
-          nextTierEl.textContent = msg;
-          if (cur.within20PercentOfNextTier) nextTierEl.style.fontWeight = '600';
-        } else {
-          nextTierEl.textContent = 'Maximum tier reached';
-        }
-      }
-
-      if (historyListEl && data.history && data.history.length) {
-        var html = '<div class="app-usage-history-list">';
-        data.history.forEach(function(m) {
-          html += '<div class="app-usage-row">' +
-            '<strong>' + (m.month || '') + '</strong>' +
-            '<span>' + (m.runs || 0) + ' runs</span>' +
-            '<span>' + (m.parcels || 0) + ' parcels</span>' +
-            (m.overageRuns ? '<span class="app-warning-text">' + m.overageRuns + ' overage</span>' : '') +
-            '</div>';
-        });
-        html += '</div>';
-        historyListEl.innerHTML = html;
-      } else if (historyListEl) {
-        historyListEl.textContent = 'No usage history yet.';
-      }
-    } catch (e) {
-      console.warn('EUDR usage load error:', e);
-    }
+    if (typeof eudrModule.loadUsage === 'function') return eudrModule.loadUsage();
+    // fallback: silently skip when module not loaded
   }
 
   async function loadAnalysisHistory(options) {
@@ -3433,6 +3170,23 @@
       onLoadError: function () {
         setHeroRunSummary('Ready to queue', 'Billing is unavailable, but analysis can still be launched locally.');
       }
+    });
+  }
+
+  if (typeof eudrModule.init === 'function') {
+    eudrModule.init({
+      apiFetch: apiFetch,
+      getApiReady: function () { return apiDiscoveryReady; },
+      getAccount: function () { return currentAccount; },
+    });
+  }
+
+  if (typeof evidencePanelsModule.init === 'function') {
+    evidencePanelsModule.init({
+      apiFetch: apiFetch,
+      getApiReady: function () { return apiDiscoveryReady; },
+      getManifest: function () { return evidenceManifest; },
+      getInstanceId: function () { return evidenceInstanceId; },
     });
   }
 

--- a/website/js/app-summary-ui.js
+++ b/website/js/app-summary-ui.js
@@ -1,0 +1,239 @@
+(function () {
+  'use strict';
+
+  var _d = {};
+
+  function init(deps) {
+    _d = deps || {};
+  }
+
+  function currentRoleConfig() {
+    return _d.currentRoleConfig ? _d.currentRoleConfig() : {};
+  }
+
+  function currentPreferenceConfig() {
+    return _d.currentPreferenceConfig ? _d.currentPreferenceConfig() : {};
+  }
+
+  function actionLabelForTarget(target) {
+    var role = currentRoleConfig();
+    if (target === 'history') return role.reviewLabel;
+    if (target === 'content') return role.deliverableLabel;
+    return role.runLabel;
+  }
+
+  function revealWorkflowTarget(target) {
+    var cardId = target === 'history'
+      ? 'app-history-card'
+      : target === 'content'
+        ? 'app-content-card'
+        : 'app-analysis-card';
+    var card = document.getElementById(cardId);
+    if (card) card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  function renderWorkspaceGuidance() {
+    var role = currentRoleConfig();
+    var preference = currentPreferenceConfig();
+    var setText = _d.setText || function () {};
+    var workspaceRole = _d.getWorkspaceRole ? _d.getWorkspaceRole() : 'conservation';
+    var workspacePreference = _d.getWorkspacePreference ? _d.getWorkspacePreference() : 'investigate';
+
+    var dashboard = document.getElementById('app-dashboard');
+    if (dashboard) {
+      dashboard.setAttribute('data-role', workspaceRole);
+      dashboard.setAttribute('data-preference', workspacePreference);
+    }
+
+    document.querySelectorAll('[data-role-choice]').forEach(function (button) {
+      button.setAttribute('aria-pressed', button.getAttribute('data-role-choice') === workspaceRole ? 'true' : 'false');
+    });
+    document.querySelectorAll('[data-preference-choice]').forEach(function (button) {
+      button.setAttribute('aria-pressed', button.getAttribute('data-preference-choice') === workspacePreference ? 'true' : 'false');
+    });
+
+    setText('app-role-title', role.title);
+    setText('app-role-tag', role.tag);
+    setText('app-role-summary', role.summary);
+    setText('app-role-outcome', role.outcome);
+    setText('app-role-risk', role.risk);
+    setText('app-role-rhythm', role.rhythm);
+
+    setText('app-preference-title', preference.title);
+    setText('app-preference-tag', preference.tag);
+    setText('app-preference-summary', preference.summary);
+    setText('app-guided-deliverable', preference.deliverable);
+    setText('app-guided-stance', preference.stance);
+
+    var primaryButton = document.getElementById('app-guided-primary-btn');
+    var secondaryButton = document.getElementById('app-guided-secondary-btn');
+    if (primaryButton) {
+      primaryButton.textContent = actionLabelForTarget(preference.primaryTarget);
+      primaryButton.setAttribute('data-target', preference.primaryTarget);
+    }
+    if (secondaryButton) {
+      secondaryButton.textContent = actionLabelForTarget(preference.secondaryTarget);
+      secondaryButton.setAttribute('data-target', preference.secondaryTarget);
+    }
+
+    setText('app-history-copy', role.historyCopy);
+    setText('app-run-copy', role.runCopy);
+    setText('app-content-copy', role.contentCopy);
+    var lensTitle = document.getElementById('app-analysis-lens-title');
+    var lensNote = document.getElementById('app-analysis-lens-note');
+    if (lensTitle) lensTitle.textContent = role.runLensTitle;
+    if (lensNote) lensNote.textContent = role.runLensNote + ' ' + preference.summary;
+
+    var latestAnalysisRun = _d.getLatestAnalysisRun ? _d.getLatestAnalysisRun() : null;
+    var analysisHistoryLoaded = _d.getAnalysisHistoryLoaded ? _d.getAnalysisHistoryLoaded() : false;
+    var currentAccount = _d.getAccount ? _d.getAccount() : null;
+    if (!latestAnalysisRun && _d.setHeroRunSummary) {
+      if (!analysisHistoryLoaded && currentAccount) {
+        _d.setHeroRunSummary('Checking recent runs', 'Loading your recent runs.');
+      } else {
+        _d.setHeroRunSummary('Ready to queue', role.readyNote);
+      }
+    }
+
+    var latestBillingStatus = _d.getLatestBillingStatus ? _d.getLatestBillingStatus() : null;
+    if (latestBillingStatus) updateHeroSummary(latestBillingStatus);
+    updateHistorySummary(latestAnalysisRun);
+
+    if (_d.renderAnalysisHistoryList) _d.renderAnalysisHistoryList();
+    if (_d.updateContentSummary) _d.updateContentSummary(latestAnalysisRun);
+
+    var draftTextarea = document.getElementById('app-analysis-kml');
+    if (_d.updateAnalysisPreflight) {
+      _d.updateAnalysisPreflight(draftTextarea ? draftTextarea.value : '');
+    }
+  }
+
+  function updateHeroSummary(data) {
+    var role = currentRoleConfig();
+    var preference = currentPreferenceConfig();
+    var capabilityHeadline = _d.capabilityHeadline || function () { return 'Standard'; };
+    var formatRetention = _d.formatRetention || function (days) { return String(days || '-'); };
+    var caps = data.capabilities || {};
+    var planEl = document.getElementById('app-hero-plan');
+    var planNoteEl = document.getElementById('app-hero-plan-note');
+    var runsEl = document.getElementById('app-hero-runs');
+    var runsNoteEl = document.getElementById('app-hero-runs-note');
+    var modeEl = document.getElementById('app-hero-mode');
+    var modeNoteEl = document.getElementById('app-hero-mode-note');
+    if (!planEl || !planNoteEl || !runsEl || !runsNoteEl || !modeEl || !modeNoteEl) return;
+
+    if (data.preview_mode) {
+      planEl.textContent = 'Free plan preview';
+      planNoteEl.textContent = 'Sign in to turn this preview into a real workspace.';
+      runsEl.textContent = data.runs_remaining == null ? '-' : String(data.runs_remaining);
+      runsNoteEl.textContent = 'Free-plan limits shown here only activate after sign-in.';
+      modeEl.textContent = capabilityHeadline(caps);
+      modeNoteEl.textContent = role.label + ' | ' + preference.label + ' | Preview mode only until you authenticate.';
+      return;
+    }
+
+    planEl.textContent = (caps.label || data.tier || 'Free') + (data.tier_source === 'emulated' ? ' (emulated)' : '');
+    planNoteEl.textContent = data.tier_source === 'emulated'
+      ? 'Local override for product testing.'
+      : 'Based on your account.';
+    runsEl.textContent = data.runs_remaining == null ? '-' : String(data.runs_remaining);
+    runsNoteEl.textContent = data.runs_remaining == null
+      ? 'Quota unavailable in this environment.'
+      : 'Remaining analyses before the current limit is reached.';
+    modeEl.textContent = capabilityHeadline(caps);
+    modeNoteEl.textContent = role.label + ' | ' + preference.label + ' | Retention ' + formatRetention(caps.retention_days) + ' | ' + (caps.api_access ? 'API enabled' : 'API not included');
+  }
+
+  function updateHistorySummary(data) {
+    var role = currentRoleConfig();
+    var displayAnalysisPhase = _d.displayAnalysisPhase || function () { return 'unknown'; };
+    var summarizeRunTiming = _d.summarizeRunTiming || function () { return {}; };
+    var analysisHistoryRuns = _d.getAnalysisHistoryRuns ? _d.getAnalysisHistoryRuns() : [];
+    var selectedAnalysisRunId = _d.getSelectedAnalysisRunId ? _d.getSelectedAnalysisRunId() : null;
+    var analysisHistoryLoaded = _d.getAnalysisHistoryLoaded ? _d.getAnalysisHistoryLoaded() : false;
+    var currentAccount = _d.getAccount ? _d.getAccount() : null;
+
+    var statusEl = document.getElementById('app-history-latest-status');
+    var noteEl = document.getElementById('app-history-latest-note');
+    var instanceEl = document.getElementById('app-history-latest-instance');
+    var phaseEl = document.getElementById('app-history-latest-phase');
+    var pathEl = document.getElementById('app-history-latest-path');
+    if (!statusEl || !noteEl || !instanceEl || !phaseEl || !pathEl) return;
+
+    renderPortfolioSummary();
+
+    if (!data) {
+      if (!analysisHistoryLoaded && currentAccount) {
+        statusEl.textContent = 'Loading recent runs';
+        noteEl.textContent = 'Loading your history and checking for active runs.';
+        instanceEl.textContent = '...';
+        phaseEl.textContent = 'loading';
+        pathEl.textContent = role.activePath;
+        return;
+      }
+      statusEl.textContent = 'No runs yet';
+      noteEl.textContent = role.emptyHistoryNote;
+      instanceEl.textContent = '-';
+      phaseEl.textContent = '-';
+      pathEl.textContent = role.completedPath;
+      return;
+    }
+
+    var instanceId = data.instanceId || data.instance_id || '-';
+    var runtimeStatus = data.runtimeStatus || 'Pending';
+    var phase = displayAnalysisPhase(data.customStatus, runtimeStatus);
+    var timing = summarizeRunTiming(data);
+    var summaryLabel = analysisHistoryRuns.length > 1 && selectedAnalysisRunId
+      ? 'Selected analysis'
+      : 'Latest analysis';
+    statusEl.textContent = runtimeStatus;
+    noteEl.textContent = runtimeStatus === 'Completed'
+      ? summaryLabel + ' completed and is ready to become a ' + role.completedHistoryOutcome + '.'
+      : summaryLabel + ' is active. This rail keeps ' + role.activeHistoryContext + ' visible while you stay centered on the run.';
+    if (runtimeStatus !== 'Completed' && timing.sinceUpdate) {
+      noteEl.textContent += ' Last backend update ' + timing.sinceUpdate + ' ago.';
+    }
+    instanceEl.textContent = instanceId;
+    phaseEl.textContent = phase;
+    pathEl.textContent = runtimeStatus === 'Completed' ? role.completedPath : role.activePath;
+  }
+
+  function renderPortfolioSummary() {
+    var summaryEl = document.getElementById('app-portfolio-summary');
+    if (!summaryEl) return;
+
+    var setText = _d.setText || function () {};
+    var latestPortfolioSummary = _d.getLatestPortfolioSummary ? _d.getLatestPortfolioSummary() : null;
+    var scope = latestPortfolioSummary && latestPortfolioSummary.scope;
+    var stats = latestPortfolioSummary && latestPortfolioSummary.stats;
+    if (scope !== 'org' || !stats) {
+      summaryEl.hidden = true;
+      return;
+    }
+
+    summaryEl.hidden = false;
+    setText('app-portfolio-total-runs', String(stats.totalRuns || 0));
+    setText('app-portfolio-active-runs', String(stats.activeRuns || 0));
+    setText('app-portfolio-completed-runs', String(stats.completedRuns || 0));
+    setText('app-portfolio-total-parcels', String(stats.totalParcels || 0));
+
+    var memberCount = latestPortfolioSummary.memberCount || 1;
+    var scopeNote = memberCount > 1
+      ? 'Org portfolio view (' + memberCount + ' members)'
+      : 'Org portfolio view';
+    setText('app-portfolio-scope-note', scopeNote);
+
+    var exportRow = document.getElementById('app-summary-export-row');
+    if (exportRow) exportRow.hidden = false;
+  }
+
+  window.CanopexSummaryUi = {
+    init: init,
+    actionLabelForTarget: actionLabelForTarget,
+    revealWorkflowTarget: revealWorkflowTarget,
+    renderWorkspaceGuidance: renderWorkspaceGuidance,
+    updateHeroSummary: updateHeroSummary,
+    updateHistorySummary: updateHistorySummary,
+    renderPortfolioSummary: renderPortfolioSummary,
+  };
+})();

--- a/website/js/app-workspace.js
+++ b/website/js/app-workspace.js
@@ -1,0 +1,228 @@
+(function () {
+  'use strict';
+
+  const WORKSPACE_ROLES = {
+    conservation: {
+      label: 'Conservation',
+      tag: 'Field evidence',
+      title: 'Conservation monitoring',
+      summary: 'Built for protected-area coordinators who need rapid, plain-English evidence they can take to rangers, directors, or donors.',
+      outcome: 'Evidence packs',
+      risk: 'No silent fallback',
+      rhythm: 'Monthly watchlist',
+      historyCopy: 'Keep the most recent incident visible while you compare new reports against what already ran.',
+      runCopy: 'Queue an analysis for a protected area or reported clearing.',
+      contentCopy: 'Use this rail to understand what evidence is being assembled and what will be ready for a field or donor brief.',
+      runLensTitle: 'Conservation analysis',
+      runLensNote: 'Frame this run around vegetation change, weather context, and plain-English proof.',
+      readyNote: 'Ready to run a conservation analysis.',
+      emptyHistoryNote: 'Your next submission will appear here.',
+      activeHistoryContext: 'field evidence',
+      completedHistoryOutcome: 'shareable evidence brief',
+      activePath: 'Tracking evidence build',
+      completedPath: 'Review results',
+      runLabel: 'Start analysis',
+      reviewLabel: 'Review latest incident',
+      deliverableLabel: 'Open evidence rail',
+      emptyContent: {
+        imageryTitle: 'Waiting for a run',
+        imageryNote: 'Before/after imagery and NDVI layers will appear here as the evidence stack forms.',
+        enrichmentTitle: 'Context pending',
+        enrichmentNote: 'Weather and narrative context will follow once the imagery pipeline is stable.',
+        exportsTitle: 'Evidence pack next',
+        exportsNote: 'Saved maps, narrative, and donor-ready exports will land here once run detail is wired.'
+      },
+      completedContent: {
+        exportsTitle: 'Evidence pack next',
+        exportsNote: 'Maps, narrative, and a field-ready evidence pack will be available after results load.'
+      }
+    },
+    eudr: {
+      label: 'EUDR',
+      tag: 'Audit trail',
+      title: 'EUDR due diligence',
+      summary: 'Support compliance teams that need post-2020 evidence, clear audit language, and no ambiguity about what the product actually processed.',
+      outcome: 'Due diligence dossier',
+      risk: 'Audit-ready trust',
+      rhythm: 'Quarterly refresh cadence',
+      historyCopy: 'Keep the most recent assessment visible while you decide whether another supplier plot needs review.',
+      runCopy: 'Queue a due diligence run with explicit product-path status.',
+      contentCopy: 'Use this rail to understand what audit evidence is forming before it becomes a saved due diligence dossier.',
+      runLensTitle: 'EUDR compliance check',
+      runLensNote: 'Keep baseline integrity, plain-English findings, and product-path reliability front and center.',
+      readyNote: 'Ready to run a due diligence check.',
+      emptyHistoryNote: 'Your next submission will appear here.',
+      activeHistoryContext: 'audit context',
+      completedHistoryOutcome: 'due diligence dossier',
+      activePath: 'Tracking audit evidence',
+      completedPath: 'Prepare audit dossier',
+      runLabel: 'Start due diligence run',
+      reviewLabel: 'Review latest assessment',
+      deliverableLabel: 'Open dossier rail',
+      emptyContent: {
+        imageryTitle: 'Awaiting baseline review',
+        imageryNote: 'Before/after imagery will anchor the post-2020 evidence trail once you queue a run.',
+        enrichmentTitle: 'Assessment pending',
+        enrichmentNote: 'Narrative findings and methodology framing follow after imagery is stable.',
+        exportsTitle: 'Audit dossier next',
+        exportsNote: 'Saved evidence packages with coordinates, methods, and narrative will land here once run detail is wired.'
+      },
+      completedContent: {
+        exportsTitle: 'Audit dossier next',
+        exportsNote: 'Coordinates, methods, and exportable due diligence evidence will be available after results load.'
+      }
+    },
+    portfolio: {
+      label: 'Portfolio Ops',
+      tag: 'Batch triage',
+      title: 'Portfolio operations',
+      summary: 'Support advisors, insurers, and ops teams who need to scan many parcels quickly, keep batch context visible, and decide what needs follow-up.',
+      outcome: 'Batch triage',
+      risk: 'Scale without guesswork',
+      rhythm: 'Event-driven review',
+      historyCopy: 'Keep the most recent batch visible so you can triage new uploads against what already moved.',
+      runCopy: 'Queue a batch-style analysis and keep scale warnings visible.',
+      contentCopy: 'Use this rail to understand what the current run is building before you reopen it as a parcel-level review.',
+      runLensTitle: 'Portfolio triage run',
+      runLensNote: 'Bias the workspace toward batch readiness, AOI spread, and which runs need deeper follow-up.',
+      readyNote: 'Ready to run a batch analysis.',
+      emptyHistoryNote: 'Your next submission will appear here.',
+      activeHistoryContext: 'batch context',
+      completedHistoryOutcome: 'triage summary',
+      activePath: 'Tracking batch progress',
+      completedPath: 'Open triage summary',
+      runLabel: 'Start batch triage run',
+      reviewLabel: 'Review latest batch',
+      deliverableLabel: 'Open triage rail',
+      emptyContent: {
+        imageryTitle: 'Awaiting parcel stack',
+        imageryNote: 'Imagery layers will appear here as batch-ready AOIs begin resolving into usable review outputs.',
+        enrichmentTitle: 'Triage context pending',
+        enrichmentNote: 'Context layers follow once the imagery stack shows where deeper review is needed.',
+        exportsTitle: 'Triage summary next',
+        exportsNote: 'Saved parcel review packs and export actions will land here once run detail is wired.'
+      },
+      completedContent: {
+        exportsTitle: 'Triage summary next',
+        exportsNote: 'Parcel-level review and export actions will be available after results load.'
+      }
+    }
+  };
+
+  const WORKSPACE_PREFERENCES = {
+    investigate: {
+      label: 'Investigate',
+      tag: 'Run-first',
+      title: 'Investigate suspicious change',
+      summary: 'Stay centered on the live run while you prove what changed, why it changed, and what to do next.',
+      deliverable: 'Operator brief',
+      stance: 'Prove the change before escalation',
+      primaryTarget: 'run',
+      secondaryTarget: 'history'
+    },
+    monitor: {
+      label: 'Monitor',
+      tag: 'Queue-first',
+      title: 'Monitor for movement over time',
+      summary: 'Bias the workspace toward what changed recently so recurring reviews and follow-up runs stay efficient.',
+      deliverable: 'Monitoring cadence',
+      stance: 'Spot movement early and repeat',
+      primaryTarget: 'history',
+      secondaryTarget: 'run'
+    },
+    report: {
+      label: 'Report',
+      tag: 'Deliverable-first',
+      title: 'Package findings for action',
+      summary: 'Focus on outputs, evidence language, and what to deliver next.',
+      deliverable: 'Decision packet',
+      stance: 'Translate signal into action',
+      primaryTarget: 'content',
+      secondaryTarget: 'run'
+    }
+  };
+
+  let _deps = {};
+  let _workspaceRole = 'conservation';
+  let _workspacePreference = 'investigate';
+
+  function init(deps) {
+    _deps = deps || {};
+  }
+
+  function readStoredValue(key) {
+    if (_deps.readStoredValue) return _deps.readStoredValue(key);
+    return null;
+  }
+
+  function storeValue(key, value) {
+    if (_deps.storeValue) _deps.storeValue(key, value);
+  }
+
+  function currentRoleConfig() {
+    return WORKSPACE_ROLES[_workspaceRole] || WORKSPACE_ROLES.conservation;
+  }
+
+  function currentPreferenceConfig() {
+    return WORKSPACE_PREFERENCES[_workspacePreference] || WORKSPACE_PREFERENCES.investigate;
+  }
+
+  function notifyChange() {
+    if (_deps.onChange) _deps.onChange();
+  }
+
+  function setRole(roleKey, options) {
+    if (!WORKSPACE_ROLES[roleKey]) return;
+    _workspaceRole = roleKey;
+    if (_deps.setCoreState) _deps.setCoreState('workspaceRole', roleKey);
+    if (!options || options.persist !== false) {
+      storeValue(_deps.roleStorageKey, roleKey);
+    }
+    notifyChange();
+  }
+
+  function setPreference(preferenceKey, options) {
+    if (!WORKSPACE_PREFERENCES[preferenceKey]) return;
+    _workspacePreference = preferenceKey;
+    if (_deps.setCoreState) _deps.setCoreState('workspacePreference', preferenceKey);
+    if (!options || options.persist !== false) {
+      storeValue(_deps.preferenceStorageKey, preferenceKey);
+    }
+    notifyChange();
+  }
+
+  function bootstrap(activeProfile, lockedWorkspace) {
+    const profile = activeProfile || {};
+    if (lockedWorkspace) {
+      _workspaceRole = profile.defaultRole || 'eudr';
+      _workspacePreference = profile.defaultPreference || 'report';
+    } else {
+      _workspaceRole = readStoredValue(_deps.roleStorageKey) || _workspaceRole;
+      _workspacePreference = readStoredValue(_deps.preferenceStorageKey) || _workspacePreference;
+    }
+    if (_deps.setCoreState) {
+      _deps.setCoreState('workspaceRole', _workspaceRole);
+      _deps.setCoreState('workspacePreference', _workspacePreference);
+    }
+    notifyChange();
+  }
+
+  function getRole() {
+    return _workspaceRole;
+  }
+
+  function getPreference() {
+    return _workspacePreference;
+  }
+
+  window.CanopexWorkspace = {
+    init: init,
+    bootstrap: bootstrap,
+    getRole: getRole,
+    getPreference: getPreference,
+    currentRoleConfig: currentRoleConfig,
+    currentPreferenceConfig: currentPreferenceConfig,
+    setRole: setRole,
+    setPreference: setPreference,
+  };
+})();

--- a/website/js/canopex-api-client.js
+++ b/website/js/canopex-api-client.js
@@ -10,24 +10,15 @@
     apiHealthTimeoutMs: 1200
   };
 
-  function normalizeHostname(value) {
-    if (!value || typeof value !== 'string') return '';
-    if (value[0] === '[' && value[value.length - 1] === ']') {
-      return value.slice(1, -1);
-    }
-    return value;
-  }
-
   function runningOnLocalDevOrigin() {
-    const hostname = normalizeHostname(window.location.hostname);
-    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+    return window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
   }
 
   function isLoopbackApiBase(value) {
     if (!value || typeof value !== 'string') return false;
     try {
       const parsed = new URL(value);
-      const host = normalizeHostname(parsed.hostname);
+      const host = parsed.hostname;
       return host === 'localhost' || host === '127.0.0.1' || host === '::1';
     } catch {
       return false;

--- a/website/js/canopex-geo.js
+++ b/website/js/canopex-geo.js
@@ -134,6 +134,49 @@
     return 'Single run';
   }
 
+  /**
+   * Parse name/lat/lon rows from CSV text.
+   * Accepts an optional header row detected by the presence of "name" and "lat"/"lon".
+   *
+   * @param {string} text - raw CSV text from user input
+   * @returns {{ plots: Array<{ name: string, lat: number, lon: number }>, errors: string[] }}
+   */
+  function parseCSVCoordinates(text) {
+    var lines = text.trim().split(/\r?\n/).filter(Boolean);
+    if (lines.length === 0) return { plots: [], errors: ['No data entered'] };
+
+    var plots = [];
+    var errors = [];
+    var startIdx = 0;
+
+    // Detect header row
+    var firstLine = lines[0].toLowerCase().replace(/\s/g, '');
+    if (firstLine.indexOf('name') >= 0 && (firstLine.indexOf('lat') >= 0 || firstLine.indexOf('lon') >= 0)) {
+      startIdx = 1;
+    }
+
+    for (var i = startIdx; i < lines.length; i++) {
+      var parts = lines[i].split(',').map(function(s) { return s.trim(); });
+      if (parts.length < 3) {
+        errors.push('Row ' + (i + 1) + ': expected name, lat, lon — got ' + parts.length + ' columns');
+        continue;
+      }
+      var name = parts[0] || 'Parcel ' + (plots.length + 1);
+      var lat = parseFloat(parts[1]);
+      var lon = parseFloat(parts[2]);
+      if (isNaN(lat) || isNaN(lon)) {
+        errors.push('Row ' + (i + 1) + ': invalid coordinates (' + parts[1] + ', ' + parts[2] + ')');
+        continue;
+      }
+      if (lat < -90 || lat > 90 || lon < -180 || lon > 180) {
+        errors.push('Row ' + (i + 1) + ': coordinates out of range (lat: ' + lat + ', lon: ' + lon + ')');
+        continue;
+      }
+      plots.push({ name: name, lat: lat, lon: lon });
+    }
+    return { plots: plots, errors: errors };
+  }
+
   window.CanopexGeo = {
     escHtml: escHtml,
     parseKmlText: parseKmlText,
@@ -145,5 +188,6 @@
     formatDistance: formatDistance,
     formatHectares: formatHectares,
     determineProcessingMode: determineProcessingMode,
+    parseCSVCoordinates: parseCSVCoordinates,
   };
 })();


### PR DESCRIPTION
## Summary
- extract shared frontend runtime state into app-runtime.js
- rewire app-shell.js into composition-only module wiring (no local runtime-state ownership)
- move remaining history upsert coordination into app-run-lifecycle.js
- add app-runtime.js script include for both app entrypoints
- add frontend regression coverage for runtime script load order
- mark composition-only work item done in docs/APP_SHELL_HEALTH_PLAN.md

## Validation
- python -m pytest tests/test_frontend_config.py tests/test_analysis_submission_endpoints.py tests/test_billing_endpoints.py -x -q (130 passed)
- make test (1621 passed, 1 skipped, 27 deselected)

## Notes
- This PR is scoped to app-shell modularization and composition-root cleanup only.
- Manual smoke checklist in APP_SHELL_HEALTH_PLAN remains to be completed during review/QA.
