### PR TITLE
Fix EUDR account usage consistency and loading states

### DIFF
--- a/tests/test_frontend_config.py
+++ b/tests/test_frontend_config.py
@@ -23,6 +23,8 @@ EUDR_INDEX_HTML = WEBSITE / "eudr" / "index.html"
 LANDING_JS = WEBSITE / "js" / "landing.js"
 APP_SHELL_JS = WEBSITE / "js" / "app-shell.js"
 APP_RUNS_JS = WEBSITE / "js" / "app-runs.js"
+APP_BILLING_JS = WEBSITE / "js" / "app-billing.js"
+APP_EUDR_JS = WEBSITE / "js" / "app-eudr.js"
 API_CLIENT_JS = WEBSITE / "js" / "canopex-api-client.js"
 APP_AUTH_JS = WEBSITE / "js" / "app-auth.js"
 SWA_CONFIG = WEBSITE / "staticwebapp.config.json"
@@ -57,6 +59,16 @@ def app_shell_js():
 @pytest.fixture()
 def app_runs_js():
     return APP_RUNS_JS.read_text()
+
+
+@pytest.fixture()
+def app_billing_js():
+    return APP_BILLING_JS.read_text()
+
+
+@pytest.fixture()
+def app_eudr_js():
+    return APP_EUDR_JS.read_text()
 
 
 @pytest.fixture()
@@ -253,6 +265,47 @@ class TestAuthConfig:
         )
         assert "history-org" in app_runs_js, (
             "app-runs.js must keep org history cache separate from user-scoped history cache"
+        )
+
+
+class TestBillingEmulationUi:
+    def test_billing_module_defines_fallback_emulation_tiers(self, app_billing_js):
+        """Plan emulation selector should remain usable if API omits emulation.tiers."""
+        expected = "['demo', 'free', 'starter', 'pro', 'team', 'enterprise', 'eudr_pro']"
+        assert expected in app_billing_js, (
+            "app-billing.js must define a fallback tier list for plan emulation"
+        )
+
+    def test_billing_module_formats_eudr_pro_label(self, app_billing_js):
+        """Emulation selector should render eudr_pro with a readable label."""
+        assert "if (tier === 'eudr_pro') return 'EUDR Pro';" in app_billing_js, (
+            "app-billing.js must render eudr_pro as EUDR Pro in plan emulation options"
+        )
+
+
+class TestEudrUsageConsistency:
+    def test_eudr_usage_labels_include_scope(self, eudr_index_html):
+        """EUDR usage card labels should explicitly communicate metric scope."""
+        assert "Included parcels (current billing period)" in eudr_index_html, (
+            "eudr/index.html must label included parcels as current billing period"
+        )
+        assert "Last 6 months (org run history)" in eudr_index_html, (
+            "eudr/index.html must label history as org run history"
+        )
+
+    def test_eudr_inline_script_no_longer_depends_on_global_apifetch(self, eudr_index_html):
+        """Legacy inline billing script must not wait for window.apiFetch anymore."""
+        assert "window.apiFetch" not in eudr_index_html, (
+            "eudr/index.html should use CanopexApiClient directly, not window.apiFetch"
+        )
+
+    def test_app_eudr_updates_hero_parcels_and_unavailable_state(self, app_eudr_js):
+        """EUDR module should set hero parcel pill and clear loading state on errors."""
+        assert "eudr-parcels-used" in app_eudr_js, (
+            "app-eudr.js must update the hero parcels stat pill"
+        )
+        assert "Usage unavailable right now." in app_eudr_js, (
+            "app-eudr.js must clear loading text when usage fetch fails"
         )
 
 

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -520,13 +520,13 @@
             <article class="app-card app-support-card" id="app-eudr-usage-card">
               <h3>Usage Dashboard</h3>
               <dl class="app-stats compact" id="app-eudr-usage-stats">
-                <div><dt>Included parcels</dt><dd id="app-eudr-usage-included">Loading…</dd></div>
+                <div><dt>Included parcels (current billing period)</dt><dd id="app-eudr-usage-included">Loading…</dd></div>
                 <div><dt>Overage parcels</dt><dd id="app-eudr-usage-overage">Loading…</dd></div>
                 <div><dt>Estimated spend</dt><dd id="app-eudr-usage-spend">Loading…</dd></div>
                 <div><dt>Next tier</dt><dd id="app-eudr-usage-next-tier">Loading…</dd></div>
               </dl>
               <div class="app-content-block" id="app-eudr-usage-history-block">
-                <span class="app-content-label">Last 6 months</span>
+                <span class="app-content-label">Last 6 months (org run history)</span>
                 <div id="app-eudr-usage-history-list">Loading usage history…</div>
               </div>
             </article>
@@ -643,59 +643,6 @@
   function isEudrPage() { return window.location.pathname.indexOf('/eudr/') === 0; }
   if (!isEudrPage()) return;
 
-  function waitForShell() {
-    return new Promise(function (resolve, reject) {
-      if (typeof window.apiFetch === 'function') { resolve(); return; }
-      var attempts = 0;
-      var maxAttempts = 100; /* 10 seconds at 100ms intervals */
-      var t = setInterval(function () {
-        attempts++;
-        if (typeof window.apiFetch === 'function') { clearInterval(t); resolve(); }
-        else if (attempts >= maxAttempts) { clearInterval(t); reject(new Error('App shell did not load')); }
-      }, 100);
-    });
-  }
-
-  async function loadEudrBilling() {
-    await waitForShell();
-    try {
-      var res = await window.apiFetch('/api/eudr/billing');
-      var data = await res.json();
-      eudrBillingData = data;
-      applyEudrBilling(data);
-    } catch (e) {
-      console.warn('EUDR billing load failed', e);
-    }
-  }
-
-  function applyEudrBilling(data) {
-    var planEl = document.getElementById('app-hero-plan');
-    var planNoteEl = document.getElementById('app-hero-plan-note');
-    var parcelsEl = document.getElementById('eudr-parcels-used');
-    var parcelsNoteEl = document.getElementById('eudr-parcels-note');
-
-    if (planEl && data.plan) {
-      planEl.textContent = data.subscribed ? 'EUDR Pro' : 'Free Trial';
-      planNoteEl.textContent = data.subscribed
-        ? 'Active subscription'
-        : data.trial_remaining + ' of 2 free assessments remaining';
-    }
-
-    if (parcelsEl) {
-      if (data.subscribed) {
-        parcelsEl.textContent = data.period_parcels_used + ' / ' + data.included_parcels;
-        parcelsNoteEl.textContent = data.overage_parcels > 0
-          ? data.overage_parcels + ' overage parcels this period'
-          : 'Included parcels used this period';
-      } else {
-        parcelsEl.textContent = data.assessments_used + ' / 2';
-        parcelsNoteEl.textContent = data.trial_remaining > 0
-          ? data.trial_remaining + ' free assessment' + (data.trial_remaining > 1 ? 's' : '') + ' remaining'
-          : 'Free trial exhausted — subscribe to continue';
-      }
-    }
-  }
-
   function showSubscribeModal() {
     var backdrop = document.getElementById('eudr-subscribe-backdrop');
     if (backdrop) {
@@ -714,8 +661,12 @@
     var btn = document.getElementById('eudr-subscribe-btn');
     if (btn) { btn.disabled = true; btn.textContent = 'Redirecting…'; }
     try {
-      await waitForShell();
-      var res = await window.apiFetch('/api/eudr/subscribe', {
+      if (!window.CanopexApiClient || typeof window.CanopexApiClient.createClient !== 'function') {
+        throw new Error('API client unavailable');
+      }
+      var client = window.CanopexApiClient.createClient();
+      await client.discoverApiBase();
+      var res = await client.fetch('/api/eudr/subscribe', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({})
@@ -740,6 +691,7 @@
 
   /* Expose for the app shell to call when entitlement check fails */
   window.showEudrSubscribeModal = showSubscribeModal;
+  window.setEudrBillingData = function (data) { eudrBillingData = data; };
   window.eudrBillingData = function () { return eudrBillingData; };
 
   document.addEventListener('DOMContentLoaded', function () {
@@ -762,17 +714,9 @@
 
     /* Check for ?subscribed=true after Stripe redirect */
     if (window.location.search.indexOf('subscribed=true') !== -1) {
-      /* Clean URL and reload billing */
+      /* Clean URL after Stripe redirect */
       history.replaceState(null, '', window.location.pathname);
-      loadEudrBilling();
     }
-  });
-
-  /* Load EUDR billing when the shell signals auth is ready */
-  document.addEventListener('canopex:auth-ready', loadEudrBilling);
-  /* Also try loading on DOMContentLoaded in case auth-ready already fired */
-  document.addEventListener('DOMContentLoaded', function () {
-    setTimeout(loadEudrBilling, 500);
   });
 })();
 </script>

--- a/website/js/app-billing.js
+++ b/website/js/app-billing.js
@@ -32,6 +32,7 @@
   var _latestBillingStatus = null;
 
   var CACHE_TTL_BILLING = 5 * 60 * 1000; // 5 minutes
+  var DEFAULT_EMULATION_TIERS = ['demo', 'free', 'starter', 'pro', 'team', 'enterprise', 'eudr_pro'];
 
   function init(deps) {
     _apiFetch = deps.apiFetch;
@@ -63,6 +64,27 @@
     if (retEl) retEl.textContent = formatRetention(caps.retention_days);
   }
 
+  function resolveEmulationTiers(emulation) {
+    var rawTiers = Array.isArray(emulation && emulation.tiers)
+      ? emulation.tiers
+      : DEFAULT_EMULATION_TIERS;
+    var seen = {};
+    var normalized = [];
+    rawTiers.forEach(function (tier) {
+      if (typeof tier !== 'string') return;
+      var value = tier.trim().toLowerCase();
+      if (!value || value === 'actual' || seen[value]) return;
+      seen[value] = true;
+      normalized.push(value);
+    });
+    return normalized.length ? normalized : DEFAULT_EMULATION_TIERS.slice();
+  }
+
+  function tierLabel(tier) {
+    if (tier === 'eudr_pro') return 'EUDR Pro';
+    return tier.charAt(0).toUpperCase() + tier.slice(1);
+  }
+
   function renderTierEmulation(data) {
     var card = document.getElementById('app-tier-emulation-card');
     var select = document.getElementById('app-tier-emulation-select');
@@ -83,14 +105,18 @@
     actualOption.textContent = 'Actual billing state';
     select.appendChild(actualOption);
 
-    (data.emulation.tiers || []).forEach(function (tier) {
+    resolveEmulationTiers(data.emulation).forEach(function (tier) {
       var option = document.createElement('option');
       option.value = tier;
-      option.textContent = tier.charAt(0).toUpperCase() + tier.slice(1);
+      option.textContent = tierLabel(tier);
       select.appendChild(option);
     });
 
-    select.value = data.emulation.active ? data.emulation.tier : 'actual';
+    var selected = data.emulation.active ? data.emulation.tier : 'actual';
+    if (typeof selected !== 'string' || !select.querySelector("option[value='" + selected + "']")) {
+      selected = 'actual';
+    }
+    select.value = selected;
     if (data.emulation.active) {
       note.textContent = 'Currently emulating ' + (data.capabilities.label || data.tier) + ' for your account. Billing remains ' + ((data.subscription && data.subscription.tier) || 'free') + '.';
     } else {

--- a/website/js/app-eudr.js
+++ b/website/js/app-eudr.js
@@ -16,11 +16,56 @@
   var _apiFetch = null;
   var _getApiReady = null;
   var _getAccount = null;
+  var _billingSnapshot = null;
 
   function init(deps) {
     _apiFetch    = deps.apiFetch    || _apiFetch;
     _getApiReady = deps.getApiReady || _getApiReady;
     _getAccount  = deps.getAccount  || _getAccount;
+    // Keep backward compatibility for existing consumers (e.g. cost estimate).
+    window.eudrBillingData = function () { return _billingSnapshot; };
+  }
+
+  function setHeroParcels(periodUsed, included, overage) {
+    var parcelsEl = document.getElementById('eudr-parcels-used');
+    var parcelsNoteEl = document.getElementById('eudr-parcels-note');
+    if (!parcelsEl || !parcelsNoteEl) return;
+
+    parcelsEl.textContent = periodUsed + ' / ' + included;
+    parcelsNoteEl.textContent = overage > 0
+      ? overage + ' overage parcels this billing period'
+      : 'Included parcels used this billing period';
+  }
+
+  function setUsageUnavailable() {
+    var includedEl = document.getElementById('app-eudr-usage-included');
+    var overageEl = document.getElementById('app-eudr-usage-overage');
+    var spendEl = document.getElementById('app-eudr-usage-spend');
+    var nextTierEl = document.getElementById('app-eudr-usage-next-tier');
+    var historyListEl = document.getElementById('app-eudr-usage-history-list');
+    var parcelsEl = document.getElementById('eudr-parcels-used');
+    var parcelsNoteEl = document.getElementById('eudr-parcels-note');
+
+    if (includedEl) includedEl.textContent = '—';
+    if (overageEl) overageEl.textContent = '—';
+    if (spendEl) spendEl.textContent = '—';
+    if (nextTierEl) nextTierEl.textContent = 'Usage unavailable';
+    if (historyListEl) historyListEl.textContent = 'Usage unavailable right now.';
+    if (parcelsEl) parcelsEl.textContent = '—';
+    if (parcelsNoteEl) parcelsNoteEl.textContent = 'Usage unavailable right now.';
+  }
+
+  async function refreshBillingSnapshot() {
+    try {
+      var billingRes = await _apiFetch('/api/eudr/billing');
+      if (!billingRes.ok) return;
+      _billingSnapshot = await billingRes.json();
+      if (typeof window.setEudrBillingData === 'function') {
+        window.setEudrBillingData(_billingSnapshot);
+      }
+    } catch (_err) {
+      // Billing snapshot is best-effort and should not block usage rendering.
+    }
   }
 
   async function loadUsage() {
@@ -36,27 +81,33 @@
 
     try {
       var res = await _apiFetch('/api/eudr/usage');
-      if (!res.ok) return;
+      if (!res.ok) {
+        setUsageUnavailable();
+        return;
+      }
       var data = await res.json();
       var cur = data.current || {};
 
       var periodUsed = cur.periodParcelsUsed || 0;
       var included   = cur.includedParcels   || 0;
+      var overage = cur.overageParcels || 0;
       if (includedEl) includedEl.textContent = periodUsed + ' / ' + included;
-      if (overageEl)  overageEl.textContent  = (cur.overageParcels || 0) + ' parcels';
+      if (overageEl)  overageEl.textContent  = overage + ' parcels';
       if (spendEl) {
         var spend = cur.estimatedSpendGbp;
         spendEl.textContent = (spend != null) ? ('£' + spend.toFixed(2)) : '—';
       }
       if (nextTierEl) {
         if (cur.nextTierThreshold) {
-          var msg = cur.parcelsToNextTier + ' until next tier (£' + cur.nextTierRateGbp + '/parcel)';
+          var msg = cur.parcelsToNextTier + ' until next tier this billing period (£' + cur.nextTierRateGbp + '/parcel)';
           nextTierEl.textContent = msg;
           if (cur.within20PercentOfNextTier) nextTierEl.style.fontWeight = '600';
         } else {
           nextTierEl.textContent = 'Maximum tier reached';
         }
       }
+
+      setHeroParcels(periodUsed, included, overage);
 
       if (historyListEl && data.history && data.history.length) {
         var html = '<div class="app-usage-history-list">';
@@ -73,8 +124,11 @@
       } else if (historyListEl) {
         historyListEl.textContent = 'No usage history yet.';
       }
+
+      await refreshBillingSnapshot();
     } catch (e) {
       console.warn('EUDR usage load error:', e);
+      setUsageUnavailable();
     }
   }
 


### PR DESCRIPTION
## Summary
- fix EUDR parcel pill and usage dashboard to use a single modular data path
- remove legacy inline `/api/eudr/billing` loader that depended on missing `window.apiFetch` and left usage stuck on loading
- make usage scope explicit in UI labels (current billing period vs org run history)
- preserve billing snapshot compatibility for existing parcel cost estimate consumers
- add frontend regressions for scope labels, modular loader behavior, and removal of legacy apiFetch coupling

## Validation
- `node --check website/js/app-billing.js`
- `node --check website/js/app-eudr.js`
- `python -m pytest tests/test_frontend_config.py -x -q`
- `make test`

fixes #727
