### PR TITLE
docs(roadmap): link Stage 2E.5 issue chain

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -160,12 +160,12 @@ JTBD: submit once to one stable API surface and get reliable async completion.
 
 | Order | Issue | Title | Status |
 |-------|-------|-------|--------|
-| 2E.5.1 | — (new) | single owner for Event Grid webhook target (orchestrator) | Planned |
-| 2E.5.2 | — (new) | drift guard tests: fail on compute-host Event Grid endpoint references | Planned |
-| 2E.5.3 | — (new) | symmetric rollback and readiness for compute + orchestrator apps | Planned |
-| 2E.5.4 | — (new) | shared function registration module for dual entrypoints | Planned |
-| 2E.5.5 | — (new) | orchestrator-only public API surface; compute host internalized | Planned |
-| 2E.5.6 | — (new) | post-readiness async functional smoke gate as promotion blocker | Planned |
+| 2E.5.1 | #729 | single owner for Event Grid webhook target (orchestrator) | Open |
+| 2E.5.2 | #730 | drift guard tests: fail on compute-host Event Grid endpoint references | Open (post #729) |
+| 2E.5.3 | #731 | symmetric rollback and readiness for compute + orchestrator apps | Open (post #729, #730) |
+| 2E.5.4 | #732 | shared function registration module for dual entrypoints | Open (post #731) |
+| 2E.5.5 | #733 | orchestrator-only public API surface; compute host internalized | Open (post #732) |
+| 2E.5.6 | #734 | post-readiness async functional smoke gate as promotion blocker | Open (post #729–#733) |
 
 Validation gates for every slice:
 


### PR DESCRIPTION
## Summary\n- replace Stage 2E.5 placeholder rows with linked issues #729-#734\n- encode execution dependencies in row status text\n\n## Why\n- makes Stage 2E.5 execution order explicit in the roadmap source of truth\n\n## Validation\n- markdownlint-cli2\n\nrefs #729\nrefs #730\nrefs #731\nrefs #732\nrefs #733\nrefs #734