### PR TITLE
fix: copy function_registration.py into both Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,6 @@ RUN uv export --no-dev --no-hashes > /tmp/requirements.txt && \
     rm -f /tmp/requirements.txt /usr/local/bin/uv
 
 # Copy application code only (no scripts/, typings/, tests/, docs/)
-COPY host.json function_app.py ./
+COPY host.json function_app.py function_registration.py ./
 COPY treesight/ treesight/
 COPY blueprints/ blueprints/

--- a/Dockerfile.orchestrator
+++ b/Dockerfile.orchestrator
@@ -46,7 +46,7 @@ RUN uv export --no-dev --no-hashes > /tmp/requirements.txt && \
 # Copy application code only (no scripts/, typings/, tests/, docs/)
 # function_app_orch.py is the orchestrator entry point, installed as
 # function_app.py so the Functions runtime finds it automatically.
-COPY host.json function_app_orch.py ./
+COPY host.json function_app_orch.py function_registration.py ./
 RUN mv function_app_orch.py function_app.py
 COPY treesight/ treesight/
 COPY blueprints/ blueprints/


### PR DESCRIPTION
## Problem

The `function_registration` module was added in the orchestrator-split PR (#736) but was missing from the `COPY` instructions in both `Dockerfile` and `Dockerfile.orchestrator`.

This caused the container smoke test to fail on main:
```
✗ function_app.py importable — No module named 'function_registration'
```

## Fix

Added `function_registration.py` to the `COPY` line in both Dockerfiles.

## Checklist
- [x] Fixes post-merge CI failure
- [x] No test changes needed (container smoke test will pass once module is present)