### PR TITLE
fix(ci): pass bearer env to container smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,10 @@ jobs:
       - name: Run container smoke tests
         run: |
           docker run --rm \
+            -e AUTH_MODE="bearer_only" \
+            -e CIAM_AUTHORITY="https://treesightauth.ciamlogin.com" \
+            -e CIAM_TENANT_ID="ci-test-tenant" \
+            -e CIAM_API_AUDIENCE="api://ci-test-audience" \
             -v "${{ github.workspace }}/scripts:/scripts:ro" \
             treesight:ci-check \
             python3 /scripts/container_smoke_test.py


### PR DESCRIPTION
## Summary
- pass bearer-only auth env vars into CI build job container smoke test
- align container import-time config checks with existing CI test-job auth config

## Why
Recent main CI failed in Build Docker image because function_app.py import validation now requires CIAM env vars when AUTH_MODE=bearer_only, but the container smoke step did not provide them.

## Validation
- pre-commit run --files .github/workflows/ci.yml
