### PR TITLE
fix(deploy): pass bearer env to container smoke test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -195,6 +195,10 @@ jobs:
           IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
         run: |
           docker run --rm \
+            -e AUTH_MODE="bearer_only" \
+            -e CIAM_AUTHORITY="https://treesightauth.ciamlogin.com" \
+            -e CIAM_TENANT_ID="ci-test-tenant" \
+            -e CIAM_API_AUDIENCE="api://ci-test-audience" \
             -v "${{ github.workspace }}/scripts:/scripts:ro" \
             "${IMAGE_NAME}:${{ github.sha }}" \
             python3 /scripts/container_smoke_test.py


### PR DESCRIPTION
## Summary
- pass bearer-only auth env vars into Deploy workflow container smoke test step
- align Deploy build-time container validation with CI and runtime bearer-only config requirements

## Root cause
Deploy failed in Build & Push Container at Run container smoke tests because function_app.py import now requires CIAM env vars when AUTH_MODE=bearer_only, but deploy smoke invocation did not set them.

## Validation
- pre-commit run --files .github/workflows/deploy.yml
