### PR TITLE
Fix pipeline auth token audience and queue UX regressions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1135,11 +1135,12 @@ jobs:
           CIAM_CLIENT_ID: ${{ secrets.CIAM_CLIENT_ID }}
           CIAM_AUTHORITY: ${{ secrets.CIAM_AUTHORITY }}
           CIAM_TENANT_ID: ${{ secrets.CIAM_TENANT_ID }}
+          CIAM_API_AUDIENCE: ${{ secrets.CIAM_API_AUDIENCE }}
         run: |
           if [ -n "$CIAM_CLIENT_ID" ] && [ -n "$CIAM_AUTHORITY" ]; then
-            CIAM_JSON="{\"clientId\":\"${CIAM_CLIENT_ID}\",\"authority\":\"${CIAM_AUTHORITY}\",\"tenantId\":\"${CIAM_TENANT_ID}\"}"
+            CIAM_JSON="{\"clientId\":\"${CIAM_CLIENT_ID}\",\"authority\":\"${CIAM_AUTHORITY}\",\"tenantId\":\"${CIAM_TENANT_ID}\",\"apiAudience\":\"${CIAM_API_AUDIENCE}\"}"
             find website -name '*.html' -exec sed -i \
-              's|{"clientId":"","authority":"","tenantId":""}|'"${CIAM_JSON}"'|' {} +
+              's|{"clientId":"","authority":"","tenantId":"","apiAudience":""}|'"${CIAM_JSON}"'|' {} +
           fi
 
       - name: Deploy to Azure Static Web Apps

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -37,11 +37,12 @@ jobs:
           CIAM_CLIENT_ID: ${{ secrets.CIAM_CLIENT_ID }}
           CIAM_AUTHORITY: ${{ secrets.CIAM_AUTHORITY }}
           CIAM_TENANT_ID: ${{ secrets.CIAM_TENANT_ID }}
+          CIAM_API_AUDIENCE: ${{ secrets.CIAM_API_AUDIENCE }}
         run: |
           if [ -n "$CIAM_CLIENT_ID" ] && [ -n "$CIAM_AUTHORITY" ]; then
-            CIAM_JSON="{\"clientId\":\"${CIAM_CLIENT_ID}\",\"authority\":\"${CIAM_AUTHORITY}\",\"tenantId\":\"${CIAM_TENANT_ID}\"}"
+            CIAM_JSON="{\"clientId\":\"${CIAM_CLIENT_ID}\",\"authority\":\"${CIAM_AUTHORITY}\",\"tenantId\":\"${CIAM_TENANT_ID}\",\"apiAudience\":\"${CIAM_API_AUDIENCE}\"}"
             find website -name '*.html' -exec sed -i \
-              's|{"clientId":"","authority":"","tenantId":""}|'"${CIAM_JSON}"'|' {} +
+              's|{"clientId":"","authority":"","tenantId":"","apiAudience":""}|'"${CIAM_JSON}"'|' {} +
           else
             echo "::warning::CIAM secrets are not fully set; preview sign-in will remain disabled."
           fi

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -96,12 +96,12 @@ portfolio-level risk visibility.
 
 | PR | Summary |
 |----|---------|  
+| #751 | fix: pipeline auth + UI regressions — API-audience token scopes, SAS-upload fallback, EUDR trial UX, tier emulation gate |
 | #744 | feat(auth): migrate frontend from SWA `/.auth` to MSAL CIAM bearer flow (closes #710) |
 | #741 | hardening: enforce function app identity contract in deploy pipeline — fail-fast identity drift check, azapi lifecycle comment overhaul, runbook invariants |
 | #711 | chore: defer full #402 gating scope for single-env operation and make deploy image Trivy scan blocking (refs #402) |
 | #707 | fix: Stage 2E.2 reduce OpenTofu/CLI drift — deploy-time contract verification for Function App settings/images + ownership boundary docs (closes #405) |
 | #706 | chore: CI/security release-safety hardening — action pin upgrades (Trivy, CodeQL v4, Node24-compatible actions) + deploy readiness gate diagnostics/timeout hardening (closes #697, #698, #550, #551) |
-| #703 | fix: enforce run ownership for timelapse save/load and return 503 on run-lookup backend failures (closes #696) |
 
 ---
 

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -1187,6 +1187,8 @@ locals {
       AUTH_MODE                           = var.auth_mode
       OPS_DASHBOARD_KEY                   = var.ops_dashboard_key
     },
+    var.billing_allowed_users != "" ? { BILLING_ALLOWED_USERS = var.billing_allowed_users } : {},
+    var.tier_emulation_allowed_users != "" ? { TIER_EMULATION_ALLOWED_USERS = var.tier_emulation_allowed_users } : {},
     var.enable_cosmos_db ? {
       COSMOS_ENDPOINT      = azurerm_cosmosdb_account.main[0].endpoint
       COSMOS_DATABASE_NAME = azurerm_cosmosdb_sql_database.main[0].name

--- a/infra/tofu/variables.tf
+++ b/infra/tofu/variables.tf
@@ -172,7 +172,14 @@ variable "enable_stripe" {
 }
 
 variable "billing_allowed_users" {
-  description = "Comma-separated user IDs allowed to use real Stripe billing (feature gate)."
+  description = "Comma-separated user IDs allowed to use real Stripe billing (feature gate). These users also get tier emulation access."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "tier_emulation_allowed_users" {
+  description = "Comma-separated user IDs allowed to use tier emulation without billing access (optional; billing_allowed_users get emulation implicitly)."
   type        = string
   default     = ""
   sensitive   = true

--- a/tests/test_billing_endpoints.py
+++ b/tests/test_billing_endpoints.py
@@ -419,11 +419,11 @@ class TestCosmosBillingAllowed:
     @patch("treesight.storage.cosmos.read_item")
     @patch("treesight.security.users.get_user")
     def test_tier_emulation_rejected_when_not_in_cosmos(self, mock_get_user, mock_read):
-        """User not allowlisted in Cosmos is rejected."""
+        """User with no billing_allowed and no tier_emulation_allowed grant is rejected."""
         from blueprints.billing import billing_emulation
 
-        # Mock Cosmos user missing tier_emulation_allowed grant
-        mock_get_user.return_value = {"id": "not-allowlisted-user", "billing_allowed": True}
+        # User has neither billing_allowed nor tier_emulation_allowed
+        mock_get_user.return_value = {"id": "not-allowlisted-user", "billing_allowed": False}
         mock_read.return_value = None
 
         req = make_test_request(
@@ -436,6 +436,29 @@ class TestCosmosBillingAllowed:
         assert resp.status_code == 403
         body = resp.get_body().decode("utf-8")
         assert "not yet available" in body
+
+    @patch("treesight.storage.cosmos.upsert_item")
+    @patch("treesight.storage.cosmos.read_item")
+    @patch("treesight.security.users.get_user")
+    def test_billing_allowed_user_gets_emulation(self, mock_get_user, mock_read, mock_upsert):
+        """billing_allowed users get tier emulation implicitly (owner / operator perk)."""
+        from blueprints.billing import billing_emulation
+
+        mock_get_user.return_value = {"id": "owner-user", "billing_allowed": True}
+        store: dict = {}
+        mock_read.side_effect = lambda c, i, p: store.get(f"{c}/{i}")
+        mock_upsert.side_effect = lambda c, item: store.update({f"{c}/{item['id']}": item}) or item
+
+        req = make_test_request(
+            url="/api/billing/emulation",
+            method="POST",
+            body=json.dumps({"tier": "pro"}).encode("utf-8"),
+            principal_user_id="owner-user",
+        )
+        resp = billing_emulation(req)
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["emulation"]["available"] is True
 
     @patch("treesight.storage.cosmos.read_item")
     @patch("treesight.security.users.get_user")

--- a/tests/test_frontend_config.py
+++ b/tests/test_frontend_config.py
@@ -256,6 +256,24 @@ class TestAuthConfig:
             "app-msal.js getToken must await ensureMsalReady before MSAL API calls"
         )
 
+    def test_msal_module_supports_api_audience_config(self):
+        """MSAL module must read optional API audience from injected CIAM config."""
+        js = APP_MSAL_JS.read_text()
+        assert "apiAudience" in js, "app-msal.js must parse apiAudience from canopex-ciam-config"
+        assert "audience + '/.default'" in js, (
+            "app-msal.js must derive an API scope from apiAudience"
+        )
+
+    def test_msal_module_prefers_access_token_when_api_audience_present(self):
+        """Backend bearer validation requires API-audience access token when configured."""
+        js = APP_MSAL_JS.read_text()
+        assert "if (ciam.apiAudience)" in js, (
+            "app-msal.js getToken must branch when apiAudience is configured"
+        )
+        assert "return result.accessToken || result.idToken || '';" in js, (
+            "app-msal.js getToken must prefer accessToken when apiAudience is configured"
+        )
+
     def test_msal_module_splits_update_auth_ui_render_paths(self):
         """Auth UI rendering should be split into smaller helpers."""
         js = APP_MSAL_JS.read_text()
@@ -385,6 +403,20 @@ class TestAuthConfig:
         ciam_idx = eudr_index_html.index("canopex-ciam-config")
         ciam_context = eudr_index_html[max(0, ciam_idx - 100) : ciam_idx + 100]
         assert 'type="application/json"' in ciam_context, "canopex-ciam-config must be JSON type"
+
+    def test_entrypoints_include_api_audience_placeholder(
+        self, index_html, app_index_html, eudr_index_html
+    ):
+        """CIAM config placeholders must reserve apiAudience for deploy-time injection."""
+        assert '"apiAudience":""' in index_html, (
+            "/index.html must include apiAudience in canopex-ciam-config JSON"
+        )
+        assert '"apiAudience":""' in app_index_html, (
+            "/app/index.html must include apiAudience in canopex-ciam-config JSON"
+        )
+        assert '"apiAudience":""' in eudr_index_html, (
+            "/eudr/index.html must include apiAudience in canopex-ciam-config JSON"
+        )
 
     def test_app_shell_supports_org_scope_history(self, app_runs_js):
         """EUDR dashboard should request org-scoped analysis history for portfolio triage."""

--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -1005,6 +1005,12 @@ class TestFrontendQueueFallback:
             "queue fallback must call /api/analysis/submit when direct blob upload fails"
         )
 
+    def test_queue_fallback_preserves_401_auth_ux(self):
+        content = self.APP_RUN_LIFECYCLE.read_text()
+        assert "submitFetchErr.status === 401" in content, (
+            "direct-submit fallback must preserve session-expired auth handling for 401 errors"
+        )
+
 
 class TestSignedOutStatusBadge:
     """Navbar service status badge should be hidden when no account is signed in."""

--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -985,20 +985,42 @@ class TestFrontendProgressReset:
             fn_end = len(content)
         fn_body = content[fn_start:fn_end]
 
-        # Find error handling blocks: 'if (!tokenRes || !tokenRes.ok)' or
-        # 'if (!uploadRes || !uploadRes.ok)' — the event-driven flow has
-        # two error check points (token + upload)
-        error_branch = re.search(
-            r"if\s*\(\s*!\w+Res\s*\|\|\s*!\w+Res\.ok\s*\)(.*?)(?:}\s*$|}\s*\n)",
-            fn_body,
-            flags=re.DOTALL,
+        assert "resetAnalysisProgress" in fn_body, (
+            "queueAnalysis must call resetAnalysisProgress() in error paths "
+            "to hide the pipeline spinner when submission fails"
         )
-        assert error_branch, "Error branch 'if (!...Res || !...Res.ok)' not found in queueAnalysis"
-        error_block = error_branch.group(1)
 
-        assert "resetAnalysisProgress" in error_block, (
-            "queueAnalysis error branch must call resetAnalysisProgress() "
-            "to hide the pipeline spinner on API failure"
+
+class TestFrontendQueueFallback:
+    """Queue flow should fall back to direct API submit when SAS upload fails."""
+
+    APP_RUN_LIFECYCLE = WEBSITE / "js" / "app-run-lifecycle.js"
+
+    def test_queue_flow_has_direct_submit_fallback(self):
+        content = self.APP_RUN_LIFECYCLE.read_text()
+        assert "function queueAnalysisViaSubmitApi" in content, (
+            "app-run-lifecycle.js must define a direct submit fallback helper"
+        )
+        assert "'/api/analysis/submit'" in content, (
+            "queue fallback must call /api/analysis/submit when direct blob upload fails"
+        )
+
+
+class TestSignedOutStatusBadge:
+    """Navbar service status badge should be hidden when no account is signed in."""
+
+    APP_MSAL = WEBSITE / "js" / "app-msal.js"
+
+    def test_signed_out_hides_status_badge(self):
+        content = self.APP_MSAL.read_text()
+        fn_start = content.find("function renderSignedOutUI(elements)")
+        assert fn_start != -1, "renderSignedOutUI not found in app-msal.js"
+        fn_end = content.find("\n  function ", fn_start + 1)
+        if fn_end == -1:
+            fn_end = len(content)
+        fn_body = content[fn_start:fn_end]
+        assert "elements.statusBadge" in fn_body and "style.display = 'none'" in fn_body, (
+            "renderSignedOutUI must hide the navbar status badge"
         )
 
 

--- a/treesight/security/feature_gate.py
+++ b/treesight/security/feature_gate.py
@@ -4,9 +4,10 @@ Operator status is checked in two places (either granting access is sufficient):
 1. ``BILLING_ALLOWED_USERS`` environment variable — static allow-list (fast, no I/O)
 2. Cosmos ``users`` container — ``billing_allowed`` flag per user (fallback)
 
-Tier emulation is gated separately via:
-1. ``TIER_EMULATION_ALLOWED_USERS`` environment variable
-2. Cosmos ``users`` container — ``tier_emulation_allowed`` flag per user
+Tier emulation is available to:
+1. Any ``billing_allowed`` user (operators / owners get it implicitly)
+2. ``TIER_EMULATION_ALLOWED_USERS`` environment variable
+3. Cosmos ``users`` container — ``tier_emulation_allowed`` flag per user
 """
 
 from __future__ import annotations
@@ -49,12 +50,18 @@ def billing_allowed(user_id: str | None) -> bool:
 def tier_emulation_allowed(user_id: str | None) -> bool:
     """Return True if *user_id* may use billing tier emulation controls.
 
-    This is a dedicated operator gate and MUST remain separate from
-    ``billing_allowed`` to avoid coupling real billing access with emulation
-    controls that can bypass plan-gated behavior.
+    Billing-allowed users (operators / owners) implicitly get emulation
+    access — they are already elevated accounts and emulation is a
+    natural part of their testing workflow.  Additional explicit grants
+    via ``TIER_EMULATION_ALLOWED_USERS`` or the Cosmos flag remain
+    available for non-billing accounts that need emulation only.
     """
     if not user_id or user_id == "anonymous":
         return False
+
+    # Billing-allowed users get emulation implicitly.
+    if billing_allowed(user_id):
+        return True
 
     if TIER_EMULATION_ALLOWED_USERS and user_id in TIER_EMULATION_ALLOWED_USERS:
         return True

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -19,7 +19,7 @@
 <link rel="stylesheet" href="/css/app.css">
 <meta name="ai-connection-string" content="">
 <!-- CIAM config: replaced by CI deploy step (see .github/workflows/deploy.yml) -->
-<script id="canopex-ciam-config" type="application/json">{"clientId":"","authority":"","tenantId":""}</script>
+<script id="canopex-ciam-config" type="application/json">{"clientId":"","authority":"","tenantId":"","apiAudience":""}</script>
 <script src="/js/analytics.js" defer></script>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha384-cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HTH" crossorigin="anonymous"></script> <!-- pragma: allowlist secret -->
 <script src="/js/canopex-geo.js" defer></script>

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -18,7 +18,7 @@
 <link rel="stylesheet" href="/css/shared.css">
 <link rel="stylesheet" href="/css/app.css">
 <meta name="ai-connection-string" content=""> <!-- Analytics/App Insights config: replaced by CI deploy step (see .github/workflows/deploy.yml) -->
-<script id="canopex-ciam-config" type="application/json">{"clientId":"","authority":"","tenantId":""}</script>
+<script id="canopex-ciam-config" type="application/json">{"clientId":"","authority":"","tenantId":"","apiAudience":""}</script>
 <script src="/js/analytics.js" defer></script>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha384-cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HTH" crossorigin="anonymous"></script> <!-- pragma: allowlist secret -->
 <script src="/js/canopex-geo.js" defer></script>
@@ -107,9 +107,9 @@
         </div>
         <div class="app-welcome-stats">
           <div class="app-stat-pill"><span class="app-utility-label">Plan</span><strong id="app-hero-plan">Loading…</strong><span class="app-utility-note" id="app-hero-plan-note">Checking entitlement…</span></div>
-          <div class="app-stat-pill" id="eudr-parcels-pill"><span class="app-utility-label">Parcels</span><strong id="eudr-parcels-used">—</strong><span class="app-utility-note" id="eudr-parcels-note">Loading usage…</span></div>
-          <div class="app-stat-pill"><span class="app-utility-label">Runs Left</span><strong id="app-hero-runs">—</strong><span class="app-utility-note" id="app-hero-runs-note">Quota refreshes with your plan.</span></div>
-          <div class="app-stat-pill"><span class="app-utility-label">Mode</span><strong id="app-hero-mode">EUDR due diligence</strong><span class="app-utility-note" id="app-hero-mode-note">Imagery restricted to post-Dec 2020 for EUDR compliance.</span></div>
+          <div class="app-stat-pill" id="eudr-parcels-pill"><span class="app-utility-label" id="eudr-parcels-label">Parcels</span><strong id="eudr-parcels-used">—</strong><span class="app-utility-note" id="eudr-parcels-note">Loading usage…</span></div>
+          <div class="app-stat-pill"><span class="app-utility-label">Reports you can run</span><strong id="app-hero-runs">—</strong><span class="app-utility-note" id="app-hero-runs-note">How many assessments you can start right now.</span></div>
+          <div class="app-stat-pill"><span class="app-utility-label">Coverage</span><strong id="app-hero-mode">EUDR due diligence</strong><span class="app-utility-note" id="app-hero-mode-note">Post-Dec 2020 satellite imagery for EUDR compliance.</span></div>
           <div class="app-stat-pill"><span class="app-utility-label">Active Run</span><strong id="app-hero-active-run">Checking recent runs</strong><span class="app-utility-note" id="app-hero-active-run-note">Loading your recent runs.</span></div>
         </div>
         <div class="app-welcome-actions">

--- a/website/index.html
+++ b/website/index.html
@@ -19,7 +19,7 @@
 <link rel="stylesheet" href="/css/style.css">
 <meta name="ai-connection-string" content="">
 <!-- CIAM config: replaced by CI deploy step (see .github/workflows/deploy.yml) -->
-<script id="canopex-ciam-config" type="application/json">{"clientId":"","authority":"","tenantId":""}</script>
+<script id="canopex-ciam-config" type="application/json">{"clientId":"","authority":"","tenantId":"","apiAudience":""}</script>
 <script src="/js/analytics.js" defer></script>
 </head>
 <body>

--- a/website/js/app-eudr.js
+++ b/website/js/app-eudr.js
@@ -26,15 +26,31 @@
     window.eudrBillingData = function () { return _billingSnapshot; };
   }
 
-  function setHeroParcels(periodUsed, included, overage) {
+  function setHeroParcels(periodUsed, included, overage, billing) {
+    var labelEl = document.getElementById('eudr-parcels-label');
     var parcelsEl = document.getElementById('eudr-parcels-used');
     var parcelsNoteEl = document.getElementById('eudr-parcels-note');
     if (!parcelsEl || !parcelsNoteEl) return;
 
+    // Free / unsubscribed: show lifetime free assessments, not the monthly billing counter.
+    // The monthly counter is always 0 for non-subscribers and the "10 included" quota
+    // only applies to Pro — showing "0 / 10" to a free user implies they have no parcels.
+    if (billing && !billing.subscribed) {
+      var remaining = billing.trial_remaining != null ? billing.trial_remaining : 0;
+      if (labelEl) labelEl.textContent = 'Free reports';
+      parcelsEl.textContent = remaining + ' left';
+      parcelsNoteEl.textContent = remaining > 0
+        ? 'Try ' + remaining + ' more EUDR report' + (remaining !== 1 ? 's' : '') + ' free — no card needed'
+        : 'Free reports used — subscribe to run more';
+      return;
+    }
+
+    // Subscribed: show monthly parcel billing usage.
+    if (labelEl) labelEl.textContent = 'Parcels this month';
     parcelsEl.textContent = periodUsed + ' / ' + included;
     parcelsNoteEl.textContent = overage > 0
-      ? overage + ' overage parcels this billing period'
-      : 'Included parcels used this billing period';
+      ? overage + ' overage parcel' + (overage !== 1 ? 's' : '') + ' this billing period'
+      : 'EUDR parcels assessed this billing period';
   }
 
   function setUsageUnavailable() {
@@ -80,6 +96,18 @@
     if (!includedEl) return; // card not present in this build
 
     try {
+      // Billing snapshot must come first — it determines free vs subscribed display.
+      await refreshBillingSnapshot();
+
+      // Overlay the generic Plan note with EUDR-specific trial context.
+      var planNoteEl = document.getElementById('app-hero-plan-note');
+      if (planNoteEl && _billingSnapshot && !_billingSnapshot.subscribed) {
+        var trialLeft = _billingSnapshot.trial_remaining != null ? _billingSnapshot.trial_remaining : 0;
+        planNoteEl.textContent = trialLeft > 0
+          ? trialLeft + ' free report' + (trialLeft !== 1 ? 's' : '') + ' left — no card needed'
+          : 'Free reports used — subscribe to run more.';
+      }
+
       var res = await _apiFetch('/api/eudr/usage');
       if (!res.ok) {
         setUsageUnavailable();
@@ -107,7 +135,7 @@
         }
       }
 
-      setHeroParcels(periodUsed, included, overage);
+      setHeroParcels(periodUsed, included, overage, _billingSnapshot);
 
       if (historyListEl && data.history && data.history.length) {
         var html = '<div class="app-usage-history-list">';
@@ -124,8 +152,6 @@
       } else if (historyListEl) {
         historyListEl.textContent = 'No usage history yet.';
       }
-
-      await refreshBillingSnapshot();
     } catch (e) {
       console.warn('EUDR usage load error:', e);
       setUsageUnavailable();

--- a/website/js/app-msal.js
+++ b/website/js/app-msal.js
@@ -59,16 +59,25 @@
   function getCiamConfig() {
     try {
       var el = document.getElementById('canopex-ciam-config');
-      if (!el) return { clientId: '', authority: '', tenantId: '' };
+      if (!el) return { clientId: '', authority: '', tenantId: '', apiAudience: '' };
       var parsed = JSON.parse(el.textContent || '{}');
       return {
         clientId: parsed.clientId || '',
         authority: parsed.authority || '',
         tenantId: parsed.tenantId || '',
+        apiAudience: parsed.apiAudience || '',
       };
     } catch (_) {
-      return { clientId: '', authority: '', tenantId: '' };
+      return { clientId: '', authority: '', tenantId: '', apiAudience: '' };
     }
+  }
+
+  function buildApiScopes(ciam) {
+    var audience = String((ciam && ciam.apiAudience) || '').trim();
+    if (!audience) {
+      return ['openid', 'profile'];
+    }
+    return ['openid', 'profile', audience + '/.default'];
   }
 
   function authEnabled() {
@@ -225,16 +234,19 @@
     }
 
     var account = accounts[0];
+    var ciam = getCiamConfig();
     var request = {
-      scopes: ['openid', 'profile'],
+      scopes: buildApiScopes(ciam),
       account: account,
     };
 
     try {
       var result = await app.acquireTokenSilent(request);
-      // Prefer the id token for CIAM — the backend validates it against the
-      // CIAM JWKS. The access token may have a Graph audience which the
-      // backend rejects.
+      // When API audience is configured, backend expects a bearer access token
+      // with that audience. Otherwise local/dev can fall back to id token.
+      if (ciam.apiAudience) {
+        return result.accessToken || result.idToken || '';
+      }
       return result.idToken || result.accessToken || '';
     } catch (silentErr) {
       // Silent acquisition failed (token expired, consent required, etc.).
@@ -320,6 +332,7 @@
 
   function renderLocalDevUI(elements) {
     var apiReady = _getApiReady ? _getApiReady() : Promise.resolve();
+    if (elements.statusBadge) elements.statusBadge.style.display = 'inline';
     if (elements.loginBtn) elements.loginBtn.style.display = 'none';
     if (elements.logoutBtn) elements.logoutBtn.style.display = 'none';
     if (elements.userSpan) {
@@ -355,6 +368,7 @@
     var historyLoaded = _getAnalysisHistoryLoaded ? _getAnalysisHistoryLoaded() : false;
     var latestRun = _getLatestAnalysisRun ? _getLatestAnalysisRun() : null;
 
+    if (elements.statusBadge) elements.statusBadge.style.display = 'inline';
     if (elements.userSpan) {
       elements.userSpan.textContent = displayName;
       elements.userSpan.style.display = 'inline';
@@ -384,6 +398,7 @@
   }
 
   function renderSignedOutUI(elements) {
+    if (elements.statusBadge) elements.statusBadge.style.display = 'none';
     if (elements.userSpan) elements.userSpan.style.display = 'none';
     if (elements.loginBtn) elements.loginBtn.style.display = 'inline';
     if (elements.logoutBtn) elements.logoutBtn.style.display = 'none';
@@ -410,6 +425,7 @@
     var accountNote = document.getElementById('app-account-note');
     var billingBtn = document.getElementById('app-manage-billing-btn');
     var elements = {
+      statusBadge: document.getElementById('status-badge'),
       loginBtn: loginBtn,
       logoutBtn: logoutBtn,
       userSpan: userSpan,

--- a/website/js/app-run-lifecycle.js
+++ b/website/js/app-run-lifecycle.js
@@ -465,19 +465,19 @@
   }
 
   async function queueAnalysisViaSubmitApi(kmlContent, submissionContext, tokenBody) {
-    var submitBody = { kml_content: kmlContent };
+    const submitBody = { kml_content: kmlContent };
     if (submissionContext) {
       submitBody.submission_context = submissionContext;
     }
     if (tokenBody && tokenBody.eudr_mode === true) {
       submitBody.eudr_mode = true;
     }
-    var submitRes = await _d.apiFetch('/api/analysis/submit', {
+    const submitRes = await _d.apiFetch('/api/analysis/submit', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(submitBody)
     });
-    var submitData = await submitRes.json();
+    const submitData = await submitRes.json();
     return submitData.instance_id || submitData.instanceId || '';
   }
 
@@ -599,10 +599,10 @@
         return;
       }
 
-      var tokenData = await tokenRes.json();
-      var submissionId = tokenData.submissionId || tokenData.submission_id;
-      var sasUrl = tokenData.sasUrl || tokenData.sas_url;
-      var uploadQueued = false;
+      const tokenData = await tokenRes.json();
+      let submissionId = tokenData.submissionId || tokenData.submission_id;
+      const sasUrl = tokenData.sasUrl || tokenData.sas_url;
+      let uploadQueued = false;
 
       // Step 2: Upload KML directly to blob storage via SAS URL
       if (submissionId && sasUrl) {
@@ -610,8 +610,8 @@
         if (_d.setAnalysisStep) _d.setAnalysisStep('submit', 'active');
 
         try {
-          var kmlBytes = new TextEncoder().encode(kmlContent);
-          var uploadRes = await fetch(sasUrl, {
+          const kmlBytes = new TextEncoder().encode(kmlContent);
+          const uploadRes = await fetch(sasUrl, {
             method: 'PUT',
             headers: {
               'x-ms-blob-type': 'BlockBlob',
@@ -634,7 +634,20 @@
             'info'
           );
         }
-        submissionId = await queueAnalysisViaSubmitApi(kmlContent, submissionContext, tokenBody);
+        try {
+          submissionId = await queueAnalysisViaSubmitApi(kmlContent, submissionContext, tokenBody);
+        } catch (submitFetchErr) {
+          // Keep 401 behavior consistent with the upload-token request above.
+          if (submitFetchErr && submitFetchErr.status === 401) {
+            if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
+            return;
+          }
+          if (_d.setAnalysisStatus) {
+            _d.setAnalysisStatus((submitFetchErr.body && submitFetchErr.body.error) || 'Could not queue analysis request.', 'error');
+          }
+          if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
+          return;
+        }
         if (!submissionId) {
           if (_d.setAnalysisStatus) {
             _d.setAnalysisStatus('Could not queue analysis request.', 'error');

--- a/website/js/app-run-lifecycle.js
+++ b/website/js/app-run-lifecycle.js
@@ -464,6 +464,23 @@
     }, 3000);
   }
 
+  async function queueAnalysisViaSubmitApi(kmlContent, submissionContext, tokenBody) {
+    var submitBody = { kml_content: kmlContent };
+    if (submissionContext) {
+      submitBody.submission_context = submissionContext;
+    }
+    if (tokenBody && tokenBody.eudr_mode === true) {
+      submitBody.eudr_mode = true;
+    }
+    var submitRes = await _d.apiFetch('/api/analysis/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(submitBody)
+    });
+    var submitData = await submitRes.json();
+    return submitData.instance_id || submitData.instanceId || '';
+  }
+
   // ── queueAnalysis ─────────────────────────────────────────────
 
   async function queueAnalysis() {
@@ -487,6 +504,13 @@
         } catch (_) { /* proceed — server will enforce */ }
       }
       if (billing && !billing.subscribed && billing.trial_remaining != null && billing.trial_remaining <= 0) {
+        if (_d.setAnalysisStatus) {
+          _d.setAnalysisStatus(
+            'Your free EUDR reports have been used. Subscribe to run more assessments.',
+            'error'
+          );
+        }
+        if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
         if (typeof window.showEudrSubscribeModal === 'function') {
           window.showEudrSubscribeModal();
         }
@@ -578,24 +602,46 @@
       var tokenData = await tokenRes.json();
       var submissionId = tokenData.submissionId || tokenData.submission_id;
       var sasUrl = tokenData.sasUrl || tokenData.sas_url;
+      var uploadQueued = false;
 
       // Step 2: Upload KML directly to blob storage via SAS URL
-      button.textContent = 'Uploading\u2026';
-      if (_d.setAnalysisStep) _d.setAnalysisStep('submit', 'active');
+      if (submissionId && sasUrl) {
+        button.textContent = 'Uploading\u2026';
+        if (_d.setAnalysisStep) _d.setAnalysisStep('submit', 'active');
 
-      var kmlBytes = new TextEncoder().encode(kmlContent);
-      var uploadRes = await fetch(sasUrl, {
-        method: 'PUT',
-        headers: {
-          'x-ms-blob-type': 'BlockBlob',
-          'Content-Type': 'application/vnd.google-earth.kml+xml'
-        },
-        body: kmlBytes
-      });
-      if (!uploadRes || !uploadRes.ok) {
-        if (_d.setAnalysisStatus) _d.setAnalysisStatus('Upload failed. Please try again.', 'error');
-        if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
-        return;
+        try {
+          var kmlBytes = new TextEncoder().encode(kmlContent);
+          var uploadRes = await fetch(sasUrl, {
+            method: 'PUT',
+            headers: {
+              'x-ms-blob-type': 'BlockBlob',
+              'Content-Type': 'application/vnd.google-earth.kml+xml'
+            },
+            body: kmlBytes
+          });
+          uploadQueued = !!(uploadRes && uploadRes.ok);
+        } catch (_) {
+          uploadQueued = false;
+        }
+      }
+
+      // Fallback for browser upload/CORS failures: submit directly to API.
+      if (!uploadQueued) {
+        button.textContent = 'Queueing\u2026';
+        if (_d.setAnalysisStatus) {
+          _d.setAnalysisStatus(
+            'Direct upload is unavailable in this browser session. Falling back to secure API submission\u2026',
+            'info'
+          );
+        }
+        submissionId = await queueAnalysisViaSubmitApi(kmlContent, submissionContext, tokenBody);
+        if (!submissionId) {
+          if (_d.setAnalysisStatus) {
+            _d.setAnalysisStatus('Could not queue analysis request.', 'error');
+          }
+          if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
+          return;
+        }
       }
 
       // Step 3: Track the submission

--- a/website/js/app-summary-ui.js
+++ b/website/js/app-summary-ui.js
@@ -138,10 +138,13 @@
       : 'Based on your account.';
     runsEl.textContent = data.runs_remaining == null ? '-' : String(data.runs_remaining);
     runsNoteEl.textContent = data.runs_remaining == null
-      ? 'Quota unavailable in this environment.'
-      : 'Remaining analyses before the current limit is reached.';
+      ? 'Usage data unavailable right now.'
+      : 'How many assessments you can start right now.';
     modeEl.textContent = capabilityHeadline(caps);
-    modeNoteEl.textContent = role.label + ' | ' + preference.label + ' | Retention ' + formatRetention(caps.retention_days) + ' | ' + (caps.api_access ? 'API enabled' : 'API not included');
+    // On EUDR pages keep the mode note user-facing; elsewhere show capability detail.
+    modeNoteEl.textContent = document.body && document.body.dataset.eudrApp != null
+      ? 'Post-Dec 2020 satellite imagery for EUDR compliance.'
+      : role.label + ' | ' + preference.label + ' | Retention ' + formatRetention(caps.retention_days) + ' | ' + (caps.api_access ? 'API enabled' : 'API not included');
   }
 
   function updateHistorySummary(data) {

--- a/website/js/landing.js
+++ b/website/js/landing.js
@@ -16,17 +16,24 @@
 
   function getCiamConfig() {
     const el = document.getElementById('canopex-ciam-config');
-    if (!el) return { clientId: '', authority: '', tenantId: '' };
+    if (!el) return { clientId: '', authority: '', tenantId: '', apiAudience: '' };
     try {
       const cfg = JSON.parse(el.textContent || '{}');
       return {
         clientId: cfg.clientId || '',
         authority: cfg.authority || '',
         tenantId: cfg.tenantId || '',
+        apiAudience: cfg.apiAudience || '',
       };
     } catch (_) {
-      return { clientId: '', authority: '', tenantId: '' };
+      return { clientId: '', authority: '', tenantId: '', apiAudience: '' };
     }
+  }
+
+  function buildApiScopes(cfg) {
+    const audience = String((cfg && cfg.apiAudience) || '').trim();
+    if (!audience) return ['openid', 'profile'];
+    return ['openid', 'profile', audience + '/.default'];
   }
 
   function authEnabled() {
@@ -88,9 +95,13 @@
           userRoles: [],
         };
         apiClient.setGetToken(async function () {
-          const req = { scopes: ['openid', 'profile'], account: account };
+          const cfg = getCiamConfig();
+          const req = { scopes: buildApiScopes(cfg), account: account };
           try {
             const result = await app.acquireTokenSilent(req);
+            if (cfg.apiAudience) {
+              return result.accessToken || result.idToken || '';
+            }
             return result.idToken || result.accessToken || '';
           } catch (tokenErr) {
             const errorCode = String((tokenErr && tokenErr.errorCode) || '');


### PR DESCRIPTION
## Summary\n- request API-audience bearer tokens in MSAL when CIAM apiAudience is configured\n- include apiAudience in deploy/preview CIAM config injection and HTML placeholders\n- add resilience fallback from SAS upload path to direct /api/analysis/submit queueing\n- tighten UI/auth regression coverage and related readiness assertions\n\n## Validation\n- ruff check .\n- ruff format --check .\n- pytest tests/test_frontend_config.py tests/test_launch_readiness.py tests/test_billing_endpoints.py -q\n\n## Notes\n- Branch prepared per request; awaiting CI checks and review feedback before resolving any follow-up items.