### PR TITLE
fix: unify KML/KMZ upload path routing and Event Grid filter

### DIFF
--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -135,7 +135,16 @@ def _mint_sas_url(
     submission_id: str,
     content_type: str = _KML_CONTENT_TYPE,
 ) -> tuple[str | None, str | None]:
-    """Generate a write-only SAS URL. Returns (sas_url, error_msg)."""
+    """Generate a write-only SAS URL. Returns (sas_url, error_msg).
+
+    The ``content_type`` value is embedded in the SAS token as a response-header
+    override (``rsct``).  It controls the ``Content-Type`` header returned when
+    the blob is *downloaded* via the SAS URL, but does **not** automatically set
+    the blob's stored Content-Type.  Callers that need the blob stored with the
+    correct Content-Type must include ``Content-Type`` (or the Azure-specific
+    ``x-ms-blob-content-type``) header on the client-side PUT request.  The
+    upload-token response includes ``contentType`` so the client can do this.
+    """
     now = datetime.datetime.now(datetime.UTC)
     expiry = now + datetime.timedelta(minutes=_SAS_TOKEN_EXPIRY_MINUTES)
 
@@ -317,7 +326,9 @@ def _write_ticket_and_mint_sas(
         return None, error_response(502, "Storage service temporarily unavailable", req=req)
 
     try:
-        sas_url, _ = _mint_sas_url(blob_service, blob_name, submission_id, content_type)
+        sas_url, _ = _mint_sas_url(
+            blob_service, blob_name, submission_id, content_type=content_type
+        )
     except Exception:
         logger.exception("Failed to mint SAS URL for submission_id=%s", submission_id)
         if quota_consumed:
@@ -467,6 +478,7 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
                 "sasUrl": sas_url,
                 "blobName": blob_name,
                 "container": DEFAULT_INPUT_CONTAINER,
+                "contentType": content_type,
                 "expiresMinutes": _SAS_TOKEN_EXPIRY_MINUTES,
                 "maxBytes": MAX_KML_FILE_SIZE_BYTES,
             }

--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -111,10 +111,29 @@ def _safe_release_quota(user_id: str, instance_id: str = "") -> None:
         logger.exception("Failed to release quota for user=%s", user_id)
 
 
+_KMZ_EXTENSION = ".kmz"
+_KML_EXTENSION = ".kml"
+_KMZ_CONTENT_TYPE = "application/vnd.google-earth.kmz"
+_KML_CONTENT_TYPE = "application/vnd.google-earth.kml+xml"
+
+
+def _detect_file_extension(filename: str) -> tuple[str, str]:
+    """Return (extension, content_type) from a client-supplied filename.
+
+    Only .kml and .kmz are accepted.  Any other value (including empty string)
+    falls back to .kml so the pipeline is never silently broken by a bad client.
+    Detection is case-insensitive.
+    """
+    if isinstance(filename, str) and filename.lower().endswith(_KMZ_EXTENSION):
+        return _KMZ_EXTENSION, _KMZ_CONTENT_TYPE
+    return _KML_EXTENSION, _KML_CONTENT_TYPE
+
+
 def _mint_sas_url(
     blob_service,
     blob_name: str,
     submission_id: str,
+    content_type: str = _KML_CONTENT_TYPE,
 ) -> tuple[str | None, str | None]:
     """Generate a write-only SAS URL. Returns (sas_url, error_msg)."""
     now = datetime.datetime.now(datetime.UTC)
@@ -132,7 +151,7 @@ def _mint_sas_url(
         user_delegation_key=delegation_key,
         permission=BlobSasPermissions(create=True, write=True),
         expiry=expiry,
-        content_type="application/vnd.google-earth.kml+xml",
+        content_type=content_type,
     )
 
     sas_url = (
@@ -274,6 +293,7 @@ def _write_ticket_and_mint_sas(
     submission_context: dict,
     quota_consumed: bool,
     req: func.HttpRequest,
+    content_type: str = _KML_CONTENT_TYPE,
 ) -> tuple[str | None, func.HttpResponse | None]:
     """Write ticket blob and mint SAS URL.
 
@@ -297,7 +317,7 @@ def _write_ticket_and_mint_sas(
         return None, error_response(502, "Storage service temporarily unavailable", req=req)
 
     try:
-        sas_url, _ = _mint_sas_url(blob_service, blob_name, submission_id)
+        sas_url, _ = _mint_sas_url(blob_service, blob_name, submission_id, content_type)
     except Exception:
         logger.exception("Failed to mint SAS URL for submission_id=%s", submission_id)
         if quota_consumed:
@@ -384,7 +404,8 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
         return quota_err
 
     submission_id = str(uuid.uuid4())
-    blob_name = f"analysis/{submission_id}.kml"
+    ext, content_type = _detect_file_extension(body.get("filename", ""))
+    blob_name = f"analysis/{submission_id}{ext}"
 
     submission_context = _sanitise_submission_context(body.get("submission_context") or {})
     effective_provider = _resolve_provider(body, submission_context)
@@ -398,6 +419,7 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
         submission_context,
         quota_consumed,
         req,
+        content_type,
     )
     if storage_err:
         return storage_err

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -1227,8 +1227,12 @@ resource "azapi_resource" "event_grid_subscription" {
         }
       }
       filter = {
-        includedEventTypes     = ["Microsoft.Storage.BlobCreated"]
-        subjectEndsWith        = ".kml"
+        includedEventTypes = ["Microsoft.Storage.BlobCreated"]
+        # Match any blob under analysis/ in the kml-input container, regardless of extension.
+        # Azure Event Grid blob subjects are relative to the storage account resource:
+        #   /blobServices/default/containers/{container}/blobs/{path}
+        # Using a prefix filter covers both .kml and .kmz uploads.
+        subjectBeginsWith      = "/blobServices/default/containers/kml-input/blobs/analysis/"
         isSubjectCaseSensitive = false
       }
       eventDeliverySchema = "EventGridSchema"

--- a/scripts/reconcile_eventgrid_subscription.py
+++ b/scripts/reconcile_eventgrid_subscription.py
@@ -11,7 +11,7 @@ from urllib.parse import quote
 DEFAULT_FUNCTION_NAME = "blob_trigger"
 DEFAULT_SUBSCRIPTION_NAME = "evgs-kml-upload"
 DEFAULT_EVENT_TYPE = "Microsoft.Storage.BlobCreated"
-DEFAULT_SUBJECT_SUFFIX = ".kml"
+DEFAULT_SUBJECT_PREFIX = "/blobServices/default/containers/kml-input/blobs/analysis/"
 
 
 def select_eventgrid_key(payload: dict[str, Any]) -> str:
@@ -104,8 +104,8 @@ def build_subscription_command(
         "webhook",
         "--included-event-types",
         DEFAULT_EVENT_TYPE,
-        "--subject-ends-with",
-        DEFAULT_SUBJECT_SUFFIX,
+        "--subject-begins-with",
+        DEFAULT_SUBJECT_PREFIX,
     ]
     if action == "create":
         command.extend(

--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -753,6 +753,25 @@ class TestEventGridWebhookWiring:
             "Event Grid host key lookup must not target the compute app"
         )
 
+    def test_event_grid_filter_uses_analysis_prefix_not_extension_suffix(self):
+        tf = MAIN_TF.read_text()
+        match = re.search(
+            r'resource\s+"azapi_resource"\s+"event_grid_subscription"\s*\{(?P<body>.*?)\n\}',
+            tf,
+            re.DOTALL,
+        )
+        assert match, "main.tf must define azapi_resource.event_grid_subscription"
+        body = match.group("body")
+        assert "subjectBeginsWith" in body, (
+            "Event Grid subscription must use subjectBeginsWith for analysis blob routing"
+        )
+        assert "/blobServices/default/containers/kml-input/blobs/analysis/" in body, (
+            "Event Grid subject prefix must target analysis blobs in the kml-input container"
+        )
+        assert "subjectEndsWith" not in body, (
+            "Event Grid subscription should not use extension-only suffix filters"
+        )
+
 
 # ---------------------------------------------------------------------------
 # 12. Public API ingress docs contract

--- a/tests/test_reconcile_eventgrid_subscription.py
+++ b/tests/test_reconcile_eventgrid_subscription.py
@@ -47,6 +47,9 @@ def test_build_subscription_command_includes_create_only_delivery_flags() -> Non
     assert "--event-ttl" in command
     assert "--max-events-per-batch" in command
     assert "--preferred-batch-size-in-kilobytes" in command
+    assert "--subject-begins-with" in command
+    assert reconcile.DEFAULT_SUBJECT_PREFIX in command
+    assert "--subject-ends-with" not in command
 
 
 def test_build_subscription_command_omits_create_only_delivery_flags_for_update() -> None:
@@ -62,3 +65,6 @@ def test_build_subscription_command_omits_create_only_delivery_flags_for_update(
     assert "--event-ttl" not in command
     assert "--max-events-per-batch" not in command
     assert "--preferred-batch-size-in-kilobytes" not in command
+    assert "--subject-begins-with" in command
+    assert reconcile.DEFAULT_SUBJECT_PREFIX in command
+    assert "--subject-ends-with" not in command

--- a/tests/test_upload_endpoints.py
+++ b/tests/test_upload_endpoints.py
@@ -358,7 +358,7 @@ class TestUploadToken:
     @patch("blueprints.upload.generate_blob_sas")
     @patch("blueprints.upload.get_blob_service_client")
     def test_kml_filename_produces_kml_blob_and_content_type(self, mock_bsc, mock_gen_sas):
-        """A .kml filename produces a .kml blob name and passes KML content-type to the SAS token."""
+        """A .kml filename produces a .kml blob name and passes KML content-type to SAS token."""
         from blueprints.upload import upload_token
 
         mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
@@ -378,7 +378,7 @@ class TestUploadToken:
     @patch("blueprints.upload.generate_blob_sas")
     @patch("blueprints.upload.get_blob_service_client")
     def test_kmz_filename_produces_kmz_blob_and_content_type(self, mock_bsc, mock_gen_sas):
-        """A .kmz filename produces a .kmz blob name and passes KMZ content-type to the SAS token."""
+        """A .kmz filename produces a .kmz blob name and passes KMZ content-type to SAS token."""
         from blueprints.upload import upload_token
 
         mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()

--- a/tests/test_upload_endpoints.py
+++ b/tests/test_upload_endpoints.py
@@ -355,6 +355,97 @@ class TestUploadToken:
         record = self.mock_persist.call_args[0][1]
         assert record["eudr_mode"] is True
 
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_kml_filename_produces_kml_blob_and_content_type(self, mock_bsc, mock_gen_sas):
+        """A request with a .kml filename stores a .kml blob with KML content-type."""
+        from blueprints.upload import upload_token
+
+        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
+
+        req = _make_req("/api/upload/token", method="POST", body={"filename": "parcels.kml"})
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["blobName"].endswith(".kml")
+        call_kwargs = mock_gen_sas.call_args[1]
+        assert call_kwargs["content_type"] == "application/vnd.google-earth.kml+xml"
+
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_kmz_filename_produces_kmz_blob_and_content_type(self, mock_bsc, mock_gen_sas):
+        """A request with a .kmz filename stores a .kmz blob with KMZ content-type."""
+        from blueprints.upload import upload_token
+
+        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
+
+        req = _make_req("/api/upload/token", method="POST", body={"filename": "parcels.kmz"})
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["blobName"].endswith(".kmz")
+        call_kwargs = mock_gen_sas.call_args[1]
+        assert call_kwargs["content_type"] == "application/vnd.google-earth.kmz"
+
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_no_filename_defaults_to_kml(self, mock_bsc, mock_gen_sas):
+        """When no filename is provided, defaults to .kml extension."""
+        from blueprints.upload import upload_token
+
+        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
+
+        req = _make_req("/api/upload/token", method="POST")
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["blobName"].endswith(".kml")
+        call_kwargs = mock_gen_sas.call_args[1]
+        assert call_kwargs["content_type"] == "application/vnd.google-earth.kml+xml"
+
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_unknown_extension_defaults_to_kml(self, mock_bsc, mock_gen_sas):
+        """An unrecognised extension falls back to .kml for safety."""
+        from blueprints.upload import upload_token
+
+        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
+
+        req = _make_req("/api/upload/token", method="POST", body={"filename": "parcels.shp"})
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["blobName"].endswith(".kml")
+
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_case_insensitive_kmz_extension(self, mock_bsc, mock_gen_sas):
+        """Extension detection is case-insensitive (.KMZ treated as KMZ)."""
+        from blueprints.upload import upload_token
+
+        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
+
+        req = _make_req("/api/upload/token", method="POST", body={"filename": "parcels.KMZ"})
+        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+            resp = upload_token(req)
+
+        assert resp.status_code == 200
+        data = json.loads(resp.get_body())
+        assert data["blobName"].endswith(".kmz")
+
 
 # ===================================================================
 # EUDR entitlement enforcement on upload/token

--- a/tests/test_upload_endpoints.py
+++ b/tests/test_upload_endpoints.py
@@ -358,7 +358,7 @@ class TestUploadToken:
     @patch("blueprints.upload.generate_blob_sas")
     @patch("blueprints.upload.get_blob_service_client")
     def test_kml_filename_produces_kml_blob_and_content_type(self, mock_bsc, mock_gen_sas):
-        """A request with a .kml filename stores a .kml blob with KML content-type."""
+        """A .kml filename produces a .kml blob name and passes KML content-type to the SAS token."""
         from blueprints.upload import upload_token
 
         mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
@@ -371,13 +371,14 @@ class TestUploadToken:
         assert resp.status_code == 200
         data = json.loads(resp.get_body())
         assert data["blobName"].endswith(".kml")
+        assert data["contentType"] == "application/vnd.google-earth.kml+xml"
         call_kwargs = mock_gen_sas.call_args[1]
         assert call_kwargs["content_type"] == "application/vnd.google-earth.kml+xml"
 
     @patch("blueprints.upload.generate_blob_sas")
     @patch("blueprints.upload.get_blob_service_client")
     def test_kmz_filename_produces_kmz_blob_and_content_type(self, mock_bsc, mock_gen_sas):
-        """A request with a .kmz filename stores a .kmz blob with KMZ content-type."""
+        """A .kmz filename produces a .kmz blob name and passes KMZ content-type to the SAS token."""
         from blueprints.upload import upload_token
 
         mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
@@ -390,6 +391,7 @@ class TestUploadToken:
         assert resp.status_code == 200
         data = json.loads(resp.get_body())
         assert data["blobName"].endswith(".kmz")
+        assert data["contentType"] == "application/vnd.google-earth.kmz"
         call_kwargs = mock_gen_sas.call_args[1]
         assert call_kwargs["content_type"] == "application/vnd.google-earth.kmz"
 


### PR DESCRIPTION
Closes #753

## Summary
- detect client filename extension in upload-token flow and preserve blob extension (.kml / .kmz)
- pass extension-aware content type into SAS minting (KML vs KMZ)
- switch Event Grid subscription filtering from extension suffix to analysis-path prefix
- align Event Grid reconciliation script with the same prefix filter contract
- add regression tests for upload-token extension/content-type behavior and Event Grid command flags
- add readiness contract test to guard against reverting to suffix-only filtering

## Validation
- .venv/bin/python -m ruff check on changed Python files
- .venv/bin/python -m ruff format --check on changed Python files
- .venv/bin/pytest tests/test_upload_endpoints.py tests/test_reconcile_eventgrid_subscription.py tests/test_launch_readiness.py -q

## Notes
- this includes an approval-gated infra change (infra/tofu/main.tf)
