### PR TITLE
ci: skip CI + deploy for docs-only pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,14 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Adds `paths-ignore` to the `push` and `pull_request` triggers in `ci.yml` so commits touching only `docs/` or root-level markdown files skip the CI → deploy chain.

## Why

Docs-only commits (roadmap updates, ADRs, runbook edits) currently trigger the full CI pipeline + deploy, which takes ~10 minutes and causes a small service interruption on each push. This is unnecessary for changes that can't affect runtime behaviour.

## Behaviour after this change

| Push content | CI runs? | Deploy runs? |
|---|---|---|
| Code / tests / config | ✅ Yes | ✅ Yes (if CI passes) |
| `docs/**` only | ❌ Skipped | ❌ Skipped (no CI to trigger it) |
| Root `*.md` only | ❌ Skipped | ❌ Skipped |

## Approval-gated

This is a GitHub Actions workflow change — needs review before merge.