### PR TITLE
fix(auth): stop login loop on KML upload when token config is invalid

### DIFF
--- a/tests/test_frontend_config.py
+++ b/tests/test_frontend_config.py
@@ -274,6 +274,16 @@ class TestAuthConfig:
             "app-msal.js getToken must prefer accessToken when apiAudience is configured"
         )
 
+    def test_msal_module_marks_missing_api_audience_as_fatal(self):
+        """Missing apiAudience must fail fast to avoid 401/re-auth loops."""
+        js = APP_MSAL_JS.read_text()
+        assert "buildAuthFatalError" in js, (
+            "app-msal.js must expose a fatal auth error builder"
+        )
+        assert "authFatal = true" in js, (
+            "app-msal.js fatal auth errors must carry authFatal marker"
+        )
+
     def test_msal_module_splits_update_auth_ui_render_paths(self):
         """Auth UI rendering should be split into smaller helpers."""
         js = APP_MSAL_JS.read_text()
@@ -339,6 +349,15 @@ class TestAuthConfig:
         )
         assert "throw tokenErr" in api_client_js, (
             "canopex-api-client.js must rethrow redirect token errors to avoid fallback 401 loops"
+        )
+
+    def test_api_client_aborts_request_on_fatal_auth_error(self, api_client_js):
+        """API client must not send unauthenticated requests after fatal token errors."""
+        assert "authFatal" in api_client_js, (
+            "canopex-api-client.js must detect fatal auth token errors"
+        )
+        assert "if (tokenErr && tokenErr.authFatal)" in api_client_js, (
+            "canopex-api-client.js must short-circuit on authFatal"
         )
 
     def test_app_shell_uses_shared_api_client(self, app_shell_js):

--- a/website/js/app-msal.js
+++ b/website/js/app-msal.js
@@ -217,6 +217,16 @@
     return err;
   }
 
+  function buildAuthFatalError(message, cause) {
+    var err = new Error(message);
+    err.name = 'CanopexAuthFatalError';
+    err.authFatal = true;
+    if (cause) {
+      err.cause = cause;
+    }
+    return err;
+  }
+
   /**
    * Return a valid CIAM token string, acquiring silently if possible.
    * Falls back to a redirect login if no cached token is available.
@@ -255,9 +265,12 @@
       }
       // apiAudience is not configured — this is a misconfiguration even in local dev.
       // Returning an ID token as a bearer credential is a security anti-pattern.
-      // Log a clear error and return empty so callers fail visibly rather than silently.
-      console.error('[CanopexAuth] apiAudience not configured — cannot acquire API token. Check CIAM_API_AUDIENCE.');
-      return '';
+      // Raise a fatal auth error so callers do not send unauthenticated API requests,
+      // which would otherwise trigger repetitive 401/re-auth loops.
+      throw buildAuthFatalError(
+        '[CanopexAuth] apiAudience not configured — cannot acquire API token. '
+          + 'Check CIAM_API_AUDIENCE.'
+      );
     } catch (silentErr) {
       // Silent acquisition failed (token expired, consent required, etc.).
       // Trigger a redirect so the user can re-authenticate.

--- a/website/js/app-run-lifecycle.js
+++ b/website/js/app-run-lifecycle.js
@@ -593,6 +593,14 @@
           if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
           return;
         }
+        if (tokenFetchErr && tokenFetchErr.authFatal) {
+          if (_d.setAnalysisStatus) {
+            _d.setAnalysisStatus(tokenFetchErr.message || 'Authentication is misconfigured. Please contact support.', 'error');
+          }
+          updateContentSummary(null);
+          if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
+          return;
+        }
         if (_d.setAnalysisStatus) _d.setAnalysisStatus((tokenFetchErr.body && tokenFetchErr.body.error) || 'Could not prepare upload. Please try again.', 'error');
         updateContentSummary(null);
         if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
@@ -639,6 +647,13 @@
         } catch (submitFetchErr) {
           // Keep 401 behavior consistent with the upload-token request above.
           if (submitFetchErr && submitFetchErr.status === 401) {
+            if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
+            return;
+          }
+          if (submitFetchErr && submitFetchErr.authFatal) {
+            if (_d.setAnalysisStatus) {
+              _d.setAnalysisStatus(submitFetchErr.message || 'Authentication is misconfigured. Please contact support.', 'error');
+            }
             if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
             return;
           }

--- a/website/js/canopex-api-client.js
+++ b/website/js/canopex-api-client.js
@@ -158,6 +158,9 @@
           if (tokenErr && tokenErr.authRedirectTriggered) {
             throw tokenErr;
           }
+          if (tokenErr && tokenErr.authFatal) {
+            throw tokenErr;
+          }
           // Log but proceed — the backend will reject with 401 and the auth
           // error handler will redirect to login.
           console.warn('[CanopexApiClient] Failed to acquire token:', tokenErr);


### PR DESCRIPTION
## Problem
Submitting a new KML could trigger repeated login/reauth behavior, and the request never reached the pipeline.

Root cause: when token acquisition failed fatally (not redirect-in-progress), the API client logged and still sent unauthenticated requests. Backend 401 responses then retriggered auth handling, creating a loop.

## Fix
- website/js/app-msal.js
  - Added buildAuthFatalError() with authFatal=true marker.
  - In getToken(), missing apiAudience now throws fatal auth error instead of returning empty string.
- website/js/canopex-api-client.js
  - apiFetch() now rethrows authFatal token errors (no fallback unauthenticated request).
- website/js/app-run-lifecycle.js
  - Upload queue flow now surfaces clear auth misconfiguration message when authFatal occurs.
- tests/test_frontend_config.py
  - Added regression checks for authFatal behavior in auth module + API client.

## Validation
- ruff check tests/test_frontend_config.py
- python3.12 with workspace site-packages: pytest tests/test_frontend_config.py -q
- Result: 66 passed

## Expected user impact
- No more login loop when posting KML under token misconfig.
- User sees clear error message instead of silent retry/fallback behavior.
- Requests no longer spin on 401 due to missing auth headers in fatal token states.