### PR TITLE
fix(auth+telemetry): redirect to /eudr/ after sign-in, harden analytics

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1138,9 +1138,12 @@ jobs:
           CIAM_API_AUDIENCE: ${{ secrets.CIAM_API_AUDIENCE }}
         run: |
           if [ -n "$CIAM_CLIENT_ID" ] && [ -n "$CIAM_AUTHORITY" ]; then
-            CIAM_JSON="{\"clientId\":\"${CIAM_CLIENT_ID}\",\"authority\":\"${CIAM_AUTHORITY}\",\"tenantId\":\"${CIAM_TENANT_ID}\",\"apiAudience\":\"${CIAM_API_AUDIENCE}\"}"
-            find website -name '*.html' -exec sed -i \
-              's|{"clientId":"","authority":"","tenantId":"","apiAudience":""}|'"${CIAM_JSON}"'|' {} +
+            CIAM_BASE="{\"clientId\":\"${CIAM_CLIENT_ID}\",\"authority\":\"${CIAM_AUTHORITY}\",\"tenantId\":\"${CIAM_TENANT_ID}\",\"apiAudience\":\"${CIAM_API_AUDIENCE}\""
+            CIAM_EUDR="${CIAM_BASE},\"appPath\":\"/eudr/\"}"
+            CIAM_APP="${CIAM_BASE},\"appPath\":\"/app/\"}"
+            find website -name '*.html' \
+              -exec sed -i 's|{"clientId":"","authority":"","tenantId":"","apiAudience":"","appPath":"/eudr/"}|'"${CIAM_EUDR}"'|g' {} + \
+              -exec sed -i 's|{"clientId":"","authority":"","tenantId":"","apiAudience":"","appPath":"/app/"}|'"${CIAM_APP}"'|g' {} +
           fi
 
       - name: Deploy to Azure Static Web Apps

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -40,9 +40,12 @@ jobs:
           CIAM_API_AUDIENCE: ${{ secrets.CIAM_API_AUDIENCE }}
         run: |
           if [ -n "$CIAM_CLIENT_ID" ] && [ -n "$CIAM_AUTHORITY" ]; then
-            CIAM_JSON="{\"clientId\":\"${CIAM_CLIENT_ID}\",\"authority\":\"${CIAM_AUTHORITY}\",\"tenantId\":\"${CIAM_TENANT_ID}\",\"apiAudience\":\"${CIAM_API_AUDIENCE}\"}"
-            find website -name '*.html' -exec sed -i \
-              's|{"clientId":"","authority":"","tenantId":"","apiAudience":""}|'"${CIAM_JSON}"'|' {} +
+            CIAM_BASE="{\"clientId\":\"${CIAM_CLIENT_ID}\",\"authority\":\"${CIAM_AUTHORITY}\",\"tenantId\":\"${CIAM_TENANT_ID}\",\"apiAudience\":\"${CIAM_API_AUDIENCE}\""
+            CIAM_EUDR="${CIAM_BASE},\"appPath\":\"/eudr/\"}"
+            CIAM_APP="${CIAM_BASE},\"appPath\":\"/app/\"}"
+            find website -name '*.html' \
+              -exec sed -i 's|{"clientId":"","authority":"","tenantId":"","apiAudience":"","appPath":"/eudr/"}|'"${CIAM_EUDR}"'|g' {} + \
+              -exec sed -i 's|{"clientId":"","authority":"","tenantId":"","apiAudience":"","appPath":"/app/"}|'"${CIAM_APP}"'|g' {} +
           else
             echo "::warning::CIAM secrets are not fully set; preview sign-in will remain disabled."
           fi

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -19,7 +19,7 @@
 <link rel="stylesheet" href="/css/app.css">
 <meta name="ai-connection-string" content="">
 <!-- CIAM config: replaced by CI deploy step (see .github/workflows/deploy.yml) -->
-<script id="canopex-ciam-config" type="application/json">{"clientId":"","authority":"","tenantId":"","apiAudience":""}</script>
+<script id="canopex-ciam-config" type="application/json">{"clientId":"","authority":"","tenantId":"","apiAudience":"","appPath":"/app/"}</script>
 <script src="/js/analytics.js" defer></script>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha384-cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HTH" crossorigin="anonymous"></script> <!-- pragma: allowlist secret -->
 <script src="/js/canopex-geo.js" defer></script>

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -18,7 +18,7 @@
 <link rel="stylesheet" href="/css/shared.css">
 <link rel="stylesheet" href="/css/app.css">
 <meta name="ai-connection-string" content=""> <!-- Analytics/App Insights config: replaced by CI deploy step (see .github/workflows/deploy.yml) -->
-<script id="canopex-ciam-config" type="application/json">{"clientId":"","authority":"","tenantId":"","apiAudience":""}</script>
+<script id="canopex-ciam-config" type="application/json">{"clientId":"","authority":"","tenantId":"","apiAudience":"","appPath":"/eudr/"}</script>
 <script src="/js/analytics.js" defer></script>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha384-cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HTH" crossorigin="anonymous"></script> <!-- pragma: allowlist secret -->
 <script src="/js/canopex-geo.js" defer></script>
@@ -65,7 +65,7 @@
     <div class="auth-area" id="auth-area">
       <span id="status-badge">Checking…</span>
       <span class="auth-user" id="auth-user" style="display:none"></span>
-      <button class="auth-btn primary" id="auth-login-btn" type="button">Sign In</button>
+      <button class="auth-btn primary" id="auth-login-btn" type="button" data-track="nav_sign_in">Sign In</button>
       <button class="auth-btn logout" id="auth-logout-btn" style="display:none">Sign Out</button>
     </div>
   </div>
@@ -88,7 +88,7 @@
         <h2>Sign in to start EUDR due diligence</h2>
         <p>Upload land parcel boundaries, get satellite evidence for EU Deforestation Regulation compliance. 2 free parcel assessments, no credit card required.</p>
         <div class="app-gate-actions">
-          <button class="btn btn-primary" id="app-sign-in-btn" type="button">Start Free</button>
+          <button class="btn btn-primary" id="app-sign-in-btn" type="button" data-track="eudr_start_free">Start Free</button>
           <a class="btn btn-secondary" href="/#pricing">View Plans</a>
           <a class="btn btn-secondary" href="/">Back to site</a>
         </div>
@@ -251,7 +251,7 @@
             </div>
           </div>
           <div class="app-analysis-actions">
-            <button class="btn btn-primary app-analysis-queue-btn" id="app-analysis-submit-btn" type="button">Queue Due Diligence</button>
+            <button class="btn btn-primary app-analysis-queue-btn" id="app-analysis-submit-btn" type="button" data-track="eudr_queue_analysis">Queue Due Diligence</button>
           </div>
           </div><!-- /app-analysis-form-fields -->
           <div class="app-callout" id="app-analysis-status" hidden></div>
@@ -449,7 +449,7 @@
                     <span class="app-content-label">EUDR compliance</span>
                     <p class="app-evidence-action-hint">Run a deforestation-risk assessment against EU Deforestation Regulation thresholds.</p>
                   </div>
-                  <button class="btn btn-primary" id="app-evidence-eudr-btn" type="button">Assess EUDR</button>
+                  <button class="btn btn-primary" id="app-evidence-eudr-btn" type="button" data-track="eudr_assess_eudr">Assess EUDR</button>
                 </div>
                 <div id="app-evidence-eudr-content"></div>
                 <div class="app-evidence-ai-loading" id="app-evidence-eudr-loading" hidden>Running EUDR assessment&hellip;</div>
@@ -473,9 +473,9 @@
             <div class="app-evidence-export-bar" id="app-evidence-export-bar">
               <span class="app-content-label">Exports</span>
               <div class="app-evidence-export-actions">
-                <button class="btn btn-secondary app-evidence-export-btn" type="button" data-export-format="geojson" disabled>GeoJSON</button>
-                <button class="btn btn-secondary app-evidence-export-btn" type="button" data-export-format="csv" disabled>CSV</button>
-                <button class="btn btn-secondary app-evidence-export-btn" type="button" data-export-format="pdf" disabled>PDF</button>
+                <button class="btn btn-secondary app-evidence-export-btn" type="button" data-export-format="geojson" data-track="export_geojson" disabled>GeoJSON</button>
+                <button class="btn btn-secondary app-evidence-export-btn" type="button" data-export-format="csv" data-track="export_csv" disabled>CSV</button>
+                <button class="btn btn-secondary app-evidence-export-btn" type="button" data-export-format="pdf" data-track="export_pdf" disabled>PDF</button>
               </div>
               <span class="app-evidence-export-note" id="app-evidence-export-note">Select a completed run to enable exports.</span>
             </div>

--- a/website/index.html
+++ b/website/index.html
@@ -19,7 +19,7 @@
 <link rel="stylesheet" href="/css/style.css">
 <meta name="ai-connection-string" content="">
 <!-- CIAM config: replaced by CI deploy step (see .github/workflows/deploy.yml) -->
-<script id="canopex-ciam-config" type="application/json">{"clientId":"","authority":"","tenantId":"","apiAudience":""}</script>
+<script id="canopex-ciam-config" type="application/json">{"clientId":"","authority":"","tenantId":"","apiAudience":"","appPath":"/eudr/"}</script>
 <script src="/js/analytics.js" defer></script>
 </head>
 <body>
@@ -43,7 +43,7 @@
       <span id="status-badge">Checking…</span>
       <span class="auth-user" id="auth-user" style="display:none"></span>
       <a class="auth-btn primary" id="auth-dashboard-link" href="/eudr/" style="display:none">Dashboard</a>
-      <button class="auth-btn primary" id="auth-login-btn" type="button">Sign In</button>
+      <button class="auth-btn primary" id="auth-login-btn" type="button" data-track="nav_sign_in">Sign In</button>
       <button class="auth-btn logout" id="auth-logout-btn" style="display:none">Sign Out</button>
     </div>
   </div>
@@ -55,8 +55,8 @@
     <h1>EUDR Deforestation-Free Evidence<br>in Minutes.</h1>
     <p>Upload parcel coordinates, get audit-grade satellite evidence — multi-source NDVI analysis, timestamped vegetation history, and exportable compliance reports.</p>
     <div class="hero-cta">
-      <a href="/eudr/" class="btn btn-primary">Try It Free</a>
-      <a href="#sample-report" class="btn btn-secondary">See a Sample Report</a>
+      <a href="/eudr/" class="btn btn-primary" data-track="hero_try_free">Try It Free</a>
+      <a href="#sample-report" class="btn btn-secondary" data-track="hero_sample_report">See a Sample Report</a>
     </div>
     <p class="hero-note">2 free parcel assessments. No credit card required.</p>
   </div>
@@ -145,7 +145,7 @@
       </div>
 
       <div class="sample-report-footer">
-        <button class="btn btn-primary" id="btn-download-sample">Download Full PDF Report</button>
+        <button class="btn btn-primary" id="btn-download-sample" data-track="sample_download_report">Download Full PDF Report</button>
         <p class="sample-gated-note" id="sample-gated-note" style="display:none">Sign in to download the full PDF evidence report.</p>
       </div>
     </div>
@@ -225,7 +225,7 @@
           <li>All data sources included</li>
           <li>No credit card required</li>
         </ul>
-        <a href="/eudr/" class="btn btn-primary">Try It Free</a>
+        <a href="/eudr/" class="btn btn-primary" data-track="mid_try_free">Try It Free</a>
       </div>
       <div class="pricing-card featured" data-tier="pro">
         <div class="tier-name">EUDR Pro</div>
@@ -239,7 +239,7 @@
           <li>Audit-grade PDF reports</li>
           <li>Priority support</li>
         </ul>
-        <button class="btn btn-primary" id="btn-subscribe">Subscribe</button>
+        <button class="btn btn-primary" id="btn-subscribe" data-track="pricing_subscribe">Subscribe</button>
       </div>
       <div class="pricing-card" data-tier="enterprise">
         <div class="tier-name">Enterprise</div>
@@ -253,7 +253,7 @@
           <li>Custom integrations &amp; API</li>
           <li>SLA &amp; audit logs</li>
         </ul>
-        <a href="mailto:hello@canopex.io?subject=Enterprise%20enquiry" class="btn btn-secondary">Contact Us</a>
+        <a href="mailto:hello@canopex.io?subject=Enterprise%20enquiry" class="btn btn-secondary" data-track="pricing_contact_us">Contact Us</a>
       </div>
     </div>
     <p class="pricing-note">All plans include Sentinel-2, WorldCover, FIRMS, and weather data via Microsoft Planetary Computer at no extra cost. VAT calculated at checkout. Volume discounts available for 100+ parcels. You can cancel any time. 14-day cancellation right applies under UK Consumer Contracts Regulations 2013.</p>

--- a/website/js/analytics.js
+++ b/website/js/analytics.js
@@ -5,8 +5,9 @@
  * snippet is a no-op.
  *
  * Uses the Application Insights JS SDK "snippet" (lightweight ~36 KB).
- * Tracks: page views, click events, unhandled exceptions, and basic
- * Web Vitals (LCP, FID, CLS) when the browser supports them.
+ * Tracks: page views, click events, unhandled exceptions (window.onerror +
+ * unhandledrejection), and basic Web Vitals (LCP, FID, CLS) when the
+ * browser supports them.
  */
 (function () {
   "use strict";
@@ -24,7 +25,7 @@
     enableAutoRouteTracking: true,   // SPA hash-change tracking
     disableAjaxTracking: false,      // track API calls
     maxBatchInterval: 15000,         // batch telemetry every 15s
-    disableExceptionTracking: false, // catch unhandled errors
+    disableExceptionTracking: false, // catch unhandled errors via SDK
   };
 
   // Load the SDK asynchronously from the CDN
@@ -38,6 +39,9 @@
       sdk.loadAppInsights();
       sdk.trackPageView();
 
+      // Expose SDK for use by other scripts (e.g. app-run-lifecycle.js).
+      window.__ai = sdk;
+
       // Track click events with data-track attribute
       document.addEventListener("click", function (e) {
         var btn = e.target.closest("[data-track]");
@@ -45,7 +49,29 @@
           sdk.trackEvent({ name: btn.getAttribute("data-track") });
         }
       });
+
+      // Catch unhandled synchronous errors not already caught by the SDK.
+      var _origOnError = window.onerror;
+      window.onerror = function (msg, src, line, col, err) {
+        sdk.trackException({ exception: err || new Error(String(msg)), severityLevel: 3 });
+        if (typeof _origOnError === "function") return _origOnError.apply(this, arguments);
+        return false;
+      };
+
+      // Catch unhandled Promise rejections.
+      window.addEventListener("unhandledrejection", function (evt) {
+        var err = evt.reason instanceof Error ? evt.reason : new Error(String(evt.reason));
+        sdk.trackException({ exception: err, severityLevel: 3 });
+      });
     }
   };
+
+  // SDK load failure — we can't use AI to report this, but log to console.
+  script.onerror = function () {
+    if (window.console && window.console.warn) {
+      window.console.warn("[canopex] App Insights SDK failed to load");
+    }
+  };
+
   document.head.appendChild(script);
 })();

--- a/website/js/app-msal.js
+++ b/website/js/app-msal.js
@@ -92,8 +92,9 @@
         clientId: ciam.clientId,
         // ciamlogin.com authority — correct for Entra External ID.
         authority: ciam.authority,
-        // Redirect back to the app page, not the root.
-        redirectUri: window.location.origin + '/app/',
+        // Redirect URI comes from the per-page CIAM config (injected by CI).
+        // Falls back to the current page path so dev / staging work without config.
+        redirectUri: window.location.origin + (ciam.appPath || window.location.pathname),
         postLogoutRedirectUri: window.location.origin + '/',
         // CIAM tenants require this to be set explicitly.
         knownAuthorities: [ciam.authority.replace(/https?:\/\//, '').split('/')[0]],
@@ -520,7 +521,7 @@
       if (url.searchParams.get('mode') === 'demo') {
         url.searchParams.delete('mode');
         const nextUrl = url.pathname + (url.search || '') + (url.hash || '');
-        const appBase = _getAppBase ? _getAppBase() : '/app/';
+        const appBase = _getAppBase ? _getAppBase() : '/eudr/';
         window.history.replaceState({}, '', nextUrl || appBase);
       }
     } catch (_) { /* ignore */ }

--- a/website/js/landing.js
+++ b/website/js/landing.js
@@ -60,7 +60,8 @@
           auth: {
             clientId: cfg.clientId,
             authority: cfg.authority,
-            redirectUri: window.location.origin + '/app/',
+            // Redirect URI comes from the per-page CIAM config (injected by CI).
+            redirectUri: window.location.origin + (cfg.appPath || '/eudr/'),
             postLogoutRedirectUri: window.location.origin + '/',
             knownAuthorities: [cfg.authority.replace(/https?:\/\//, '').split('/')[0]],
           },


### PR DESCRIPTION
## Summary

### Auth redirect fix (biggest fragility)
The MSAL `redirectUri` was hardcoded as `/app/` in both `app-msal.js` and `landing.js`. After sign-in, CIAM redirected users to `/app/` rather than the EUDR dashboard at `/eudr/`.

**Fix:** Added `appPath` field to the per-page `canopex-ciam-config` JSON placeholder (already injected at deploy time by CI). Both MSAL modules now read `ciam.appPath` instead of hardcoding a path. CI `sed` injection updated to handle two distinct placeholder variants (`/eudr/` and `/app/`). Fallback to `window.location.pathname` keeps local dev working without config.

Pages:
- `/eudr/index.html` → `appPath: "/eudr/"`
- `/app/index.html` → `appPath: "/app/"`  
- `/index.html` → `appPath: "/eudr/"` (landing → EUDR app after sign-in)

### Analytics hardening
- `window.onerror` handler forwards unhandled sync errors to App Insights
- `unhandledrejection` handler forwards Promise rejections to App Insights
- `script.onerror` logs SDK load failure to console (can't use AI for this)
- Expose SDK as `window.__ai` so other modules can emit custom events
- `data-track` attributes on all primary CTAs: `hero_try_free`, `eudr_queue_analysis`, `eudr_assess_eudr`, `export_pdf/csv/geojson`, `nav_sign_in`, `pricing_subscribe`, etc.

## Testing
- Python test suite: no Python code changed; JS/HTML/YAML only
- `test_frontend_config.py` assertions unaffected: `"apiAudience":""` and `id="canopex-ciam-config"` remain present on all pages
- CI YAML tested by CI itself

## Note for CIAM app registration
`/eudr/` must be registered as an allowed redirect URI in the Entra External ID app registration (alongside `/app/`). If it isn't already, add it before merging.