### PR TITLE
fix(auth): consolidate MSAL into single canopex-auth.js module

### DIFF
--- a/tests/test_frontend_config.py
+++ b/tests/test_frontend_config.py
@@ -272,7 +272,8 @@ class TestAuthConfig:
             "canopex-auth.js must mark redirect-in-progress token errors with authRedirectTriggered"
         )
         assert "throw buildRedirectError" in js, (
-            "canopex-auth.js getToken must throw a redirect marker error when re-auth redirect starts"
+            "canopex-auth.js getToken must throw a redirect marker error "
+            "when re-auth redirect starts"
         )
 
     def test_msal_module_get_token_waits_for_init(self):

--- a/tests/test_frontend_config.py
+++ b/tests/test_frontend_config.py
@@ -299,11 +299,8 @@ class TestAuthConfig:
     def test_msal_module_prefers_access_token_when_api_audience_present(self):
         """Backend bearer validation requires API-audience access token when configured."""
         js = APP_CIAM_JS.read_text()
-        assert "if (ciam.apiAudience)" in js, (
-            "canopex-auth.js getToken must branch when apiAudience is configured"
-        )
         assert "return result.accessToken || '';" in js, (
-            "canopex-auth.js getToken must prefer accessToken when apiAudience is configured"
+            "canopex-auth.js getToken must return the access token from silent acquisition"
         )
 
     def test_msal_module_surfaces_missing_audience_as_error(self):
@@ -327,8 +324,16 @@ class TestAuthConfig:
         eliminates the need for either.
         """
         js = APP_CIAM_JS.read_text()
-        assert "window.location.origin + window.location.pathname" in js, (
+        assert "window.location.pathname" in js, (
             "canopex-auth.js must derive redirectUri from window.location.pathname"
+        )
+        assert "window.location.origin" in js, (
+            "canopex-auth.js must build redirectUri from window.location.origin"
+        )
+        # Path normalisation so /app and /app/ both resolve to the same
+        # registered redirect URI in CIAM (SWA navigationFallback quirk).
+        assert "index.html" in js, (
+            "canopex-auth.js must strip a trailing index.html from the redirect URI"
         )
         assert "+ '/app/'" not in js, (
             "canopex-auth.js must not hard-code '/app/' in the redirectUri"

--- a/tests/test_frontend_config.py
+++ b/tests/test_frontend_config.py
@@ -26,6 +26,7 @@ APP_RUNS_JS = WEBSITE / "js" / "app-runs.js"
 APP_BILLING_JS = WEBSITE / "js" / "app-billing.js"
 APP_EUDR_JS = WEBSITE / "js" / "app-eudr.js"
 API_CLIENT_JS = WEBSITE / "js" / "canopex-api-client.js"
+APP_CIAM_JS = WEBSITE / "js" / "canopex-auth.js"
 APP_MSAL_JS = WEBSITE / "js" / "app-msal.js"
 SWA_CONFIG = WEBSITE / "staticwebapp.config.json"
 HELPERS_PY = Path(__file__).resolve().parent.parent / "blueprints" / "_helpers.py"
@@ -208,13 +209,37 @@ class TestAuthConfig:
             "landing.js must not use SWA /.auth/login/aad — auth is CIAM/MSAL"
         )
 
-    def test_landing_marks_redirect_triggered_token_errors(self, landing_js):
-        """Landing token flow must mark redirect-in-progress failures for API client."""
-        assert "authRedirectTriggered" in landing_js, (
-            "landing.js token refresh path must set authRedirectTriggered on redirect"
+    def test_landing_delegates_msal_to_shared_module(self, landing_js):
+        """landing.js must delegate MSAL primitives to window.CanopexCiam.
+
+        The duplicated MSAL setup that used to live in landing.js was the
+        root cause of cross-page sign-in races and scope drift. landing.js
+        must now import everything via window.CanopexCiam.
+        """
+        assert "window.CanopexCiam" in landing_js, (
+            "landing.js must reference window.CanopexCiam (canopex-auth.js)"
         )
-        assert "acquireTokenRedirect" in landing_js, (
-            "landing.js must trigger acquireTokenRedirect when silent token refresh fails"
+        assert "new window.msal.PublicClientApplication" not in landing_js, (
+            "landing.js must not construct its own PublicClientApplication "
+            "— delegate to canopex-auth.js"
+        )
+        assert "loginRedirect(" not in landing_js, (
+            "landing.js must not call loginRedirect directly — use CanopexCiam.login()"
+        )
+
+    def test_landing_marks_redirect_triggered_token_errors(self):
+        """The shared CIAM auth module must signal redirect-in-progress errors.
+
+        landing.js delegates to window.CanopexCiam, so the redirect-in-progress
+        marker (authRedirectTriggered) is enforced in canopex-auth.js — the
+        single source of truth.
+        """
+        js = APP_CIAM_JS.read_text()
+        assert "authRedirectTriggered" in js, (
+            "canopex-auth.js token refresh path must set authRedirectTriggered"
+        )
+        assert "acquireTokenRedirect" in js, (
+            "canopex-auth.js must trigger acquireTokenRedirect when silent token refresh fails"
         )
 
     def test_landing_auth_enabled_depends_on_ciam_config(self, landing_js):
@@ -224,54 +249,88 @@ class TestAuthConfig:
         )
 
     def test_msal_module_uses_public_client_app(self):
-        """app-msal.js must use MSAL PublicClientApplication for CIAM auth."""
-        js = APP_MSAL_JS.read_text()
+        """The shared canopex-auth.js module must use MSAL PublicClientApplication."""
+        js = APP_CIAM_JS.read_text()
         assert "PublicClientApplication" in js, (
-            "app-msal.js must create msal.PublicClientApplication for CIAM auth"
+            "canopex-auth.js must create msal.PublicClientApplication for CIAM auth"
         )
 
     def test_msal_module_uses_login_redirect(self):
-        """app-msal.js must use loginRedirect (not loginPopup) for consistent UX."""
-        js = APP_MSAL_JS.read_text()
-        assert "loginRedirect" in js, "app-msal.js must call loginRedirect for the MSAL login flow"
+        """The shared canopex-auth.js module must use loginRedirect (not loginPopup)."""
+        js = APP_CIAM_JS.read_text()
+        assert "loginRedirect" in js, (
+            "canopex-auth.js must call loginRedirect for the MSAL login flow"
+        )
 
     def test_msal_module_marks_redirect_triggered_token_errors(self):
         """getToken must signal redirect-in-progress.
 
         Callers use this marker to avoid unauthenticated fallback calls.
         """
-        js = APP_MSAL_JS.read_text()
+        js = APP_CIAM_JS.read_text()
         assert "authRedirectTriggered" in js, (
-            "app-msal.js must mark redirect-in-progress token errors with authRedirectTriggered"
+            "canopex-auth.js must mark redirect-in-progress token errors with authRedirectTriggered"
         )
         assert "throw buildRedirectError" in js, (
-            "app-msal.js getToken must throw a redirect marker error when re-auth redirect starts"
+            "canopex-auth.js getToken must throw a redirect marker error when re-auth redirect starts"
         )
 
     def test_msal_module_get_token_waits_for_init(self):
         """getToken must wait for MSAL initialization and redirect handling."""
-        js = APP_MSAL_JS.read_text()
-        assert "ensureMsalReady" in js, "app-msal.js must define a shared ensureMsalReady helper"
+        js = APP_CIAM_JS.read_text()
+        assert "ensureMsalReady" in js, (
+            "canopex-auth.js must define a shared ensureMsalReady helper"
+        )
         assert "var app = await ensureMsalReady();" in js, (
-            "app-msal.js getToken must await ensureMsalReady before MSAL API calls"
+            "canopex-auth.js getToken must await ensureMsalReady before MSAL API calls"
         )
 
     def test_msal_module_supports_api_audience_config(self):
         """MSAL module must read optional API audience from injected CIAM config."""
-        js = APP_MSAL_JS.read_text()
-        assert "apiAudience" in js, "app-msal.js must parse apiAudience from canopex-ciam-config"
+        js = APP_CIAM_JS.read_text()
+        assert "apiAudience" in js, (
+            "canopex-auth.js must parse apiAudience from canopex-ciam-config"
+        )
         assert "audience + '/User.Read'" in js, (
-            "app-msal.js must derive an API scope from apiAudience"
+            "canopex-auth.js must derive an API scope from apiAudience"
         )
 
     def test_msal_module_prefers_access_token_when_api_audience_present(self):
         """Backend bearer validation requires API-audience access token when configured."""
-        js = APP_MSAL_JS.read_text()
+        js = APP_CIAM_JS.read_text()
         assert "if (ciam.apiAudience)" in js, (
-            "app-msal.js getToken must branch when apiAudience is configured"
+            "canopex-auth.js getToken must branch when apiAudience is configured"
         )
         assert "return result.accessToken || '';" in js, (
-            "app-msal.js getToken must prefer accessToken when apiAudience is configured"
+            "canopex-auth.js getToken must prefer accessToken when apiAudience is configured"
+        )
+
+    def test_msal_module_surfaces_missing_audience_as_error(self):
+        """When apiAudience is missing, getToken must raise — not return ''.
+
+        Returning '' silently caused intermittent 401 floods because callers
+        sent unauthenticated requests against a CIAM-protected backend.
+        """
+        js = APP_CIAM_JS.read_text()
+        assert "throw new Error" in js and "apiAudience is not configured" in js, (
+            "canopex-auth.js getToken must throw a visible error when apiAudience is missing"
+        )
+
+    def test_msal_module_uses_page_derived_redirect_uri(self):
+        """redirectUri must be derived from the current page path, not hard-coded.
+
+        Hard-coding redirectUri to '/app/' caused the long-running bug where
+        sign-in from /eudr/ landed on /app/ and the originating page lost
+        the redirect handshake. PR #774 patched this with a per-page appPath
+        config + doubled CI sed; deriving from window.location.pathname
+        eliminates the need for either.
+        """
+        js = APP_CIAM_JS.read_text()
+        assert "window.location.origin + window.location.pathname" in js, (
+            "canopex-auth.js must derive redirectUri from window.location.pathname"
+        )
+        assert "+ '/app/'" not in js, (
+            "canopex-auth.js must not hard-code '/app/' in the redirectUri"
         )
 
     def test_msal_module_splits_update_auth_ui_render_paths(self):
@@ -373,12 +432,12 @@ class TestAuthConfig:
 
     def test_msal_module_tracks_last_token_acquired_at(self):
         """getToken must update _lastTokenAcquiredAt after a successful acquisition (#757)."""
-        js = APP_MSAL_JS.read_text()
+        js = APP_CIAM_JS.read_text()
         assert "_lastTokenAcquiredAt" in js, (
-            "app-msal.js must declare _lastTokenAcquiredAt for token age telemetry (#757)"
+            "canopex-auth.js must declare _lastTokenAcquiredAt for token age telemetry (#757)"
         )
         assert "tokenAge" in js or "_lastTokenAcquiredAt = new Date" in js, (
-            "app-msal.js must update _lastTokenAcquiredAt when a token is acquired (#757)"
+            "canopex-auth.js must update _lastTokenAcquiredAt when a token is acquired (#757)"
         )
 
     def test_msal_handle_api_error_uses_popup_not_logout(self):
@@ -386,11 +445,17 @@ class TestAuthConfig:
 
         Logging out on a 401 would interrupt a demo mid-session. The handler
         must instead try a popup so the user can re-authenticate in place.
+        Popup logic now lives in canopex-auth.js (reauthInPlace) and
+        app-msal.js handleApiError invokes it.
         """
-        js = APP_MSAL_JS.read_text()
-        assert "acquireTokenPopup" in js, (
-            "app-msal.js handleApiError must call acquireTokenPopup "
+        ciam_js = APP_CIAM_JS.read_text()
+        msal_js = APP_MSAL_JS.read_text()
+        assert "acquireTokenPopup" in ciam_js, (
+            "canopex-auth.js reauthInPlace must call acquireTokenPopup "
             "for transparent 401 re-auth (#757)"
+        )
+        assert "reauthInPlace" in msal_js, (
+            "app-msal.js handleApiError must delegate to CanopexCiam.reauthInPlace (#757)"
         )
 
     def test_msal_handle_api_error_no_immediate_logout(self):
@@ -468,6 +533,56 @@ class TestAuthConfig:
         assert '"apiAudience":""' in eudr_index_html, (
             "/eudr/index.html must include apiAudience in canopex-ciam-config JSON"
         )
+
+    def test_entrypoints_load_canopex_auth_before_consumers(
+        self, index_html, app_index_html, eudr_index_html
+    ):
+        """canopex-auth.js (shared CIAM module) must load before MSAL consumers.
+
+        landing.js, app-msal.js and any future consumer rely on
+        window.CanopexCiam being defined at script execution. Defer scripts
+        execute in document order, so canopex-auth.js must appear earlier
+        in the HTML than its consumers.
+        """
+        ciam_script = '<script src="/js/canopex-auth.js" defer></script>'
+
+        # / (marketing landing)
+        assert ciam_script in index_html, "/index.html must load canopex-auth.js with defer"
+        landing_script = '<script src="/js/landing.js" defer></script>'
+        assert index_html.index(ciam_script) < index_html.index(landing_script), (
+            "/index.html must load canopex-auth.js before landing.js"
+        )
+
+        # /app/
+        assert ciam_script in app_index_html, "/app/index.html must load canopex-auth.js with defer"
+        app_msal_script = '<script src="/js/app-msal.js" defer></script>'
+        assert app_index_html.index(ciam_script) < app_index_html.index(app_msal_script), (
+            "/app/index.html must load canopex-auth.js before app-msal.js"
+        )
+
+        # /eudr/
+        assert ciam_script in eudr_index_html, (
+            "/eudr/index.html must load canopex-auth.js with defer"
+        )
+        assert eudr_index_html.index(ciam_script) < eudr_index_html.index(app_msal_script), (
+            "/eudr/index.html must load canopex-auth.js before app-msal.js"
+        )
+
+    def test_entrypoints_load_msal_cdn_before_canopex_auth(
+        self, index_html, app_index_html, eudr_index_html
+    ):
+        """MSAL.js CDN must load before canopex-auth.js (which references window.msal)."""
+        ciam_script = "/js/canopex-auth.js"
+        msal_marker = "@azure/msal-browser@3.30.0"
+        for name, html in (
+            ("/index.html", index_html),
+            ("/app/index.html", app_index_html),
+            ("/eudr/index.html", eudr_index_html),
+        ):
+            assert msal_marker in html, f"{name} must include MSAL CDN script"
+            assert html.index(msal_marker) < html.index(ciam_script), (
+                f"{name} must load MSAL CDN before canopex-auth.js"
+            )
 
     def test_app_shell_supports_org_scope_history(self, app_runs_js):
         """EUDR dashboard should request org-scoped analysis history for portfolio triage."""

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -40,6 +40,7 @@
     <script src="/js/app-analysis-progress.js" defer></script>
     <script src="/js/app-evidence-display.js" defer></script>
     <script src="https://unpkg.com/@azure/msal-browser@3.30.0/lib/msal-browser.min.js" integrity="sha384-YnOjsoOxSYo65h1BXWnSq24bFbqW8HfzMWSEQxYEMRmjW9Vl1J3HZI3iZxqNYvIi" crossorigin="anonymous" defer></script>
+    <script src="/js/canopex-auth.js" defer></script>
     <script src="/js/app-msal.js" defer></script>
     <script src="/js/app-bindings.js" defer></script>
     <script src="/js/app-run-lifecycle.js" defer></script>

--- a/website/eudr/index.html
+++ b/website/eudr/index.html
@@ -39,6 +39,7 @@
     <script src="/js/app-analysis-progress.js" defer></script>
     <script src="/js/app-evidence-display.js" defer></script>
     <script src="https://unpkg.com/@azure/msal-browser@3.30.0/lib/msal-browser.min.js" integrity="sha384-YnOjsoOxSYo65h1BXWnSq24bFbqW8HfzMWSEQxYEMRmjW9Vl1J3HZI3iZxqNYvIi" crossorigin="anonymous" defer></script>
+    <script src="/js/canopex-auth.js" defer></script>
     <script src="/js/app-msal.js" defer></script>
     <script src="/js/app-bindings.js" defer></script>
     <script src="/js/app-run-lifecycle.js" defer></script>

--- a/website/index.html
+++ b/website/index.html
@@ -287,6 +287,7 @@
 
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha384-cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HTH" crossorigin="anonymous"></script> <!-- pragma: allowlist secret -->
 <script src="https://unpkg.com/@azure/msal-browser@3.30.0/lib/msal-browser.min.js" integrity="sha384-YnOjsoOxSYo65h1BXWnSq24bFbqW8HfzMWSEQxYEMRmjW9Vl1J3HZI3iZxqNYvIi" crossorigin="anonymous" defer></script>
+<script src="/js/canopex-auth.js" defer></script>
 <script src="/js/canopex-api-client.js" defer></script>
 <script src="/js/landing.js" defer></script>
 </body>

--- a/website/js/app-msal.js
+++ b/website/js/app-msal.js
@@ -48,127 +48,39 @@
   var _setAnalysisStatus = null;
   var _setGetToken = null; // wire getToken into the API client
 
-  // ── MSAL state ───────────────────────────────────────────────
-  var _msalApp = null;
-  var _msalInitPromise = null;
+  // ── MSAL primitives delegated to window.CanopexCiam (canopex-auth.js) ──
+  if (!window.CanopexCiam) {
+    throw new Error('[CanopexAuth] canopex-auth.js must be loaded before app-msal.js');
+  }
+  var ciamAuth = window.CanopexCiam;
 
-  // CIAM config — injected at deploy time into a JSON script element
-  // (id="canopex-ciam-config", type="application/json") by the CI pipeline.
-  // Falls back to nothing; authEnabled() returns false and the UI stays
-  // in local-dev mode.
   function getCiamConfig() {
-    try {
-      var el = document.getElementById('canopex-ciam-config');
-      if (!el) return { clientId: '', authority: '', tenantId: '', apiAudience: '' };
-      var parsed = JSON.parse(el.textContent || '{}');
-      return {
-        clientId: parsed.clientId || '',
-        authority: parsed.authority || '',
-        tenantId: parsed.tenantId || '',
-        apiAudience: parsed.apiAudience || '',
-      };
-    } catch (_) {
-      return { clientId: '', authority: '', tenantId: '', apiAudience: '' };
-    }
+    return ciamAuth.getCiamConfig();
   }
 
   function buildApiScopes(ciam) {
-    var audience = String((ciam && ciam.apiAudience) || '').trim();
-    if (!audience) {
-      return ['openid', 'profile'];
-    }
-    return ['openid', 'profile', audience + '/User.Read'];
+    return ciamAuth.buildApiScopes(ciam);
   }
 
   function authEnabled() {
-    var cfg = getCiamConfig();
-    return !!(cfg.clientId && cfg.authority);
-  }
-
-  // Build MSAL config from the injected CIAM config.
-  function buildMsalConfig(ciam) {
-    return {
-      auth: {
-        clientId: ciam.clientId,
-        // ciamlogin.com authority — correct for Entra External ID.
-        authority: ciam.authority,
-        // Redirect back to the app page, not the root.
-        redirectUri: window.location.origin + '/app/',
-        postLogoutRedirectUri: window.location.origin + '/',
-        // CIAM tenants require this to be set explicitly.
-        knownAuthorities: [ciam.authority.replace(/https?:\/\//, '').split('/')[0]],
-      },
-      cache: {
-        cacheLocation: 'localStorage',
-        storeAuthStateInCookie: false,
-      },
-    };
-  }
-
-  function getMsalApp() {
-    if (_msalApp) {
-      return _msalApp;
-    }
-    if (!window.msal) {
-      console.warn('[CanopexAuth] MSAL.js not loaded');
-      return null;
-    }
-    var ciam = getCiamConfig();
-    if (!ciam.clientId || !ciam.authority) {
-      return null;
-    }
-    try {
-      _msalApp = new window.msal.PublicClientApplication(buildMsalConfig(ciam));
-      return _msalApp;
-    } catch (err) {
-      console.warn('[CanopexAuth] MSAL init failed:', err);
-      return null;
-    }
-  }
-
-  function applyCachedAccount(app) {
-    var accounts = app.getAllAccounts();
-    if (accounts && accounts.length > 0) {
-      var account = accounts[0];
-      if (_setAccount) {
-        _setAccount({
-          userId: account.localAccountId || account.homeAccountId || '',
-          name: account.name || account.username || '',
-          identityProvider: 'ciam',
-          userRoles: [],
-        });
-      }
-      return account;
-    }
-    return null;
+    return ciamAuth.authEnabled();
   }
 
   function ensureMsalReady() {
-    if (!authEnabled()) {
-      return Promise.resolve(null);
-    }
+    var p = ciamAuth.ensureMsalReady();
+    return p.then(function (app) {
+      applyCachedAccount(app);
+      return app;
+    });
+  }
 
-    var app = getMsalApp();
-    if (!app) {
-      return Promise.resolve(null);
+  function applyCachedAccount(app) {
+    if (!app) return null;
+    var account = ciamAuth.getAccount();
+    if (account && _setAccount) {
+      _setAccount(ciamAuth.getCurrentUser());
     }
-
-    if (!_msalInitPromise) {
-      _msalInitPromise = app.initialize().then(function () {
-        return app.handleRedirectPromise().catch(function (redirectErr) {
-          console.warn('[CanopexAuth] handleRedirectPromise error:', redirectErr);
-          return null;
-        });
-      }).then(function () {
-        applyCachedAccount(app);
-        return app;
-      }).catch(function (initErr) {
-        _msalInitPromise = null;
-        throw initErr;
-      });
-    }
-
-    return _msalInitPromise;
+    return account;
   }
 
   // ── Dep injection ─────────────────────────────────────────────
@@ -202,75 +114,10 @@
     }
   }
 
-  // ── getToken ──────────────────────────────────────────────────
+  // ── getToken (delegated) ──────────────────────────────────────
 
-  // Token age telemetry (#757): timestamp of the last successful token acquisition.
-  var _lastTokenAcquiredAt = null;
-
-  function buildRedirectError(message, cause) {
-    var err = new Error(message);
-    err.name = 'CanopexAuthRedirectError';
-    err.authRedirectTriggered = true;
-    if (cause) {
-      err.cause = cause;
-    }
-    return err;
-  }
-
-  /**
-   * Return a valid CIAM token string, acquiring silently if possible.
-   * Falls back to a redirect login if no cached token is available.
-   * Logs token age to console for debugging (#757).
-   * Throws if MSAL is not configured (authEnabled() === false).
-   */
-  async function getToken() {
-    var app = await ensureMsalReady();
-    if (!app) {
-      throw new Error('[CanopexAuth] MSAL not configured — cannot get token');
-    }
-
-    var accounts = app.getAllAccounts();
-    if (!accounts || accounts.length === 0) {
-      // No cached account — trigger login.
-      login();
-      // Stop API callers from sending unauthenticated requests while redirecting.
-      throw buildRedirectError('[CanopexAuth] Redirecting to login (no cached account)');
-    }
-
-    var account = accounts[0];
-    var ciam = getCiamConfig();
-    var request = {
-      scopes: buildApiScopes(ciam),
-      account: account,
-    };
-
-    try {
-      var result = await app.acquireTokenSilent(request);
-      _lastTokenAcquiredAt = new Date().toISOString();
-      console.debug('[CanopexAuth] tokenAge: acquired at', _lastTokenAcquiredAt);
-      if (ciam.apiAudience) {
-        // API audience is registered — backend requires a CIAM access token.
-        // Never use the ID token as a bearer credential.
-        return result.accessToken || '';
-      }
-      // apiAudience is not configured — this is a misconfiguration even in local dev.
-      // Returning an ID token as a bearer credential is a security anti-pattern.
-      // Log a clear error and return empty so callers fail visibly rather than silently.
-      console.error('[CanopexAuth] apiAudience not configured — cannot acquire API token. Check CIAM_API_AUDIENCE.');
-      return '';
-    } catch (silentErr) {
-      // Silent acquisition failed (token expired, consent required, etc.).
-      // Trigger a redirect so the user can re-authenticate.
-      var errorCode = String((silentErr && silentErr.errorCode) || '');
-      if (errorCode !== 'interaction_in_progress') {
-        console.warn('[CanopexAuth] Silent token acquisition failed, redirecting:', silentErr);
-        app.acquireTokenRedirect(request).catch(function (redirectErr) {
-          console.error('[CanopexAuth] Redirect login failed:', redirectErr);
-        });
-      }
-      // Stop API callers from sending unauthenticated requests while redirecting.
-      throw buildRedirectError('[CanopexAuth] Redirecting to refresh session', silentErr);
-    }
+  function getToken() {
+    return ciamAuth.getToken();
   }
 
   // ── login / logout ────────────────────────────────────────────
@@ -282,15 +129,8 @@
   }
 
   function login() {
-    ensureMsalReady().then(function (app) {
-      if (!app) {
-        return;
-      }
-      rememberPostLoginDestination();
-      return app.loginRedirect({ scopes: buildApiScopes(getCiamConfig()) });
-    }).catch(function (err) {
-      console.error('[CanopexAuth] loginRedirect failed:', err);
-    });
+    rememberPostLoginDestination();
+    ciamAuth.login();
   }
 
   function logout() {
@@ -300,21 +140,7 @@
     try {
       sessionStorage.removeItem(_postLoginDestinationKey || 'canopex-post-login');
     } catch (_) { /* ignore */ }
-
-    ensureMsalReady().then(function (app) {
-      if (!app) {
-        return;
-      }
-      var accounts = app.getAllAccounts();
-      var account = accounts && accounts[0];
-      return app.logoutRedirect({
-        account: account || null,
-        postLogoutRedirectUri: window.location.origin + '/',
-      });
-    }).catch(function (err) {
-      console.error('[CanopexAuth] logoutRedirect failed:', err);
-    }).catch(function (err) {
-    });
+    ciamAuth.logout();
   }
 
   // ── handleApiError ────────────────────────────────────────────
@@ -337,28 +163,13 @@
       _setAnalysisStatus('Session refreshing — signing you back in…', 'info');
     }
 
-    ensureMsalReady().then(function (app) {
-      if (!app) {
-        return;
+    // Try popup re-auth first so the page doesn't navigate away mid-demo.
+    ciamAuth.reauthInPlace().then(function (result) {
+      if (result && _setAnalysisStatus) {
+        _setAnalysisStatus('', '');
       }
-      var accounts = app.getAllAccounts();
-      var account = accounts && accounts[0];
-      if (!account) {
-        login();
-        return;
-      }
-      var ciam = getCiamConfig();
-      var request = { scopes: buildApiScopes(ciam), account: account };
-      // Try popup first so the page doesn't navigate away mid-demo.
-      return app.acquireTokenPopup(request).then(function (result) {
-        _lastTokenAcquiredAt = new Date().toISOString();
-        console.debug('[CanopexAuth] Re-auth via popup succeeded at', _lastTokenAcquiredAt);
-        if (_setAnalysisStatus) {
-          _setAnalysisStatus('', '');
-        }
-      });
     }).catch(function (popupErr) {
-      // Popup blocked or failed — fall back to full redirect.
+      // Popup blocked or failed — fall back to full redirect login.
       console.warn('[CanopexAuth] Popup re-auth failed, falling back to redirect:', popupErr);
       if (_stopAnalysisPolling) {
         _stopAnalysisPolling();

--- a/website/js/canopex-auth.js
+++ b/website/js/canopex-auth.js
@@ -88,8 +88,21 @@
   // Page-derived redirect URI. The page that started the login completes
   // the redirect handshake — this avoids cross-page MSAL state desync and
   // makes adding a new entrypoint zero-config.
+  //
+  // Normalisation: SWA's navigationFallback means both `/app` and `/app/`
+  // resolve to the same page, but MSAL string-matches the redirect URI
+  // exactly against what's registered in CIAM. Strip a trailing
+  // `index.html`, then ensure non-file directory paths end in `/` so
+  // operators only need to register the canonical (slash-terminated)
+  // form once per page.
   function pageRedirectUri() {
-    return window.location.origin + window.location.pathname;
+    var path = window.location.pathname || '/';
+    path = path.replace(/index\.html$/i, '');
+    var lastSegment = path.substring(path.lastIndexOf('/') + 1);
+    if (lastSegment.length > 0 && lastSegment.indexOf('.') === -1) {
+      path = path + '/';
+    }
+    return window.location.origin + path;
   }
 
   function buildMsalConfig(ciam) {
@@ -260,10 +273,7 @@
       var result = await app.acquireTokenSilent(request);
       _lastTokenAcquiredAt = new Date().toISOString();
       console.debug('[CanopexCiam] tokenAge: acquired at', _lastTokenAcquiredAt);
-      if (ciam.apiAudience) {
-        return result.accessToken || '';
-      }
-      return '';
+      return result.accessToken || '';
     } catch (silentErr) {
       var errorCode = String((silentErr && silentErr.errorCode) || '');
       if (errorCode !== 'interaction_in_progress') {

--- a/website/js/canopex-auth.js
+++ b/website/js/canopex-auth.js
@@ -1,0 +1,328 @@
+/**
+ * canopex-auth.js
+ *
+ * Single source of truth for CIAM (Entra External ID) browser auth via MSAL.js.
+ *
+ * This module replaces the parallel MSAL setups that previously lived in
+ * landing.js (marketing page) and app-msal.js (app shell). Both consumers
+ * now go through `window.CanopexCiam` so:
+ *   - There is exactly one PublicClientApplication per page.
+ *   - `redirectUri` is derived from the current page path, so the page that
+ *     initiates login is the page that completes the redirect handshake.
+ *     This removes the "sign-in lands on /app/ instead of /eudr/" class of
+ *     bug at its root and removes the need for per-page `appPath` config or
+ *     the doubled CI sed substitution that PR #774 introduced.
+ *   - Scope construction, token preference, error semantics and the
+ *     `authRedirectTriggered` marker are defined once.
+ *
+ * Requires `window.msal` (MSAL.js browser bundle) loaded before this file.
+ *
+ * Public API (window.CanopexCiam):
+ *   getCiamConfig()            — read injected `<script id="canopex-ciam-config">`
+ *   authEnabled()              — true when MSAL + CIAM config are present
+ *   ensureMsalReady()          — Promise<PublicClientApplication|null>
+ *   getAccount()               — cached MSAL AccountInfo or null
+ *   getCurrentUser()           — normalised {userId,name,identityProvider} or null
+ *   login()                    — start loginRedirect
+ *   logout(opts)               — start logoutRedirect (opts.onBeforeLogout cb)
+ *   getToken()                 — Promise<string> CIAM access token (throws
+ *                                CanopexAuthRedirectError if redirect started)
+ *   onAccountChange(cb)        — subscribe to account-state changes
+ *   buildRedirectError(msg, cause)
+ */
+(function () {
+  'use strict';
+
+  var _msalApp = null;
+  var _msalInitPromise = null;
+  var _cachedAccount = null;
+  var _lastTokenAcquiredAt = null;
+  var _accountChangeListeners = [];
+
+  function getCiamConfig() {
+    try {
+      var el = document.getElementById('canopex-ciam-config');
+      if (!el) {
+        return { clientId: '', authority: '', tenantId: '', apiAudience: '' };
+      }
+      var parsed = JSON.parse(el.textContent || '{}');
+      return {
+        clientId: parsed.clientId || '',
+        authority: parsed.authority || '',
+        tenantId: parsed.tenantId || '',
+        apiAudience: parsed.apiAudience || '',
+      };
+    } catch (_) {
+      return { clientId: '', authority: '', tenantId: '', apiAudience: '' };
+    }
+  }
+
+  function authEnabled() {
+    var cfg = getCiamConfig();
+    return !!(window.msal && cfg.clientId && cfg.authority);
+  }
+
+  // API scope construction. When apiAudience is configured we request
+  // `<audience>/User.Read` so CIAM mints an access token for our API
+  // (audience match is verified server-side). When apiAudience is empty
+  // we only request OIDC scopes — the resulting calls will be unauthenticated
+  // and getToken() will surface a visible misconfiguration error.
+  function buildApiScopes(ciam) {
+    var audience = String((ciam && ciam.apiAudience) || '').trim();
+    if (!audience) {
+      return ['openid', 'profile'];
+    }
+    return ['openid', 'profile', audience + '/User.Read'];
+  }
+
+  function buildRedirectError(message, cause) {
+    var err = new Error(message);
+    err.name = 'CanopexAuthRedirectError';
+    err.authRedirectTriggered = true;
+    if (cause) {
+      err.cause = cause;
+    }
+    return err;
+  }
+
+  // Page-derived redirect URI. The page that started the login completes
+  // the redirect handshake — this avoids cross-page MSAL state desync and
+  // makes adding a new entrypoint zero-config.
+  function pageRedirectUri() {
+    return window.location.origin + window.location.pathname;
+  }
+
+  function buildMsalConfig(ciam) {
+    return {
+      auth: {
+        clientId: ciam.clientId,
+        authority: ciam.authority,
+        redirectUri: pageRedirectUri(),
+        postLogoutRedirectUri: window.location.origin + '/',
+        knownAuthorities: [ciam.authority.replace(/https?:\/\//, '').split('/')[0]],
+      },
+      cache: {
+        cacheLocation: 'localStorage',
+        storeAuthStateInCookie: false,
+      },
+    };
+  }
+
+  function getMsalApp() {
+    if (_msalApp) {
+      return _msalApp;
+    }
+    if (!window.msal) {
+      console.warn('[CanopexCiam] MSAL.js not loaded');
+      return null;
+    }
+    var ciam = getCiamConfig();
+    if (!ciam.clientId || !ciam.authority) {
+      return null;
+    }
+    try {
+      _msalApp = new window.msal.PublicClientApplication(buildMsalConfig(ciam));
+      return _msalApp;
+    } catch (err) {
+      console.warn('[CanopexCiam] MSAL init failed:', err);
+      return null;
+    }
+  }
+
+  function notifyAccountChange() {
+    for (var i = 0; i < _accountChangeListeners.length; i += 1) {
+      try {
+        _accountChangeListeners[i](_cachedAccount);
+      } catch (cbErr) {
+        console.warn('[CanopexCiam] onAccountChange listener threw:', cbErr);
+      }
+    }
+  }
+
+  function applyCachedAccount(app) {
+    var accounts = app.getAllAccounts();
+    var prev = _cachedAccount;
+    if (accounts && accounts.length > 0) {
+      _cachedAccount = accounts[0];
+    } else {
+      _cachedAccount = null;
+    }
+    if (prev !== _cachedAccount) {
+      notifyAccountChange();
+    }
+    return _cachedAccount;
+  }
+
+  function ensureMsalReady() {
+    if (!authEnabled()) {
+      return Promise.resolve(null);
+    }
+    var app = getMsalApp();
+    if (!app) {
+      return Promise.resolve(null);
+    }
+    if (!_msalInitPromise) {
+      _msalInitPromise = app.initialize().then(function () {
+        return app.handleRedirectPromise().catch(function (redirectErr) {
+          console.warn('[CanopexCiam] handleRedirectPromise error:', redirectErr);
+          return null;
+        });
+      }).then(function () {
+        applyCachedAccount(app);
+        return app;
+      }).catch(function (initErr) {
+        _msalInitPromise = null;
+        throw initErr;
+      });
+    }
+    return _msalInitPromise;
+  }
+
+  function getAccount() {
+    return _cachedAccount;
+  }
+
+  function getCurrentUser() {
+    if (!_cachedAccount) return null;
+    return {
+      userId: _cachedAccount.localAccountId || _cachedAccount.homeAccountId || '',
+      name: _cachedAccount.name || _cachedAccount.username || '',
+      identityProvider: 'ciam',
+      userRoles: [],
+    };
+  }
+
+  function login() {
+    return ensureMsalReady().then(function (app) {
+      if (!app) return null;
+      return app.loginRedirect({ scopes: buildApiScopes(getCiamConfig()) });
+    }).catch(function (err) {
+      console.error('[CanopexCiam] loginRedirect failed:', err);
+      return null;
+    });
+  }
+
+  function logout(opts) {
+    var options = opts || {};
+    return ensureMsalReady().then(function (app) {
+      if (typeof options.onBeforeLogout === 'function') {
+        try { options.onBeforeLogout(); } catch (_) { /* ignore */ }
+      }
+      if (!app) return null;
+      var account = app.getAllAccounts()[0] || null;
+      return app.logoutRedirect({
+        account: account,
+        postLogoutRedirectUri: window.location.origin + '/',
+      });
+    }).catch(function (err) {
+      console.error('[CanopexCiam] logoutRedirect failed:', err);
+      return null;
+    });
+  }
+
+  /**
+   * Acquire a CIAM API access token, redirecting if interactive auth is needed.
+   *
+   * Throws a CanopexAuthRedirectError (with `authRedirectTriggered=true`) when
+   * a redirect login has been initiated — callers should catch this and avoid
+   * issuing the unauthenticated request.
+   *
+   * Throws a regular Error when auth is misconfigured (apiAudience missing).
+   * This is preferred over silently returning '' — empty tokens were the
+   * cause of intermittent 401 floods we saw in production.
+   */
+  async function getToken() {
+    var app = await ensureMsalReady();
+    if (!app) {
+      throw new Error('[CanopexCiam] MSAL not configured — cannot get token');
+    }
+
+    var ciam = getCiamConfig();
+    if (!ciam.apiAudience) {
+      // Misconfiguration. Raise loudly instead of returning '' so the caller
+      // sees a real error and the operator notices.
+      throw new Error(
+        '[CanopexCiam] apiAudience is not configured — backend will reject ' +
+        'every request. Check CIAM_API_AUDIENCE deploy secret.'
+      );
+    }
+
+    var accounts = app.getAllAccounts();
+    if (!accounts || accounts.length === 0) {
+      login();
+      throw buildRedirectError('[CanopexCiam] Redirecting to login (no cached account)');
+    }
+
+    var account = accounts[0];
+    var request = { scopes: buildApiScopes(ciam), account: account };
+
+    try {
+      var result = await app.acquireTokenSilent(request);
+      _lastTokenAcquiredAt = new Date().toISOString();
+      console.debug('[CanopexCiam] tokenAge: acquired at', _lastTokenAcquiredAt);
+      if (ciam.apiAudience) {
+        return result.accessToken || '';
+      }
+      return '';
+    } catch (silentErr) {
+      var errorCode = String((silentErr && silentErr.errorCode) || '');
+      if (errorCode !== 'interaction_in_progress') {
+        console.warn('[CanopexCiam] Silent token acquisition failed, redirecting:', silentErr);
+        app.acquireTokenRedirect(request).catch(function (redirectErr) {
+          console.error('[CanopexCiam] Redirect login failed:', redirectErr);
+        });
+      }
+      throw buildRedirectError('[CanopexCiam] Redirecting to refresh session', silentErr);
+    }
+  }
+
+  // Internal hook for handleApiError flows — try popup re-auth without
+  // navigating away from the current page (so an in-flight demo survives a
+  // 401). Falls back to a full redirect login if the popup is blocked.
+  async function reauthInPlace() {
+    var app = await ensureMsalReady();
+    if (!app) return null;
+    var account = app.getAllAccounts()[0];
+    if (!account) {
+      login();
+      return null;
+    }
+    var ciam = getCiamConfig();
+    var request = { scopes: buildApiScopes(ciam), account: account };
+    var result = await app.acquireTokenPopup(request);
+    _lastTokenAcquiredAt = new Date().toISOString();
+    console.debug('[CanopexCiam] Re-auth via popup succeeded at', _lastTokenAcquiredAt);
+    return result;
+  }
+
+  function onAccountChange(cb) {
+    if (typeof cb === 'function') {
+      _accountChangeListeners.push(cb);
+    }
+    return function unsubscribe() {
+      _accountChangeListeners = _accountChangeListeners.filter(function (fn) {
+        return fn !== cb;
+      });
+    };
+  }
+
+  function getLastTokenAcquiredAt() {
+    return _lastTokenAcquiredAt;
+  }
+
+  window.CanopexCiam = {
+    getCiamConfig: getCiamConfig,
+    buildApiScopes: buildApiScopes,
+    authEnabled: authEnabled,
+    ensureMsalReady: ensureMsalReady,
+    getAccount: getAccount,
+    getCurrentUser: getCurrentUser,
+    login: login,
+    logout: logout,
+    getToken: getToken,
+    reauthInPlace: reauthInPlace,
+    onAccountChange: onAccountChange,
+    buildRedirectError: buildRedirectError,
+    getLastTokenAcquiredAt: getLastTokenAcquiredAt,
+  };
+})();

--- a/website/js/landing.js
+++ b/website/js/landing.js
@@ -1,6 +1,14 @@
 (function() {
   'use strict';
 
+  // All MSAL/CIAM primitives are sourced from window.CanopexCiam (canopex-auth.js).
+  // landing.js owns *only* the marketing-page UI (header buttons, sample report,
+  // sample map, FAQ, subscribe). Auth state is mirrored locally for UI rendering.
+  if (!window.CanopexCiam) {
+    throw new Error('[canopex] canopex-auth.js must be loaded before landing.js');
+  }
+  const ciamAuth = window.CanopexCiam;
+
   let currentAccount = null;
 
   function createApiClient() {
@@ -14,105 +22,27 @@
 
   const apiClient = createApiClient();
 
-  function getCiamConfig() {
-    const el = document.getElementById('canopex-ciam-config');
-    if (!el) return { clientId: '', authority: '', tenantId: '', apiAudience: '' };
-    try {
-      const cfg = JSON.parse(el.textContent || '{}');
-      return {
-        clientId: cfg.clientId || '',
-        authority: cfg.authority || '',
-        tenantId: cfg.tenantId || '',
-        apiAudience: cfg.apiAudience || '',
-      };
-    } catch (_) {
-      return { clientId: '', authority: '', tenantId: '', apiAudience: '' };
-    }
-  }
-
-  function buildApiScopes(cfg) {
-    const audience = String((cfg && cfg.apiAudience) || '').trim();
-    if (!audience) return ['openid', 'profile'];
-    return ['openid', 'profile', audience + '/.default'];
-  }
-
   function authEnabled() {
-    const cfg = getCiamConfig();
+    const cfg = ciamAuth.getCiamConfig();
     return !!(window.msal && cfg.clientId && cfg.authority);
   }
 
-  function buildRedirectError(message, cause) {
-    const err = new Error(message);
-    err.name = 'CanopexAuthRedirectError';
-    err.authRedirectTriggered = true;
-    if (cause) err.cause = cause;
-    return err;
-  }
-
-  // Returns the MSAL app instance, or null if CIAM is not configured.
-  function getMsalApp() {
-    if (!window.msal) return null;
-    const cfg = getCiamConfig();
-    if (!cfg.clientId || !cfg.authority) return null;
-    if (!getMsalApp._instance) {
-      try {
-        getMsalApp._instance = new window.msal.PublicClientApplication({
-          auth: {
-            clientId: cfg.clientId,
-            authority: cfg.authority,
-            redirectUri: window.location.origin + '/app/',
-            postLogoutRedirectUri: window.location.origin + '/',
-            knownAuthorities: [cfg.authority.replace(/https?:\/\//, '').split('/')[0]],
-          },
-          cache: { cacheLocation: 'localStorage', storeAuthStateInCookie: false },
-        });
-      } catch (err) {
-        console.warn('[canopex] MSAL init failed:', err);
-        return null;
-      }
-    }
-    return getMsalApp._instance;
-  }
-
   async function initAuth() {
-    const app = getMsalApp();
-    if (!app) {
-      // CIAM not configured (local dev) — show unauthenticated UI.
+    if (!authEnabled()) {
       updateAuthUI();
       updateSampleReportGate();
       return;
     }
     try {
-      await app.initialize();
-      await app.handleRedirectPromise();
-      const accounts = app.getAllAccounts();
-      if (accounts && accounts.length > 0) {
-        const account = accounts[0];
-        currentAccount = {
-          userId: account.localAccountId || account.homeAccountId || '',
-          name: account.name || account.username || '',
-          identityProvider: 'ciam',
-          userRoles: [],
-        };
-        apiClient.setGetToken(async function () {
-          const cfg = getCiamConfig();
-          const req = { scopes: buildApiScopes(cfg), account: account };
-          try {
-            const result = await app.acquireTokenSilent(req);
-            if (cfg.apiAudience) {
-              return result.accessToken || result.idToken || '';
-            }
-            return result.idToken || result.accessToken || '';
-          } catch (tokenErr) {
-            const errorCode = String((tokenErr && tokenErr.errorCode) || '');
-            if (errorCode !== 'interaction_in_progress') {
-              app.acquireTokenRedirect(req).catch(function (redirectErr) {
-                console.error('[canopex] acquireTokenRedirect failed:', redirectErr);
-              });
-            }
-            throw buildRedirectError('[canopex] Redirecting to refresh session', tokenErr);
-          }
-        });
+      const app = await ciamAuth.ensureMsalReady();
+      if (app) {
+        const account = ciamAuth.getAccount();
+        if (account) {
+          currentAccount = ciamAuth.getCurrentUser();
+        }
+        // Wire the API client to use ciamAuth.getToken — surfaces
+        // authRedirectTriggered errors so the API client can stop fallback flow.
+        apiClient.setGetToken(ciamAuth.getToken);
       }
     } catch (err) {
       console.warn('[canopex] MSAL auth check failed:', err);
@@ -122,23 +52,11 @@
   }
 
   function login() {
-    const app = getMsalApp();
-    if (!app) return;
-    app.loginRedirect({ scopes: ['openid', 'profile'] }).catch(function (err) {
-      console.error('[canopex] loginRedirect failed:', err);
-    });
+    ciamAuth.login();
   }
 
   function logout() {
-    const app = getMsalApp();
-    if (!app) return;
-    const accounts = app.getAllAccounts();
-    app.logoutRedirect({
-      account: accounts && accounts[0] || null,
-      postLogoutRedirectUri: window.location.origin + '/',
-    }).catch(function (err) {
-      console.error('[canopex] logoutRedirect failed:', err);
-    });
+    ciamAuth.logout();
   }
 
   function updateAuthUI() {


### PR DESCRIPTION
## Summary

Reviewed the browser-side authentication architecture end-to-end and fixed the root cause of the "auth is flakey / breaks when anything changes" symptoms. Supersedes #774.

## What was wrong

1. **Two parallel MSAL implementations** in `landing.js` and `app-msal.js`. Both built their own `PublicClientApplication` (same `clientId`, both `cacheLocation: localStorage`) — two MSAL singletons racing on shared storage during init/redirect handshakes. The two had also drifted: `landing.js` used `<audience>/.default`, `app-msal.js` used `<audience>/User.Read`; different fallback semantics on missing audience; different login error handling. Any change to one needed manual mirroring in the other, and forgetting to do so was the source of most "broke when something changed" reports.
2. **Hard-coded `redirectUri = '/app/'`** in two places — the symptom #774 was patching. Real fix: derive `redirectUri` from the page itself, so the page that initiated login is the page that completes the redirect handshake. No per-page `appPath` config needed, no doubled CI sed pattern needed.
3. **Silent misconfig**: `getToken()` returned `''` when `apiAudience` was missing, causing `canopex-api-client.js` to send unauthenticated requests that the bearer-only backend would 401. The user saw "logged-in UI but everything 401s" with no console error.
4. **Brittle CI sed-based config injection** scaling linearly with pages (#774 had to double the patterns).

Backend (`treesight/security/auth.py`, `blueprints/_helpers.py`) is solid — bearer-only JWT against CIAM/Entra External ID with JWKS, audience and issuer checks. **No backend changes in this PR.**

## What this PR does

- **New `website/js/canopex-auth.js`** — single source of truth exposed as `window.CanopexCiam`. Owns the MSAL singleton, `getCiamConfig`, `ensureMsalReady`, `login`, `logout`, `getToken`, `reauthInPlace`, `onAccountChange`.
- **`redirectUri = window.location.origin + window.location.pathname`** — page-derived. Eliminates the cross-page redirect bug at the root and obsoletes the `appPath` config + doubled sed substitution that #774 introduced.
- **Standardised on `<audience>/User.Read`** (matches what app-shell already used).
- **`getToken()` throws** a visible `Error('apiAudience is not configured')` when misconfigured — no more silent unauthenticated requests.
- **`landing.js`** (425 → 308 lines) and **`app-msal.js`** (558 → 331 lines) are now thin consumers of `window.CanopexCiam`. `app-msal.js` preserves the existing `window.CanopexAuth` contract so `app-shell.js` is unchanged.
- **HTML entrypoints** (`/`, `/app/`, `/eudr/`) load `/js/canopex-auth.js` after the MSAL CDN and before any consumer.
- **Tests**: existing implementation-string assertions migrated to `canopex-auth.js`; added new tests for script load order (`test_entrypoints_load_canopex_auth_before_consumers`, `test_entrypoints_load_msal_cdn_before_canopex_auth`), missing-audience error visibility (`test_msal_module_surfaces_missing_audience_as_error`), and page-derived redirect URI (`test_msal_module_uses_page_derived_redirect_uri`).

## Test results

Targeted: `tests/test_frontend_config.py` → **69 passed**.
Broader run (excluding three pre-existing unrelated failing modules): **1547 passed, 28 skipped**, no regressions.

JS not runtime-validated (no Node on this host) — only static-asserted via the contract tests.

## Operator action required

Confirm that `/`, `/eudr/` and `/app/` (the actual page paths customers land on) are all registered as **redirect URIs** in the CIAM app registration. PR #774's body suggested `/eudr/` was already added; please confirm `/` and `/app/` are also registered. With page-derived `redirectUri`, any future page added to the site will need its path registered too.

## Out of scope (separate follow-up)

The user asked about Microsoft + Google IdP support, eventual SSO, and team / parcel-collection access. None of that is wired today. Path forward (to be filed as a separate issue):

- Federated identity providers in CIAM (Google, generic OIDC).
- For B2B / customer Microsoft tenants: switch to Workforce Entra app registration with `signInAudience = AzureADMultipleOrgs`, or stay on CIAM and federate per-customer Entra tenants.
- A "team / parcel-collection" claim (group, app role, or extension attribute) propagated as a JWT claim and consumed by `require_auth` for access control.

## Closes / supersedes

- Supersedes #774 — please close that PR. The hard-coded `redirectUri` it was fixing is fixed at the root here, and the `appPath` machinery it introduced is no longer needed.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;