### PR TITLE
chore(infra): manage CIAM tenant config via Tofu + Key Vault

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
     env:
       AzureWebJobsStorage: "UseDevelopmentStorage=true"
       DEMO_VALET_TOKEN_SECRET: "ci-test-secret"  # pragma: allowlist secret
-      AUTH_MODE: "bearer_only"
       CIAM_AUTHORITY: "https://treesightauth.ciamlogin.com"
       CIAM_TENANT_ID: "ci-test-tenant"
       CIAM_API_AUDIENCE: "api://ci-test-audience"
@@ -102,7 +101,6 @@ jobs:
       - name: Run container smoke tests
         run: |
           docker run --rm \
-            -e AUTH_MODE="bearer_only" \
             -e CIAM_AUTHORITY="https://treesightauth.ciamlogin.com" \
             -e CIAM_TENANT_ID="ci-test-tenant" \
             -e CIAM_API_AUDIENCE="api://ci-test-audience" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1145,10 +1145,26 @@ jobs:
           # Read CIAM page-config values from Key Vault (single source of truth
           # populated by Tofu). Empty values disable the page config (sign-in
           # button hidden) rather than failing the deploy.
-          CIAM_CLIENT_ID="$(az keyvault secret show --vault-name "$KEY_VAULT_NAME" --name ciam-client-id --query value -o tsv 2>/dev/null || echo '')"
-          CIAM_AUTHORITY="$(az keyvault secret show --vault-name "$KEY_VAULT_NAME" --name ciam-authority --query value -o tsv 2>/dev/null || echo '')"
-          CIAM_TENANT_ID="$(az keyvault secret show --vault-name "$KEY_VAULT_NAME" --name ciam-tenant-id --query value -o tsv 2>/dev/null || echo '')"
-          CIAM_API_AUDIENCE="$(az keyvault secret show --vault-name "$KEY_VAULT_NAME" --name ciam-api-audience --query value -o tsv 2>/dev/null || echo '')"
+          # Retry with backoff to tolerate transient KV throttling / RBAC
+          # propagation right after a fresh Tofu apply.
+          read_kv_secret() {
+            local name="$1"
+            local attempt
+            for attempt in 1 2 3 4 5; do
+              local value
+              value="$(az keyvault secret show --vault-name "$KEY_VAULT_NAME" --name "$name" --query value -o tsv 2>/dev/null || true)"
+              if [ -n "$value" ]; then
+                echo "$value"
+                return 0
+              fi
+              sleep $((attempt * 2))
+            done
+            echo ""
+          }
+          CIAM_CLIENT_ID="$(read_kv_secret ciam-client-id)"
+          CIAM_AUTHORITY="$(read_kv_secret ciam-authority)"
+          CIAM_TENANT_ID="$(read_kv_secret ciam-tenant-id)"
+          CIAM_API_AUDIENCE="$(read_kv_secret ciam-api-audience)"
           if [ -n "$CIAM_CLIENT_ID" ] && [ -n "$CIAM_AUTHORITY" ]; then
             CIAM_JSON="{\"clientId\":\"${CIAM_CLIENT_ID}\",\"authority\":\"${CIAM_AUTHORITY}\",\"tenantId\":\"${CIAM_TENANT_ID}\",\"apiAudience\":\"${CIAM_API_AUDIENCE}\"}"
             find website -name '*.html' -exec sed -i \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -273,9 +273,8 @@ jobs:
     env:
       TF_VAR_deploy_principal_client_id: ${{ secrets.AZURE_CLIENT_ID }}
       TF_VAR_auth_mode: bearer_only
-      # CIAM tenant_id, authority, client_id are now hardcoded in tfvars (public values).
-      # Only the api_audience and the (optional) deploy SP client_id remain as secrets.
-      TF_VAR_ciam_api_audience: ${{ secrets.TF_VAR_CIAM_API_AUDIENCE || '' }}
+      # CIAM tenant_id, authority, client_id, and api_audience are now in tfvars
+      # (all public values). Only the deploy SP client_id remains as a secret.
       TF_VAR_ciam_deploy_client_id: ${{ secrets.TF_VAR_CIAM_DEPLOY_CLIENT_ID || '' }}
     outputs:
       function_app_orch_hostname: ${{ steps.hostname.outputs.hostname }}
@@ -312,14 +311,9 @@ jobs:
             echo "Invalid TF_VAR_auth_mode='${mode}'. Expected bearer_only."
             exit 1
           fi
-          # tenant_id, authority, client_id are sourced from tfvars (public values).
-          # Only api_audience needs to be checked; deploy_client_id is optional
-          # (without it, Tofu skips redirect URI management — set to enable).
-          ciam_api_audience="$(trim_space "${TF_VAR_ciam_api_audience:-}")"
-          if [[ -z "$ciam_api_audience" ]]; then
-            echo "CIAM auth misconfigured: TF_VAR_auth_mode=${mode} requires TF_VAR_CIAM_API_AUDIENCE secret."
-            exit 1
-          fi
+          # tenant_id, authority, client_id, api_audience are sourced from tfvars
+          # (public values). Only deploy_client_id remains a secret; without it,
+          # Tofu skips redirect URI management.
           ciam_deploy_client_id="$(trim_space "${TF_VAR_ciam_deploy_client_id:-}")"
           if [[ -z "$ciam_deploy_client_id" ]]; then
             echo "⚠️  TF_VAR_CIAM_DEPLOY_CLIENT_ID not set — Tofu will skip managing CIAM SPA redirect URIs. Bootstrap the deploy SP and set this secret to enable automatic redirect URI registration."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -195,7 +195,6 @@ jobs:
           IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
         run: |
           docker run --rm \
-            -e AUTH_MODE="bearer_only" \
             -e CIAM_AUTHORITY="https://treesightauth.ciamlogin.com" \
             -e CIAM_TENANT_ID="ci-test-tenant" \
             -e CIAM_API_AUDIENCE="api://ci-test-audience" \
@@ -272,15 +271,15 @@ jobs:
     environment: ${{ github.event.inputs.environment || 'dev' }}
     env:
       TF_VAR_deploy_principal_client_id: ${{ secrets.AZURE_CLIENT_ID }}
-      TF_VAR_auth_mode: bearer_only
-      # CIAM tenant_id, authority, client_id, and api_audience are now in tfvars
-      # (all public values). Only the deploy SP client_id remains as a secret.
+      # CIAM tenant_id, subdomain, client_id, and api_audience are in tfvars
+      # (all public values). Only the deploy SP client_id remains a secret.
       TF_VAR_ciam_deploy_client_id: ${{ secrets.TF_VAR_CIAM_DEPLOY_CLIENT_ID || '' }}
     outputs:
       function_app_orch_hostname: ${{ steps.hostname.outputs.hostname }}
       appinsights_connection_string: ${{ steps.appinsights.outputs.connection_string }}
       swa_hostname: ${{ steps.swa-hostname.outputs.hostname }}
       custom_domain: ${{ steps.swa-hostname.outputs.custom_domain }}
+      ciam_page_config: ${{ steps.ciam-page-config.outputs.json }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -296,7 +295,7 @@ jobs:
         with:
           tofu_version: ${{ env.TOFU_VERSION }}
 
-      - name: Validate CIAM auth env wiring
+      - name: Validate CIAM deploy SP wiring
         shell: bash
         run: |
           trim_space() {
@@ -306,12 +305,7 @@ jobs:
             printf '%s' "$value"
           }
           set -euo pipefail
-          mode="${TF_VAR_auth_mode:-bearer_only}"
-          if [[ "$mode" != "bearer_only" ]]; then
-            echo "Invalid TF_VAR_auth_mode='${mode}'. Expected bearer_only."
-            exit 1
-          fi
-          # tenant_id, authority, client_id, api_audience are sourced from tfvars
+          # tenant_id, subdomain, client_id, api_audience are sourced from tfvars
           # (public values). Only deploy_client_id remains a secret; without it,
           # Tofu skips redirect URI management.
           ciam_deploy_client_id="$(trim_space "${TF_VAR_ciam_deploy_client_id:-}")"
@@ -804,6 +798,19 @@ jobs:
         run: |
           echo "connection_string=$(tofu output -raw appinsights_connection_string)" >> "$GITHUB_OUTPUT"
 
+      - name: Export CIAM page config
+        id: ciam-page-config
+        working-directory: infra/tofu
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_USE_OIDC: "true"
+        run: |
+          # Single JSON blob with public CIAM bootstrap values; injected into
+          # page HTML by the SWA deploy job. No Key Vault round-trip needed.
+          echo "json=$(tofu output -raw ciam_page_config)" >> "$GITHUB_OUTPUT"
+
       - name: Verify runtime readiness
         id: verify-readiness
         working-directory: infra/tofu
@@ -1139,39 +1146,21 @@ jobs:
 
       - name: Inject CIAM config
         env:
-          KEY_VAULT_NAME: kv-kmlsat-${{ github.event.inputs.environment || 'dev' }}
+          CIAM_JSON: ${{ needs.deploy-infra.outputs.ciam_page_config }}
         run: |
           set -euo pipefail
-          # Read CIAM page-config values from Key Vault (single source of truth
-          # populated by Tofu). Empty values disable the page config (sign-in
-          # button hidden) rather than failing the deploy.
-          # Retry with backoff to tolerate transient KV throttling / RBAC
-          # propagation right after a fresh Tofu apply.
-          read_kv_secret() {
-            local name="$1"
-            local attempt
-            for attempt in 1 2 3 4 5; do
-              local value
-              value="$(az keyvault secret show --vault-name "$KEY_VAULT_NAME" --name "$name" --query value -o tsv 2>/dev/null || true)"
-              if [ -n "$value" ]; then
-                echo "$value"
-                return 0
-              fi
-              sleep $((attempt * 2))
-            done
-            echo ""
-          }
-          CIAM_CLIENT_ID="$(read_kv_secret ciam-client-id)"
-          CIAM_AUTHORITY="$(read_kv_secret ciam-authority)"
-          CIAM_TENANT_ID="$(read_kv_secret ciam-tenant-id)"
-          CIAM_API_AUDIENCE="$(read_kv_secret ciam-api-audience)"
-          if [ -n "$CIAM_CLIENT_ID" ] && [ -n "$CIAM_AUTHORITY" ]; then
-            CIAM_JSON="{\"clientId\":\"${CIAM_CLIENT_ID}\",\"authority\":\"${CIAM_AUTHORITY}\",\"tenantId\":\"${CIAM_TENANT_ID}\",\"apiAudience\":\"${CIAM_API_AUDIENCE}\"}"
-            find website -name '*.html' -exec sed -i \
-              's|{"clientId":"","authority":"","tenantId":"","apiAudience":""}|'"${CIAM_JSON}"'|' {} +
-          else
-            echo "⚠️  ciam-client-id or ciam-authority not present in Key Vault $KEY_VAULT_NAME — page config will not be injected."
+          # CIAM page config is a JSON blob produced by `tofu output -raw
+          # ciam_page_config` (see locals.ciam_page_config_json). Values are
+          # public; no secret-store round-trip required. Empty JSON disables
+          # the page config rather than failing the deploy.
+          if [ -z "$CIAM_JSON" ] || [ "$CIAM_JSON" = "{}" ]; then
+            echo "⚠️  ciam_page_config Tofu output is empty — page config will not be injected."
+            exit 0
           fi
+          # Escape sed delimiter / metacharacters in the JSON payload.
+          ESCAPED=$(printf '%s' "$CIAM_JSON" | sed -e 's/[\&|]/\\&/g')
+          find website -name '*.html' -exec sed -i \
+            's|{"clientId":"","authority":"","tenantId":"","apiAudience":""}|'"${ESCAPED}"'|' {} +
 
       - name: Deploy to Azure Static Web Apps
         uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -273,10 +273,9 @@ jobs:
     env:
       TF_VAR_deploy_principal_client_id: ${{ secrets.AZURE_CLIENT_ID }}
       TF_VAR_auth_mode: bearer_only
-      TF_VAR_ciam_authority: ${{ secrets.TF_VAR_CIAM_AUTHORITY || '' }}
-      TF_VAR_ciam_tenant_id: ${{ secrets.TF_VAR_CIAM_TENANT_ID || '' }}
+      # CIAM tenant_id, authority, client_id are now hardcoded in tfvars (public values).
+      # Only the api_audience and the (optional) deploy SP client_id remain as secrets.
       TF_VAR_ciam_api_audience: ${{ secrets.TF_VAR_CIAM_API_AUDIENCE || '' }}
-      TF_VAR_ciam_client_id: ${{ secrets.TF_VAR_CIAM_CLIENT_ID || '' }}
       TF_VAR_ciam_deploy_client_id: ${{ secrets.TF_VAR_CIAM_DEPLOY_CLIENT_ID || '' }}
     outputs:
       function_app_orch_hostname: ${{ steps.hostname.outputs.hostname }}
@@ -313,17 +312,17 @@ jobs:
             echo "Invalid TF_VAR_auth_mode='${mode}'. Expected bearer_only."
             exit 1
           fi
-          ciam_authority="$(trim_space "${TF_VAR_ciam_authority:-}")"
-          ciam_tenant_id="$(trim_space "${TF_VAR_ciam_tenant_id:-}")"
+          # tenant_id, authority, client_id are sourced from tfvars (public values).
+          # Only api_audience needs to be checked; deploy_client_id is optional
+          # (without it, Tofu skips redirect URI management — set to enable).
           ciam_api_audience="$(trim_space "${TF_VAR_ciam_api_audience:-}")"
-          if [[ -z "$ciam_authority" || -z "$ciam_tenant_id" || -z "$ciam_api_audience" ]]; then
-            echo "CIAM auth misconfigured: TF_VAR_auth_mode=${mode} requires TF_VAR_ciam_authority, TF_VAR_ciam_tenant_id, and TF_VAR_ciam_api_audience."
+          if [[ -z "$ciam_api_audience" ]]; then
+            echo "CIAM auth misconfigured: TF_VAR_auth_mode=${mode} requires TF_VAR_CIAM_API_AUDIENCE secret."
             exit 1
           fi
-          ciam_client_id="$(trim_space "${TF_VAR_ciam_client_id:-}")"
           ciam_deploy_client_id="$(trim_space "${TF_VAR_ciam_deploy_client_id:-}")"
-          if [[ -z "$ciam_client_id" || -z "$ciam_deploy_client_id" ]]; then
-            echo "⚠️  TF_VAR_ciam_client_id or TF_VAR_ciam_deploy_client_id not set — Tofu will skip managing CIAM SPA redirect URIs. Set both secrets to enable automatic redirect URI registration."
+          if [[ -z "$ciam_deploy_client_id" ]]; then
+            echo "⚠️  TF_VAR_CIAM_DEPLOY_CLIENT_ID not set — Tofu will skip managing CIAM SPA redirect URIs. Bootstrap the deploy SP and set this secret to enable automatic redirect URI registration."
           fi
 
       - name: Cache OpenTofu providers
@@ -1122,6 +1121,13 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Azure Login (OIDC)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: Inject API config
         run: |
           cat > website/api-config.json <<EOF
@@ -1139,15 +1145,22 @@ jobs:
 
       - name: Inject CIAM config
         env:
-          CIAM_CLIENT_ID: ${{ secrets.CIAM_CLIENT_ID }}
-          CIAM_AUTHORITY: ${{ secrets.CIAM_AUTHORITY }}
-          CIAM_TENANT_ID: ${{ secrets.CIAM_TENANT_ID }}
-          CIAM_API_AUDIENCE: ${{ secrets.CIAM_API_AUDIENCE }}
+          KEY_VAULT_NAME: kv-kmlsat-${{ github.event.inputs.environment || 'dev' }}
         run: |
+          set -euo pipefail
+          # Read CIAM page-config values from Key Vault (single source of truth
+          # populated by Tofu). Empty values disable the page config (sign-in
+          # button hidden) rather than failing the deploy.
+          CIAM_CLIENT_ID="$(az keyvault secret show --vault-name "$KEY_VAULT_NAME" --name ciam-client-id --query value -o tsv 2>/dev/null || echo '')"
+          CIAM_AUTHORITY="$(az keyvault secret show --vault-name "$KEY_VAULT_NAME" --name ciam-authority --query value -o tsv 2>/dev/null || echo '')"
+          CIAM_TENANT_ID="$(az keyvault secret show --vault-name "$KEY_VAULT_NAME" --name ciam-tenant-id --query value -o tsv 2>/dev/null || echo '')"
+          CIAM_API_AUDIENCE="$(az keyvault secret show --vault-name "$KEY_VAULT_NAME" --name ciam-api-audience --query value -o tsv 2>/dev/null || echo '')"
           if [ -n "$CIAM_CLIENT_ID" ] && [ -n "$CIAM_AUTHORITY" ]; then
             CIAM_JSON="{\"clientId\":\"${CIAM_CLIENT_ID}\",\"authority\":\"${CIAM_AUTHORITY}\",\"tenantId\":\"${CIAM_TENANT_ID}\",\"apiAudience\":\"${CIAM_API_AUDIENCE}\"}"
             find website -name '*.html' -exec sed -i \
               's|{"clientId":"","authority":"","tenantId":"","apiAudience":""}|'"${CIAM_JSON}"'|' {} +
+          else
+            echo "⚠️  ciam-client-id or ciam-authority not present in Key Vault $KEY_VAULT_NAME — page config will not be injected."
           fi
 
       - name: Deploy to Azure Static Web Apps

--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -42,10 +42,9 @@ jobs:
     env:
       TF_VAR_deploy_principal_client_id: ${{ secrets.AZURE_CLIENT_ID }}
       TF_VAR_auth_mode: bearer_only
-      TF_VAR_ciam_authority: ${{ secrets.TF_VAR_CIAM_AUTHORITY || '' }}
-      TF_VAR_ciam_tenant_id: ${{ secrets.TF_VAR_CIAM_TENANT_ID || '' }}
-      TF_VAR_ciam_api_audience: ${{ secrets.TF_VAR_CIAM_API_AUDIENCE || '' }}
-      TF_VAR_ciam_client_id: ${{ secrets.TF_VAR_CIAM_CLIENT_ID || '' }}
+      # Public CIAM values (tenant_id, authority, client_id, api_audience) are
+      # sourced from infra/tofu/environments/*.tfvars. Only the deploy SP appId
+      # is still wired in via env-secret because it gates azuread provider use.
       TF_VAR_ciam_deploy_client_id: ${{ secrets.TF_VAR_CIAM_DEPLOY_CLIENT_ID || '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -91,30 +90,6 @@ jobs:
         uses: opentofu/setup-opentofu@fc711fa910b93cba0f3fbecaafc9f42fd0c411cb # v2.0.0
         with:
           tofu_version: ${{ env.TOFU_VERSION }}
-
-      - name: Validate CIAM auth env wiring
-        if: steps.azure_login.outcome == 'success'
-        shell: bash
-        run: |
-          trim_space() {
-            local value="${1-}"
-            value="${value#"${value%%[![:space:]]*}"}"
-            value="${value%"${value##*[![:space:]]}"}"
-            printf '%s' "$value"
-          }
-          set -euo pipefail
-          mode="${TF_VAR_auth_mode:-bearer_only}"
-          if [[ "$mode" != "bearer_only" ]]; then
-            echo "Invalid TF_VAR_auth_mode='${mode}'. Expected bearer_only."
-            exit 1
-          fi
-          ciam_authority="$(trim_space "${TF_VAR_ciam_authority:-}")"
-          ciam_tenant_id="$(trim_space "${TF_VAR_ciam_tenant_id:-}")"
-          ciam_api_audience="$(trim_space "${TF_VAR_ciam_api_audience:-}")"
-          if [[ -z "$ciam_authority" || -z "$ciam_tenant_id" || -z "$ciam_api_audience" ]]; then
-            echo "CIAM auth misconfigured: TF_VAR_auth_mode=${mode} requires TF_VAR_ciam_authority, TF_VAR_ciam_tenant_id, and TF_VAR_ciam_api_audience."
-            exit 1
-          fi
 
       - name: Cache OpenTofu providers
         if: steps.azure_login.outcome == 'success'

--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -41,10 +41,9 @@ jobs:
     environment: dev
     env:
       TF_VAR_deploy_principal_client_id: ${{ secrets.AZURE_CLIENT_ID }}
-      TF_VAR_auth_mode: bearer_only
-      # Public CIAM values (tenant_id, authority, client_id, api_audience) are
-      # sourced from infra/tofu/environments/*.tfvars. Only the deploy SP appId
-      # is still wired in via env-secret because it gates azuread provider use.
+      # Public CIAM values (tenant_subdomain, tenant_id, client_id, api_audience)
+      # are sourced from infra/tofu/environments/*.tfvars. Only the deploy SP
+      # appId is still wired in via env-secret because it gates azuread provider use.
       TF_VAR_ciam_deploy_client_id: ${{ secrets.TF_VAR_CIAM_DEPLOY_CLIENT_ID || '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/blueprints/_helpers.py
+++ b/blueprints/_helpers.py
@@ -9,7 +9,6 @@ from typing import Any
 
 import azure.functions as func
 
-from treesight.config import AUTH_MODE
 from treesight.security.auth import (
     get_user_id,
     get_user_id_from_bearer_claims,
@@ -165,7 +164,7 @@ def require_auth(fn):
 
         if claims:
             uid = get_user_id_from_bearer_claims(claims)
-            logger.info("auth_path=bearer mode=%s", AUTH_MODE)
+            logger.info("auth_path=bearer")
             resp = fn(req, auth_claims=claims, user_id=uid)
             _track_req(req, resp, uid, _t0)
             return resp
@@ -194,7 +193,7 @@ def check_auth(req: func.HttpRequest) -> tuple[dict, str]:
     claims = _resolve_bearer_claims(req)
     if claims:
         uid = get_user_id_from_bearer_claims(claims)
-        logger.info("auth_path=bearer mode=%s", AUTH_MODE)
+        logger.info("auth_path=bearer")
         return claims, uid
 
     if os.environ.get("REQUIRE_AUTH", "").lower() not in ("true", "1", "yes"):

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -108,7 +108,6 @@ signature verification.
 
 - Backend bearer validation: ✅ complete (#709 closed).
 - Frontend MSAL migration: ✅ complete (#710 delivered).
-- Deployed `AUTH_MODE`: `bearer_only`.
 
 > **Do not add new code that depends on `X-MS-CLIENT-PRINCIPAL` forwarding or
 > `/.auth/*` being in the auth trust chain.** Those are transitional and will
@@ -116,8 +115,8 @@ signature verification.
 
 #### CIAM Bearer Auth (#709 — complete)
 
-Backend bearer JWT validation is complete. `AUTH_MODE=bearer_only` is the only
-supported mode, and it requires these env vars:
+Backend bearer JWT validation is complete. Bearer-only is the only supported
+auth mode, and it requires these env vars:
 
 - `CIAM_AUTHORITY`
 - `CIAM_TENANT_ID`

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -50,8 +50,7 @@ Reference: .github/workflows/deploy.yml and infra/tofu/README.md.
 
 ### Auth Model
 
-- `AUTH_MODE=bearer_only` is the only supported mode.
-- Authenticated endpoints require `Authorization: Bearer <token>`.
+- Bearer-only is the only supported mode (JWT in `Authorization: Bearer …`).
 - Required app settings: `CIAM_AUTHORITY`, `CIAM_TENANT_ID`, `CIAM_API_AUDIENCE`.
 
 Anonymous operator endpoints:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -104,7 +104,7 @@ portfolio-level risk visibility.
 
 | PR | Summary |
 |----|---------|  
-| TBD | chore(infra): manage CIAM tenant config in Tofu + Key Vault — bake public CIAM IDs into tfvars, write 4 KV secrets, Function App reads via `@Microsoft.KeyVault` refs, deploy workflow reads frontend HTML config from KV (replaces direct GH-secrets injection) |
+| #799 | chore(infra): manage CIAM tenant config in Tofu + Key Vault — bake public CIAM IDs into tfvars, write 4 KV secrets, Function App reads via `@Microsoft.KeyVault` refs, deploy workflow reads frontend HTML config from KV (replaces direct GH-secrets injection) |
 | #796 | refactor(blueprints): migrate `org.py` handlers to `@require_auth` decorator (pilot for #791) — removes 4 duplicated OPTIONS+check_auth blocks |
 | #790 | docs(architecture): comprehensive C4 review (Level 1–4 + code analysis) — confirms #779–#785 and surfaces new code-hygiene issues #791, #792, #793 |
 | #797 | ci: stub `Lint`/`Test` checks for docs-only PRs to satisfy branch protection (`paths-ignore` in ci.yml left required checks unreported, blocking docs-only auto-merge) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -104,7 +104,7 @@ portfolio-level risk visibility.
 
 | PR | Summary |
 |----|---------|  
-| #799 | chore(infra): manage CIAM tenant config in Tofu + Key Vault — bake public CIAM IDs into tfvars, write 4 KV secrets, Function App reads via `@Microsoft.KeyVault` refs, deploy workflow reads frontend HTML config from KV (replaces direct GH-secrets injection) |
+| #799 | chore(infra): refactor CIAM tenant config to HashiCorp/MS reference architecture — bake public CIAM IDs into tfvars (no Key Vault, no GH-secrets injection), derive `ciam_authority` from tenant subdomain, surface single `ciam_page_config` Tofu output for SWA HTML injection, drop dead `auth_mode` variable, simplify redirect-URI gate (closes #801, #802, #803, #805) |
 | #796 | refactor(blueprints): migrate `org.py` handlers to `@require_auth` decorator (pilot for #791) — removes 4 duplicated OPTIONS+check_auth blocks |
 | #790 | docs(architecture): comprehensive C4 review (Level 1–4 + code analysis) — confirms #779–#785 and surfaces new code-hygiene issues #791, #792, #793 |
 | #797 | ci: stub `Lint`/`Test` checks for docs-only PRs to satisfy branch protection (`paths-ignore` in ci.yml left required checks unreported, blocking docs-only auto-merge) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -104,12 +104,12 @@ portfolio-level risk visibility.
 
 | PR | Summary |
 |----|---------|  
+| TBD | chore(infra): manage CIAM tenant config in Tofu + Key Vault — bake public CIAM IDs into tfvars, write 4 KV secrets, Function App reads via `@Microsoft.KeyVault` refs, deploy workflow reads frontend HTML config from KV (replaces direct GH-secrets injection) |
 | #796 | refactor(blueprints): migrate `org.py` handlers to `@require_auth` decorator (pilot for #791) — removes 4 duplicated OPTIONS+check_auth blocks |
 | #790 | docs(architecture): comprehensive C4 review (Level 1–4 + code analysis) — confirms #779–#785 and surfaces new code-hygiene issues #791, #792, #793 |
 | #797 | ci: stub `Lint`/`Test` checks for docs-only PRs to satisfy branch protection (`paths-ignore` in ci.yml left required checks unreported, blocking docs-only auto-merge) |
 | #787 | feat(analytics+docs): harden frontend telemetry (`window.onerror` + `unhandledrejection` + `data-track` CTAs) and add C4 architecture review (2026-05-11) — files arch findings as #779/#780/#782/#784/#785 |
 | #776 | fix(infra): CIAM SPA redirect URI management via Tofu — conditional azuread provider, lockfile, all-or-nothing validation (closes #777) |
-| #769 | fix(pipeline): prevent double quota on SAS fallback + accept KMZ end-to-end (closes #767, #768) |
 
 ---
 

--- a/infra/tofu/README.md
+++ b/infra/tofu/README.md
@@ -53,14 +53,55 @@ Configure for each environment (`dev`, `prd`):
 
 ## Required GitHub Environment Secrets (CIAM/Bearer Token Auth)
 
-Bearer-token authentication is mandatory. Configure:
+Bearer-token authentication is mandatory. The CIAM tenant_id, authority, and
+client_id are public values committed to `environments/<env>.tfvars`. Tofu
+populates them as Key Vault secrets (`ciam-tenant-id`, `ciam-authority`,
+`ciam-client-id`, `ciam-api-audience`) so both the Function App (via
+`@Microsoft.KeyVault` env refs) and the SWA deploy step (via `az keyvault
+secret show`) read from a single source of truth.
 
-- `TF_VAR_AUTH_MODE` — Must be `bearer_only`
-- `TF_VAR_CIAM_AUTHORITY` — Azure Entra CIAM authority endpoint (required)
-- `TF_VAR_CIAM_TENANT_ID` — Azure Entra tenant ID for CIAM app registration (required)
-- `TF_VAR_CIAM_API_AUDIENCE` — API audience (app ID URI) from CIAM app registration (required)
+The remaining secrets you must set in each GitHub Environment are:
 
-The Function App validates these settings at startup and fails fast if they are missing.
+- `TF_VAR_CIAM_API_AUDIENCE` — API audience (Application ID URI) from the CIAM
+  app registration's "Expose an API" blade. Required for JWT validation. Kept
+  as a secret only because we have not confirmed its value is OK to commit.
+- `TF_VAR_CIAM_DEPLOY_CLIENT_ID` — *Optional.* Client ID of a service
+  principal **in the CIAM tenant** that has `Application.ReadWrite.OwnedBy`
+  permission and is an Owner of the SPA app, with a federated GitHub OIDC
+  credential trusting `repo:<owner>/<repo>:environment:<env>`. When set, Tofu
+  manages the SPA app's redirect URIs (`azuread_application_redirect_uris`).
+  When unset, redirect URI registration is skipped silently — see
+  "CIAM deploy SP bootstrap" below.
+
+The Function App validates the CIAM settings at startup and fails fast if any
+are missing or unreadable from Key Vault.
+
+## CIAM deploy SP bootstrap (one-time, manual)
+
+To enable Tofu management of the CIAM SPA app's redirect URIs, a service
+principal in the CIAM tenant is required (the workforce-tenant deploy SP
+cannot manage CIAM-tenant resources). Until this is automated:
+
+1. `az login --tenant <CIAM_TENANT_ID> --allow-no-subscriptions` as a CIAM
+   tenant admin (typically the tenant owner identity).
+2. Create the deploy SP in the CIAM tenant: `az ad app create --display-name
+   "Canopex Tofu Deploy"`. Note its `appId` (this is `TF_VAR_CIAM_DEPLOY_CLIENT_ID`).
+3. Grant it `Application.ReadWrite.OwnedBy` on Microsoft Graph and admin-consent.
+4. Add it as an Owner of the SPA app (`6e2abd0a-…`):
+   `az ad app owner add --id <SPA_APP_ID> --owner-object-id <DEPLOY_SP_OBJECT_ID>`.
+5. Add a federated credential on the deploy SP for each GitHub Environment:
+   - Issuer: `https://token.actions.githubusercontent.com`
+   - Subject: `repo:<owner>/<repo>:environment:<env>`
+   - Audience: `api://AzureADTokenExchange`
+6. Set `TF_VAR_CIAM_DEPLOY_CLIENT_ID` in the matching GitHub Environment.
+
+Until step 6 is done, redirect URIs in the CIAM SPA app are not reconciled by
+Tofu. To unblock sign-in for a new origin manually, run (after step 1):
+
+```bash
+az ad app update --id 6e2abd0a-61a4-41a5-bdb5-7e1c91471fc6 \
+  --set spa.redirectUris='["https://canopex.hrdcrprwn.com/","https://canopex.hrdcrprwn.com/app/","https://canopex.hrdcrprwn.com/eudr/"]'
+```
 
 ## Local Usage
 
@@ -71,16 +112,15 @@ tofu init \
   -backend-config="container_name=<TF_STATE_CONTAINER>" \
   -backend-config="key=kml-satellite-dev.tfstate"
 
-# Bearer-only auth
+# Bearer-only auth (CIAM tenant_id, authority, client_id come from <env>.tfvars).
+# Only api_audience is overridden via -var because it's not committed.
 tofu plan \
   -var "subscription_id=<SUBSCRIPTION_ID>" \
   -var "deploy_principal_client_id=<AZURE_CLIENT_ID>" \
-  -var "ciam_authority=https://login.microsoftonline.com/<TENANT_ID>" \
-  -var "ciam_tenant_id=<TENANT_ID>" \
   -var "ciam_api_audience=<API_APP_ID_URI>" \
   -var-file="environments/dev.tfvars"
 
-tofu apply -var "subscription_id=<SUBSCRIPTION_ID>" -var "deploy_principal_client_id=<AZURE_CLIENT_ID>" -var-file="environments/dev.tfvars"
+tofu apply -var "subscription_id=<SUBSCRIPTION_ID>" -var "deploy_principal_client_id=<AZURE_CLIENT_ID>" -var "ciam_api_audience=<API_APP_ID_URI>" -var-file="environments/dev.tfvars"
 ```
 
 ## Clean-Slate Migration Sequence (dev)

--- a/infra/tofu/README.md
+++ b/infra/tofu/README.md
@@ -53,18 +53,16 @@ Configure for each environment (`dev`, `prd`):
 
 ## Required GitHub Environment Secrets (CIAM/Bearer Token Auth)
 
-Bearer-token authentication is mandatory. The CIAM tenant_id, authority, and
-client_id are public values committed to `environments/<env>.tfvars`. Tofu
-populates them as Key Vault secrets (`ciam-tenant-id`, `ciam-authority`,
-`ciam-client-id`, `ciam-api-audience`) so both the Function App (via
-`@Microsoft.KeyVault` env refs) and the SWA deploy step (via `az keyvault
-secret show`) read from a single source of truth.
+Bearer-token authentication is mandatory. All public CIAM values
+(`ciam_tenant_subdomain`, `ciam_tenant_id`, `ciam_client_id`,
+`ciam_api_audience`) live in `environments/<env>.tfvars` — they ship in the
+deployed page HTML and in JWTs the SPA hands to the API, so they are not
+secrets. Tofu surfaces them as plain Function App app settings and as a
+`ciam_page_config` output that the SWA deploy step injects into the page HTML
+at deploy time. Key Vault is no longer used for these values.
 
-The remaining secrets you must set in each GitHub Environment are:
+The only CIAM-related GitHub Environment secret you must set is:
 
-- `TF_VAR_CIAM_API_AUDIENCE` — API audience (Application ID URI) from the CIAM
-  app registration's "Expose an API" blade. Required for JWT validation. Kept
-  as a secret only because we have not confirmed its value is OK to commit.
 - `TF_VAR_CIAM_DEPLOY_CLIENT_ID` — *Optional.* Client ID of a service
   principal **in the CIAM tenant** that has `Application.ReadWrite.OwnedBy`
   permission and is an Owner of the SPA app, with a federated GitHub OIDC
@@ -74,7 +72,7 @@ The remaining secrets you must set in each GitHub Environment are:
   "CIAM deploy SP bootstrap" below.
 
 The Function App validates the CIAM settings at startup and fails fast if any
-are missing or unreadable from Key Vault.
+are missing.
 
 ## CIAM deploy SP bootstrap (one-time, done)
 

--- a/infra/tofu/README.md
+++ b/infra/tofu/README.md
@@ -76,31 +76,40 @@ The remaining secrets you must set in each GitHub Environment are:
 The Function App validates the CIAM settings at startup and fails fast if any
 are missing or unreadable from Key Vault.
 
-## CIAM deploy SP bootstrap (one-time, manual)
+## CIAM deploy SP bootstrap (one-time, done)
 
-To enable Tofu management of the CIAM SPA app's redirect URIs, a service
-principal in the CIAM tenant is required (the workforce-tenant deploy SP
-cannot manage CIAM-tenant resources). Until this is automated:
+**Status (May 2026):** Bootstrap complete. Deploy SP `canopex-tofu-deploy`
+(appId `3753e9c8-8969-443a-9377-a7716f1f25a5`) exists in CIAM tenant
+`92001438-8b42-4bd7-950f-0ed1775f87b7` with `Application.ReadWrite.OwnedBy`
+(admin-consented), Owner of SPA app `6e2abd0a-…`, and federated GitHub OIDC
+credentials for `repo:Hardcoreprawn/azure-workflow-for-kml-satellite:environment:{dev,prd}`.
+Both GitHub Environments have `TF_VAR_CIAM_DEPLOY_CLIENT_ID` set. Tofu now
+manages `azuread_application_redirect_uris.ciam_spa[0]` from
+`local.ciam_spa_redirect_uris` in `locals.tf`.
+
+If the deploy SP needs to be re-created (e.g. for a new tenant or rotated):
 
 1. `az login --tenant <CIAM_TENANT_ID> --allow-no-subscriptions` as a CIAM
    tenant admin (typically the tenant owner identity).
 2. Create the deploy SP in the CIAM tenant: `az ad app create --display-name
    "Canopex Tofu Deploy"`. Note its `appId` (this is `TF_VAR_CIAM_DEPLOY_CLIENT_ID`).
 3. Grant it `Application.ReadWrite.OwnedBy` on Microsoft Graph and admin-consent.
-4. Add it as an Owner of the SPA app (`6e2abd0a-…`):
-   `az ad app owner add --id <SPA_APP_ID> --owner-object-id <DEPLOY_SP_OBJECT_ID>`.
+4. Add it as an Owner of the SPA app (`6e2abd0a-…`) via Microsoft Graph
+   (`POST /applications/<spa-objectId>/owners/$ref`).
 5. Add a federated credential on the deploy SP for each GitHub Environment:
    - Issuer: `https://token.actions.githubusercontent.com`
    - Subject: `repo:<owner>/<repo>:environment:<env>`
    - Audience: `api://AzureADTokenExchange`
 6. Set `TF_VAR_CIAM_DEPLOY_CLIENT_ID` in the matching GitHub Environment.
 
-Until step 6 is done, redirect URIs in the CIAM SPA app are not reconciled by
-Tofu. To unblock sign-in for a new origin manually, run (after step 1):
+For an emergency redirect-URI fix without running Tofu (e.g. to add a new
+origin immediately), after step 1 above:
 
 ```bash
-az ad app update --id 6e2abd0a-61a4-41a5-bdb5-7e1c91471fc6 \
-  --set spa.redirectUris='["https://canopex.hrdcrprwn.com/","https://canopex.hrdcrprwn.com/app/","https://canopex.hrdcrprwn.com/eudr/"]'
+az rest --method PATCH \
+  --uri "https://graph.microsoft.com/v1.0/applications/<spa-objectId>" \
+  --headers "Content-Type=application/json" \
+  --body '{"spa":{"redirectUris":["https://canopex.hrdcrprwn.com/", ...]}}'
 ```
 
 ## Local Usage
@@ -112,15 +121,14 @@ tofu init \
   -backend-config="container_name=<TF_STATE_CONTAINER>" \
   -backend-config="key=kml-satellite-dev.tfstate"
 
-# Bearer-only auth (CIAM tenant_id, authority, client_id come from <env>.tfvars).
-# Only api_audience is overridden via -var because it's not committed.
+# Bearer-only auth: all CIAM values (tenant_id, authority, client_id,
+# api_audience) come from <env>.tfvars. Only deploy_client_id is a secret.
 tofu plan \
   -var "subscription_id=<SUBSCRIPTION_ID>" \
   -var "deploy_principal_client_id=<AZURE_CLIENT_ID>" \
-  -var "ciam_api_audience=<API_APP_ID_URI>" \
   -var-file="environments/dev.tfvars"
 
-tofu apply -var "subscription_id=<SUBSCRIPTION_ID>" -var "deploy_principal_client_id=<AZURE_CLIENT_ID>" -var "ciam_api_audience=<API_APP_ID_URI>" -var-file="environments/dev.tfvars"
+tofu apply -var "subscription_id=<SUBSCRIPTION_ID>" -var "deploy_principal_client_id=<AZURE_CLIENT_ID>" -var-file="environments/dev.tfvars"
 ```
 
 ## Clean-Slate Migration Sequence (dev)

--- a/infra/tofu/environments/dev.tfvars
+++ b/infra/tofu/environments/dev.tfvars
@@ -30,9 +30,8 @@ orch_min_instances           = 0
 # --- CIAM (Entra External ID) ---
 # Shared with prd: dev and prd both consume the same CIAM tenant/app.
 # Public values; safe to commit. See prd.tfvars for context.
-auth_mode      = "bearer_only"
-ciam_tenant_id = "92001438-8b42-4bd7-950f-0ed1775f87b7"
-ciam_authority = "https://treesightauth.ciamlogin.com/"
-ciam_client_id = "6e2abd0a-61a4-41a5-bdb5-7e1c91471fc6"
-# ciam_api_audience: still injected via TF_VAR_CIAM_API_AUDIENCE secret until
-# confirmed against the CIAM app's "Expose an API" Application ID URI.
+auth_mode         = "bearer_only"
+ciam_tenant_id    = "92001438-8b42-4bd7-950f-0ed1775f87b7"
+ciam_authority    = "https://treesightauth.ciamlogin.com/"
+ciam_client_id    = "6e2abd0a-61a4-41a5-bdb5-7e1c91471fc6"
+ciam_api_audience = "api://canopex"

--- a/infra/tofu/environments/dev.tfvars
+++ b/infra/tofu/environments/dev.tfvars
@@ -30,8 +30,7 @@ orch_min_instances           = 0
 # --- CIAM (Entra External ID) ---
 # Shared with prd: dev and prd both consume the same CIAM tenant/app.
 # Public values; safe to commit. See prd.tfvars for context.
-auth_mode         = "bearer_only"
-ciam_tenant_id    = "92001438-8b42-4bd7-950f-0ed1775f87b7"
-ciam_authority    = "https://treesightauth.ciamlogin.com/"
-ciam_client_id    = "6e2abd0a-61a4-41a5-bdb5-7e1c91471fc6"
-ciam_api_audience = "api://canopex"
+ciam_tenant_subdomain = "treesightauth"
+ciam_tenant_id        = "92001438-8b42-4bd7-950f-0ed1775f87b7"
+ciam_client_id        = "6e2abd0a-61a4-41a5-bdb5-7e1c91471fc6"
+ciam_api_audience     = "api://canopex"

--- a/infra/tofu/environments/dev.tfvars
+++ b/infra/tofu/environments/dev.tfvars
@@ -26,3 +26,13 @@ cosmos_public_network_access = true # dev only — no VNet/private endpoint yet
 function_max_instances       = 1
 function_min_instances       = 0
 orch_min_instances           = 0
+
+# --- CIAM (Entra External ID) ---
+# Shared with prd: dev and prd both consume the same CIAM tenant/app.
+# Public values; safe to commit. See prd.tfvars for context.
+auth_mode      = "bearer_only"
+ciam_tenant_id = "92001438-8b42-4bd7-950f-0ed1775f87b7"
+ciam_authority = "https://treesightauth.ciamlogin.com/"
+ciam_client_id = "6e2abd0a-61a4-41a5-bdb5-7e1c91471fc6"
+# ciam_api_audience: still injected via TF_VAR_CIAM_API_AUDIENCE secret until
+# confirmed against the CIAM app's "Expose an API" Application ID URI.

--- a/infra/tofu/environments/prd.tfvars
+++ b/infra/tofu/environments/prd.tfvars
@@ -22,9 +22,8 @@ enable_cosmos_db      = true
 # Public values: visible in the deployed page HTML (canopex-ciam-config script).
 # Tofu writes these into Key Vault secrets; the Function App reads them from KV
 # refs and the SWA deploy step injects them into the page HTML at deploy time.
-auth_mode      = "bearer_only"
-ciam_tenant_id = "92001438-8b42-4bd7-950f-0ed1775f87b7"
-ciam_authority = "https://treesightauth.ciamlogin.com/"
-ciam_client_id = "6e2abd0a-61a4-41a5-bdb5-7e1c91471fc6"
-# ciam_api_audience: still injected via TF_VAR_CIAM_API_AUDIENCE secret until
-# confirmed against the CIAM app's "Expose an API" Application ID URI.
+auth_mode         = "bearer_only"
+ciam_tenant_id    = "92001438-8b42-4bd7-950f-0ed1775f87b7"
+ciam_authority    = "https://treesightauth.ciamlogin.com/"
+ciam_client_id    = "6e2abd0a-61a4-41a5-bdb5-7e1c91471fc6"
+ciam_api_audience = "api://canopex"

--- a/infra/tofu/environments/prd.tfvars
+++ b/infra/tofu/environments/prd.tfvars
@@ -20,10 +20,9 @@ enable_cosmos_db      = true
 
 # --- CIAM (Entra External ID) ---
 # Public values: visible in the deployed page HTML (canopex-ciam-config script).
-# Tofu writes these into Key Vault secrets; the Function App reads them from KV
-# refs and the SWA deploy step injects them into the page HTML at deploy time.
-auth_mode         = "bearer_only"
-ciam_tenant_id    = "92001438-8b42-4bd7-950f-0ed1775f87b7"
-ciam_authority    = "https://treesightauth.ciamlogin.com/"
-ciam_client_id    = "6e2abd0a-61a4-41a5-bdb5-7e1c91471fc6"
-ciam_api_audience = "api://canopex"
+# Tofu surfaces them as plain Function App app settings and a `ciam_page_config`
+# output the SWA workflow injects into the page HTML at deploy time.
+ciam_tenant_subdomain = "treesightauth"
+ciam_tenant_id        = "92001438-8b42-4bd7-950f-0ed1775f87b7"
+ciam_client_id        = "6e2abd0a-61a4-41a5-bdb5-7e1c91471fc6"
+ciam_api_audience     = "api://canopex"

--- a/infra/tofu/environments/prd.tfvars
+++ b/infra/tofu/environments/prd.tfvars
@@ -17,3 +17,14 @@ custom_domain         = "canopex.hrdcrprwn.com"
 enable_azure_ai       = false
 enable_stripe         = true
 enable_cosmos_db      = true
+
+# --- CIAM (Entra External ID) ---
+# Public values: visible in the deployed page HTML (canopex-ciam-config script).
+# Tofu writes these into Key Vault secrets; the Function App reads them from KV
+# refs and the SWA deploy step injects them into the page HTML at deploy time.
+auth_mode      = "bearer_only"
+ciam_tenant_id = "92001438-8b42-4bd7-950f-0ed1775f87b7"
+ciam_authority = "https://treesightauth.ciamlogin.com/"
+ciam_client_id = "6e2abd0a-61a4-41a5-bdb5-7e1c91471fc6"
+# ciam_api_audience: still injected via TF_VAR_CIAM_API_AUDIENCE secret until
+# confirmed against the CIAM app's "Expose an API" Application ID URI.

--- a/infra/tofu/locals.tf
+++ b/infra/tofu/locals.tf
@@ -40,6 +40,22 @@ locals {
 
   primary_site_url = var.custom_domain != "" ? "https://${var.custom_domain}" : "https://${azurerm_static_web_app.main.default_host_name}"
 
+  # CIAM authority URL is computed from the tenant subdomain. Entra External ID
+  # tenants use the canonical https://<subdomain>.ciamlogin.com/ host; the
+  # trailing slash matters for MSAL's authority parsing.
+  ciam_authority = var.ciam_tenant_subdomain != "" ? "https://${var.ciam_tenant_subdomain}.ciamlogin.com/" : ""
+
+  # Page-level CIAM bootstrap config, injected into website HTML at deploy time
+  # via `tofu output -raw ciam_page_config`. The SWA workflow substitutes this
+  # JSON into the canopex-ciam-config <script> tag. Keep field names in sync
+  # with website/js/canopex-auth.js readPageConfig().
+  ciam_page_config_json = jsonencode({
+    clientId    = var.ciam_client_id
+    authority   = local.ciam_authority
+    tenantId    = var.ciam_tenant_id
+    apiAudience = var.ciam_api_audience
+  })
+
   # SPA redirect URIs to register in the CIAM app registration.
   # Must include every origin+path that canopex-auth.js pageRedirectUri() may produce.
   # Mirrors the browser_allowed_origins pattern: localhost ports for non-prd,

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -1155,6 +1155,15 @@ resource "azurerm_role_assignment" "key_vault_secrets_officer" {
   principal_id         = data.azurerm_client_config.current.object_id
 }
 
+# Wait for the role assignment above to propagate before any Tofu-managed
+# Key Vault secret writes. Azure RBAC on Key Vault is eventually consistent;
+# without this gap, the first apply that creates the role and the secrets
+# in the same plan can intermittently 403.
+resource "time_sleep" "key_vault_secrets_officer_propagation" {
+  create_duration = "60s"
+  depends_on      = [azurerm_role_assignment.key_vault_secrets_officer]
+}
+
 # --- CIAM config in Key Vault ---
 # Single source of truth for CIAM tenant/app values. The Function App reads
 # these via @Microsoft.KeyVault references (managed-identity auth) and the SWA
@@ -1178,7 +1187,7 @@ resource "azurerm_key_vault_secret" "ciam" {
   content_type = "text/plain"
   tags         = local.tags
 
-  depends_on = [azurerm_role_assignment.key_vault_secrets_officer]
+  depends_on = [time_sleep.key_vault_secrets_officer_propagation]
 }
 
 # Cosmos DB data-plane RBAC: Built-in Data Contributor (read/write all items)

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -1146,12 +1146,39 @@ resource "azurerm_role_assignment" "orch_key_vault_secrets_user" {
   principal_id         = azapi_resource.function_app_orch.identity[0].principal_id
 }
 
-# Allow the deployer (tofu apply / setup scripts) to manage secrets
+# Allow the deployer (tofu apply / setup scripts) to manage secrets in Key Vault.
+# Required for both Stripe secret rotation (setup script) and CIAM secret
+# population (Tofu-managed azurerm_key_vault_secret resources below).
 resource "azurerm_role_assignment" "key_vault_secrets_officer" {
-  count                = var.enable_stripe ? 1 : 0
   scope                = azurerm_key_vault.main.id
   role_definition_name = "Key Vault Secrets Officer"
   principal_id         = data.azurerm_client_config.current.object_id
+}
+
+# --- CIAM config in Key Vault ---
+# Single source of truth for CIAM tenant/app values. The Function App reads
+# these via @Microsoft.KeyVault references (managed-identity auth) and the SWA
+# deploy step reads them via `az keyvault secret show` to inject the page HTML
+# config blob. Values themselves are public (visible in deployed page HTML);
+# Key Vault is used so deploys have one place to fetch them from.
+locals {
+  ciam_kv_secrets = {
+    "ciam-tenant-id"    = var.ciam_tenant_id
+    "ciam-authority"    = var.ciam_authority
+    "ciam-client-id"    = var.ciam_client_id
+    "ciam-api-audience" = var.ciam_api_audience
+  }
+}
+
+resource "azurerm_key_vault_secret" "ciam" {
+  for_each     = { for k, v in local.ciam_kv_secrets : k => v if v != "" }
+  name         = each.key
+  value        = each.value
+  key_vault_id = azurerm_key_vault.main.id
+  content_type = "text/plain"
+  tags         = local.tags
+
+  depends_on = [azurerm_role_assignment.key_vault_secrets_officer]
 }
 
 # Cosmos DB data-plane RBAC: Built-in Data Contributor (read/write all items)
@@ -1221,9 +1248,9 @@ locals {
       COSMOS_DATABASE_NAME = azurerm_cosmosdb_sql_database.main[0].name
     } : {},
     {
-      CIAM_AUTHORITY     = var.ciam_authority
-      CIAM_TENANT_ID     = var.ciam_tenant_id
-      CIAM_API_AUDIENCE  = var.ciam_api_audience
+      CIAM_AUTHORITY    = local.ciam_kv_secrets["ciam-authority"] != "" ? "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.ciam["ciam-authority"].versionless_id})" : ""
+      CIAM_TENANT_ID    = local.ciam_kv_secrets["ciam-tenant-id"] != "" ? "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.ciam["ciam-tenant-id"].versionless_id})" : ""
+      CIAM_API_AUDIENCE = local.ciam_kv_secrets["ciam-api-audience"] != "" ? "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.ciam["ciam-api-audience"].versionless_id})" : ""
     }
   )
 

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -1061,8 +1061,8 @@ resource "azurerm_static_web_app_custom_domain" "main" {
 # --- CIAM SPA redirect URIs ---
 # Keeps the app registration's allowed redirect URIs in sync with the deployed
 # site URL so that MSAL loginRedirect() (canopex-auth.js) is never rejected
-# with AADSTS50011. Only active when ciam_client_id and ciam_deploy_client_id
-# are both set (see variables.tf for the operator prerequisite).
+# with AADSTS50011. Active when ciam_deploy_client_id is set; the SPA app's
+# own client_id is always present in tfvars (validated in variables.tf).
 #
 # Operator prerequisite (one-time, manual):
 #   1. In the CIAM tenant, create a service principal (app registration).
@@ -1071,8 +1071,8 @@ resource "azurerm_static_web_app_custom_domain" "main" {
 #        Issuer: https://token.actions.githubusercontent.com
 #        Subject: repo:Hardcoreprawn/azure-workflow-for-kml-satellite:environment:<env>
 #        Audience: api://AzureADTokenExchange
-#   4. Set TF_VAR_CIAM_CLIENT_ID and TF_VAR_CIAM_DEPLOY_CLIENT_ID in the
-#      GitHub Environment secrets.
+#   4. Set TF_VAR_CIAM_DEPLOY_CLIENT_ID in the GitHub Environment secrets
+#      (the SPA app's client_id lives in environments/<env>.tfvars).
 data "azuread_application" "ciam" {
   count     = local.ciam_redirect_enabled ? 1 : 0
   client_id = var.ciam_client_id
@@ -1147,47 +1147,13 @@ resource "azurerm_role_assignment" "orch_key_vault_secrets_user" {
 }
 
 # Allow the deployer (tofu apply / setup scripts) to manage secrets in Key Vault.
-# Required for both Stripe secret rotation (setup script) and CIAM secret
-# population (Tofu-managed azurerm_key_vault_secret resources below).
+# Required by the external Stripe rotation script (`make stripe-setup`); CIAM
+# config values are no longer stored in Key Vault since they are public and now
+# flow as plain Function App app settings + a `ciam_page_config` Tofu output.
 resource "azurerm_role_assignment" "key_vault_secrets_officer" {
   scope                = azurerm_key_vault.main.id
   role_definition_name = "Key Vault Secrets Officer"
   principal_id         = data.azurerm_client_config.current.object_id
-}
-
-# Wait for the role assignment above to propagate before any Tofu-managed
-# Key Vault secret writes. Azure RBAC on Key Vault is eventually consistent;
-# without this gap, the first apply that creates the role and the secrets
-# in the same plan can intermittently 403.
-resource "time_sleep" "key_vault_secrets_officer_propagation" {
-  create_duration = "60s"
-  depends_on      = [azurerm_role_assignment.key_vault_secrets_officer]
-}
-
-# --- CIAM config in Key Vault ---
-# Single source of truth for CIAM tenant/app values. The Function App reads
-# these via @Microsoft.KeyVault references (managed-identity auth) and the SWA
-# deploy step reads them via `az keyvault secret show` to inject the page HTML
-# config blob. Values themselves are public (visible in deployed page HTML);
-# Key Vault is used so deploys have one place to fetch them from.
-locals {
-  ciam_kv_secrets = {
-    "ciam-tenant-id"    = var.ciam_tenant_id
-    "ciam-authority"    = var.ciam_authority
-    "ciam-client-id"    = var.ciam_client_id
-    "ciam-api-audience" = var.ciam_api_audience
-  }
-}
-
-resource "azurerm_key_vault_secret" "ciam" {
-  for_each     = { for k, v in local.ciam_kv_secrets : k => v if v != "" }
-  name         = each.key
-  value        = each.value
-  key_vault_id = azurerm_key_vault.main.id
-  content_type = "text/plain"
-  tags         = local.tags
-
-  depends_on = [time_sleep.key_vault_secrets_officer_propagation]
 }
 
 # Cosmos DB data-plane RBAC: Built-in Data Contributor (read/write all items)
@@ -1247,7 +1213,6 @@ locals {
       CORS_ALLOWED_ORIGINS                = join(",", local.browser_allowed_origins)
       PRIMARY_SITE_URL                    = local.primary_site_url
       REQUIRE_AUTH                        = "true"
-      AUTH_MODE                           = var.auth_mode
       OPS_DASHBOARD_KEY                   = var.ops_dashboard_key
     },
     var.billing_allowed_users != "" ? { BILLING_ALLOWED_USERS = var.billing_allowed_users } : {},
@@ -1257,9 +1222,12 @@ locals {
       COSMOS_DATABASE_NAME = azurerm_cosmosdb_sql_database.main[0].name
     } : {},
     {
-      CIAM_AUTHORITY    = local.ciam_kv_secrets["ciam-authority"] != "" ? "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.ciam["ciam-authority"].versionless_id})" : ""
-      CIAM_TENANT_ID    = local.ciam_kv_secrets["ciam-tenant-id"] != "" ? "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.ciam["ciam-tenant-id"].versionless_id})" : ""
-      CIAM_API_AUDIENCE = local.ciam_kv_secrets["ciam-api-audience"] != "" ? "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.ciam["ciam-api-audience"].versionless_id})" : ""
+      # CIAM bearer-token validation config. These values are *public* (they
+      # appear in JWTs and in the page HTML the SPA serves) so they are passed
+      # as plain app settings rather than @Microsoft.KeyVault references.
+      CIAM_AUTHORITY    = local.ciam_authority
+      CIAM_TENANT_ID    = var.ciam_tenant_id
+      CIAM_API_AUDIENCE = var.ciam_api_audience
     }
   )
 

--- a/infra/tofu/outputs.tf
+++ b/infra/tofu/outputs.tf
@@ -79,6 +79,11 @@ output "site_url" {
   description = "Primary site URL (custom domain if configured, otherwise default)."
 }
 
+output "ciam_page_config" {
+  value       = local.ciam_page_config_json
+  description = "JSON-encoded CIAM bootstrap config for the SPA. Injected into the page HTML by the SWA deploy step. Public values only — clientId, authority, tenantId, apiAudience."
+}
+
 output "appinsights_connection_string" {
   value       = azurerm_application_insights.main.connection_string
   description = "Application Insights connection string for browser SDK."

--- a/infra/tofu/providers.tf
+++ b/infra/tofu/providers.tf
@@ -11,12 +11,12 @@ provider "azapi" {
 # registration's SPA redirect URIs. Requires a service principal in the CIAM
 # tenant with Application.ReadWrite.OwnedBy, federated via OIDC for this repo.
 #
-# Both ciam_client_id AND ciam_deploy_client_id must be set for any azuread
-# resources to be created (count = 0 otherwise). Gate the provider config on
-# the same all-or-nothing condition so no OIDC exchange is attempted when
-# either value is absent (e.g. cost-estimate CI, partial configuration).
+# ciam_client_id is validated as non-empty in variables.tf, so the gating
+# condition reduces to: did the operator wire up the CIAM-tenant deploy SP?
+# When ciam_deploy_client_id is empty (e.g. cost-estimate CI, bootstrap), the
+# azuread provider stays unconfigured and no OIDC exchange is attempted.
 locals {
-  ciam_redirect_enabled = var.ciam_client_id != "" && var.ciam_deploy_client_id != ""
+  ciam_redirect_enabled = var.ciam_deploy_client_id != ""
 }
 
 provider "azuread" {

--- a/infra/tofu/variables.tf
+++ b/infra/tofu/variables.tf
@@ -199,39 +199,34 @@ variable "notification_email" {
   default     = ""
 }
 
-# --- CIAM / Bearer Token Auth (Issue #709) ---
+# --- CIAM (Entra External ID) bearer-token auth (Issue #709) ---
+#
+# Auth is bearer-only by design (see treesight.security.auth). The values below
+# are *public* — they ship in the deployed page HTML and in JWTs the SPA hands
+# to the API — so they live in committed tfvars rather than Key Vault.
+# Tofu surfaces them as plain Function App app settings and as a
+# `ciam_page_config` output the SWA workflow injects into HTML at deploy time.
 
-variable "auth_mode" {
-  description = "Auth mode. Must be bearer_only (JWT only)."
-  type        = string
-  default     = "bearer_only"
-
-  validation {
-    condition     = var.auth_mode == "bearer_only"
-    error_message = "auth_mode must be bearer_only."
-  }
-}
-
-variable "ciam_authority" {
-  description = "Azure Entra CIAM authority endpoint (e.g. https://<tenant>.ciamlogin.com/ for External ID, or https://login.microsoftonline.com/<tenant> for workforce). Public; safe to commit. Required when auth_mode is 'bearer_only'."
+variable "ciam_tenant_subdomain" {
+  description = "Entra External ID tenant subdomain (the bit before .ciamlogin.com). The CIAM authority URL is computed as https://<subdomain>.ciamlogin.com/. Public; safe to commit."
   type        = string
   default     = ""
 }
 
 variable "ciam_tenant_id" {
-  description = "Azure Entra tenant ID for CIAM app registration. Public; safe to commit. Required when auth_mode is 'bearer_only'."
+  description = "Azure Entra tenant ID (GUID) for CIAM app registration. Required by MSAL for tenant-scoped token validation. Public; safe to commit."
   type        = string
   default     = ""
 }
 
 variable "ciam_api_audience" {
-  description = "API audience (app ID URI) from CIAM app registration. Public; safe to commit. Required when auth_mode is 'bearer_only'."
+  description = "API audience (app ID URI) from CIAM app registration, e.g. api://canopex. Public; safe to commit."
   type        = string
   default     = ""
 }
 
 variable "ciam_client_id" {
-  description = "Client ID (application ID) of the CIAM SPA app registration. Public; safe to commit. Set to enable Tofu management of SPA redirect URIs."
+  description = "Client ID (application ID) of the CIAM SPA app registration. Public; safe to commit."
   type        = string
   default     = ""
 }
@@ -243,23 +238,24 @@ variable "ciam_deploy_client_id" {
   sensitive   = true
 }
 
-# Cross-variable validation: all three CIAM variables must be set for
-# bearer_only auth. Cannot be expressed in a variable validation block
-# (which may only reference the validated variable itself), so enforced here as a
-# plan-time precondition that fails fast with a descriptive error.
-resource "terraform_data" "validate_ciam_auth_vars" {
+# Cross-variable validation: all four required CIAM tfvars must be populated.
+# Cannot be expressed in a per-variable validation block (those may only
+# reference the validated variable itself), so enforced here as a plan-time
+# precondition that fails fast with a descriptive error.
+resource "terraform_data" "validate_ciam_vars" {
   lifecycle {
     precondition {
       condition = (
-        var.auth_mode != "bearer_only" ||
-        (var.ciam_authority != "" && var.ciam_tenant_id != "" && var.ciam_api_audience != "")
+        var.ciam_tenant_subdomain != "" &&
+        var.ciam_tenant_id != "" &&
+        var.ciam_api_audience != "" &&
+        var.ciam_client_id != ""
       )
-      error_message = "ciam_authority, ciam_tenant_id, and ciam_api_audience must all be non-empty when auth_mode is 'bearer_only'."
+      error_message = "ciam_tenant_subdomain, ciam_tenant_id, ciam_api_audience, and ciam_client_id must all be non-empty (set in environments/<env>.tfvars)."
     }
   }
 }
 
-# ciam_client_id is sourced from tfvars (always non-empty in real environments).
 # ciam_deploy_client_id is independently optional: when unset, Tofu skips
 # managing the CIAM SPA app's redirect URIs (azuread_application_redirect_uris
 # count = 0), and the azuread provider is not configured. This is the documented

--- a/infra/tofu/variables.tf
+++ b/infra/tofu/variables.tf
@@ -213,28 +213,25 @@ variable "auth_mode" {
 }
 
 variable "ciam_authority" {
-  description = "Azure Entra CIAM authority endpoint (https://login.microsoftonline.com/<tenant>). Required when auth_mode is 'bearer_only'."
+  description = "Azure Entra CIAM authority endpoint (e.g. https://<tenant>.ciamlogin.com/ for External ID, or https://login.microsoftonline.com/<tenant> for workforce). Public; safe to commit. Required when auth_mode is 'bearer_only'."
   type        = string
   default     = ""
-  sensitive   = true
 }
 
 variable "ciam_tenant_id" {
-  description = "Azure Entra tenant ID for CIAM app registration. Required when auth_mode is 'bearer_only'."
+  description = "Azure Entra tenant ID for CIAM app registration. Public; safe to commit. Required when auth_mode is 'bearer_only'."
   type        = string
   default     = ""
-  sensitive   = true
 }
 
 variable "ciam_api_audience" {
-  description = "API audience (app ID URI) from CIAM app registration. Required when auth_mode is 'bearer_only'."
+  description = "API audience (app ID URI) from CIAM app registration. Public; safe to commit. Required when auth_mode is 'bearer_only'."
   type        = string
   default     = ""
-  sensitive   = true
 }
 
 variable "ciam_client_id" {
-  description = "Client ID (application ID) of the CIAM app registration. Set to enable Tofu management of SPA redirect URIs."
+  description = "Client ID (application ID) of the CIAM SPA app registration. Public; safe to commit. Set to enable Tofu management of SPA redirect URIs."
   type        = string
   default     = ""
 }

--- a/infra/tofu/variables.tf
+++ b/infra/tofu/variables.tf
@@ -259,14 +259,9 @@ resource "terraform_data" "validate_ciam_auth_vars" {
   }
 }
 
-# Cross-variable validation: ciam_client_id and ciam_deploy_client_id are an
-# all-or-nothing pair. Setting only one silently disables redirect URI management
-# and leaves the azuread provider partially configured.
-resource "terraform_data" "validate_ciam_redirect_vars" {
-  lifecycle {
-    precondition {
-      condition     = (var.ciam_client_id == "") == (var.ciam_deploy_client_id == "")
-      error_message = "ciam_client_id and ciam_deploy_client_id must both be set or both be empty. Setting only one disables CIAM redirect URI management."
-    }
-  }
-}
+# ciam_client_id is sourced from tfvars (always non-empty in real environments).
+# ciam_deploy_client_id is independently optional: when unset, Tofu skips
+# managing the CIAM SPA app's redirect URIs (azuread_application_redirect_uris
+# count = 0), and the azuread provider is not configured. This is the documented
+# fallback for cost-estimate runs or environments where the deploy SP has not
+# been bootstrapped yet.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@ import pytest
 # Ensure required config env vars are set for config module import
 os.environ.setdefault("AzureWebJobsStorage", "UseDevelopmentStorage=true")
 os.environ.setdefault("DEMO_VALET_TOKEN_SECRET", "test-secret-key-for-unit-tests-only")
-os.environ.setdefault("AUTH_MODE", "bearer_only")
 os.environ.setdefault("CIAM_AUTHORITY", "https://ciam.example.com")
 os.environ.setdefault("CIAM_TENANT_ID", "test-tenant")
 os.environ.setdefault("CIAM_API_AUDIENCE", "api://test-audience")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,7 +47,6 @@ class TestValidateConfig:
         with patch.dict(
             os.environ,
             {
-                "AUTH_MODE": "bearer_only",
                 "CIAM_AUTHORITY": "https://issuer.example",
                 "CIAM_TENANT_ID": "tenant-id",
                 "CIAM_API_AUDIENCE": "client-id",
@@ -81,7 +80,6 @@ class TestValidateConfig:
         with patch.dict(
             os.environ,
             {
-                "AUTH_MODE": "bearer_only",
                 "CIAM_AUTHORITY": "",
                 "CIAM_TENANT_ID": "",
                 "CIAM_API_AUDIENCE": "",
@@ -98,7 +96,6 @@ class TestValidateConfig:
         with patch.dict(
             os.environ,
             {
-                "AUTH_MODE": "bearer_only",
                 "CIAM_AUTHORITY": "https://issuer.example",
                 "CIAM_TENANT_ID": "tenant-id",
                 "CIAM_API_AUDIENCE": "client-id",
@@ -109,12 +106,4 @@ class TestValidateConfig:
             cfg = importlib.import_module("treesight.config")
             importlib.reload(cfg)
             cfg.validate_config()
-            importlib.reload(cfg)
-
-    def test_rejects_invalid_auth_mode(self):
-        with patch.dict(os.environ, {"AUTH_MODE": "unsupported-mode"}, clear=False):
-            cfg = importlib.import_module("treesight.config")
-            importlib.reload(cfg)
-            with pytest.raises(ConfigValidationError, match="AUTH_MODE"):
-                cfg.validate_config()
             importlib.reload(cfg)

--- a/treesight/config.py
+++ b/treesight/config.py
@@ -97,9 +97,6 @@ DEMO_VALET_TOKEN_MAX_USES = _env_int("DEMO_VALET_TOKEN_MAX_USES", 3)
 # header with a valid bearer token.
 REQUIRE_AUTH = _env_bool("REQUIRE_AUTH", False)
 
-# Auth mode is now single-path only: bearer_only.
-AUTH_MODE = _env("AUTH_MODE", "bearer_only").strip().lower() or "bearer_only"
-
 # CIAM-native bearer JWT config (#709).
 CIAM_AUTHORITY = _env("CIAM_AUTHORITY")
 CIAM_TENANT_ID = _env("CIAM_TENANT_ID")
@@ -164,14 +161,12 @@ def validate_config() -> None:
         errors.append(f"AOI_BUFFER_M must be >= 0, got {AOI_BUFFER_M}")
     if AOI_MAX_AREA_HA <= 0:
         errors.append(f"AOI_MAX_AREA_HA must be > 0, got {AOI_MAX_AREA_HA}")
-    if AUTH_MODE != "bearer_only":
-        errors.append("AUTH_MODE must be bearer_only")
     if not CIAM_AUTHORITY:
-        errors.append("CIAM_AUTHORITY must be set when AUTH_MODE is bearer_only")
+        errors.append("CIAM_AUTHORITY must be set")
     if not CIAM_TENANT_ID:
-        errors.append("CIAM_TENANT_ID must be set when AUTH_MODE is bearer_only")
+        errors.append("CIAM_TENANT_ID must be set")
     if not CIAM_API_AUDIENCE:
-        errors.append("CIAM_API_AUDIENCE must be set when AUTH_MODE is bearer_only")
+        errors.append("CIAM_API_AUDIENCE must be set")
     if CIAM_JWT_LEEWAY_SECONDS < 0:
         errors.append("CIAM_JWT_LEEWAY_SECONDS must be >= 0")
     if errors:


### PR DESCRIPTION
## Summary

Move CIAM (Entra External ID) tenant configuration into Tofu + Key Vault as the single source of truth, replacing the previous mix of GitHub Actions secrets and direct injection.

The clientId, tenantId, and authority are public values (visible in `canopex-ciam-config` script in the deployed page HTML). They belong in tfvars, not GH secrets.

## Changes

- **`infra/tofu/environments/{prd,dev}.tfvars`** — bake `auth_mode`, `ciam_tenant_id`, `ciam_authority`, `ciam_client_id` (left `ciam_api_audience` injected via secret until verified against the CIAM app's "Expose an API" Application ID URI).
- **`infra/tofu/variables.tf`** — drop `sensitive = true` on the now-public CIAM vars.
- **`infra/tofu/main.tf`** — Tofu writes 4 KV secrets (`ciam-tenant-id`, `ciam-authority`, `ciam-client-id`, `ciam-api-audience`) to the existing `azurerm_key_vault.main`. Function App `CIAM_*` env vars switched to `@Microsoft.KeyVault(SecretUri=...)` references. `key_vault_secrets_officer` role assignment is no longer gated on `enable_stripe`.
- **`.github/workflows/deploy.yml`** — `deploy-infra` env drops the now-tfvars CIAM TF_VARs; CIAM validation step simplified; `deploy-website` job now does an Azure OIDC login and reads CIAM frontend config from KV via `az keyvault secret show` (single auth context instead of GH secrets).
- **`infra/tofu/README.md`** — documents the new flow + the one-time CIAM deploy SP bootstrap that is still required before Tofu can manage SPA redirect URIs.

## ⚠️ This PR does NOT fix the current AADSTS50011 prod sign-in break by itself

Root cause of the existing break: `local.ciam_redirect_enabled = var.ciam_client_id != "" && var.ciam_deploy_client_id != ""`. Both `TF_VAR_CIAM_CLIENT_ID` and `TF_VAR_CIAM_DEPLOY_CLIENT_ID` were never set in GH Actions secrets, so the `azuread_application_redirect_uris` resource added in #776 has been silently `count = 0` in every deploy. Production canopex.hrdcrprwn.com is not in the SPA redirect URI list.

After this PR merges, `var.ciam_client_id` will be populated from tfvars — but `ciam_deploy_client_id` is still the gate, and that requires the deploy SP bootstrap (see README) which needs CIAM-tenant admin auth that GH OIDC doesn't currently have.

**Immediate manual unblock** (must be run by someone with admin in the CIAM tenant `92001438-8b42-4bd7-950f-0ed1775f87b7`):

```bash
az login --tenant 92001438-8b42-4bd7-950f-0ed1775f87b7 --allow-no-subscriptions
az ad app update --id 6e2abd0a-61a4-41a5-bdb5-7e1c91471fc6 \
  --set spa.redirectUris='["https://canopex.hrdcrprwn.com/","https://canopex.hrdcrprwn.com/app/","https://canopex.hrdcrprwn.com/eudr/"]'
```

## Approval-gated

This PR touches `.github/workflows/deploy.yml` and OpenTofu — needs review before merge per standing orders.

## Validation

- `tofu fmt -recursive` — clean
- No Python touched
- CI to validate: tofu `validate`/`plan`, security scanners, deploy workflow lint

## Follow-up

A `[discovered]` issue will be filed for the CIAM deploy SP bootstrap so that long-term redirect-URI automation lands.


## Update (commit 5da1403): in-PR cleanup of #801, #802, #803, #805

After PR review against the HashiCorp/Microsoft CIAM reference architecture, six follow-up issues were filed (#801–#806). Four of them were low-risk decomplection wins and have been folded into this PR:

- **fixes #801** — drop dead `auth_mode` variable + AUTH_MODE env plumbing (only allowed value was `bearer_only`)
- **fixes #802** — simplify `ciam_redirect_enabled` to `var.ciam_deploy_client_id != ""` (the AND-with-`ciam_client_id` was redundant since tfvars always populates it)
- **fixes #803** — eliminate the four `ciam-*` Key Vault secrets entirely; CIAM tenant_id/authority/client_id/api_audience are public values, so they now flow as plain Function App app settings + a single `ciam_page_config` Tofu output the SWA deploy step injects into the page HTML
- **fixes #805** — derive `ciam_authority` from a new `ciam_tenant_subdomain` tfvar (`https://${subdomain}.ciamlogin.com/`) so the authority can never drift from the tenant

**Deferred to follow-up PRs** (need careful state import / additional Azure-side data lookups, kept out of this PR to keep blast radius small):

- #804 — move `azuread_application_federated_identity_credential` + `azuread_application_owner` into Tofu
- #806 — move the full SPA `azuread_application_registration` into Tofu (requires `tofu import` orchestration)

Validation: `make test` → 1697 passed, 28 skipped; `ruff check`/`format` clean; `tofu fmt -recursive` clean.
