### PR TITLE
fix(infra): import existing CIAM SPA redirect URIs into Tofu state

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -104,6 +104,7 @@ portfolio-level risk visibility.
 
 | PR | Summary |
 |----|---------|  
+| #807 | fix(infra): import existing CIAM SPA redirect URIs into Tofu state — `import` block adopts the resource that was created via the manual `az ad app update` bootstrap before #799 took ownership, unblocking the failed post-merge deploy (Tofu Apply was erroring with "resource already exists - to be managed via Terraform this resource needs to be imported into the State") |
 | #799 | chore(infra): refactor CIAM tenant config to HashiCorp/MS reference architecture — bake public CIAM IDs into tfvars (no Key Vault, no GH-secrets injection), derive `ciam_authority` from tenant subdomain, surface single `ciam_page_config` Tofu output for SWA HTML injection, drop dead `auth_mode` variable, simplify redirect-URI gate (closes #801, #802, #803, #805) |
 | #796 | refactor(blueprints): migrate `org.py` handlers to `@require_auth` decorator (pilot for #791) — removes 4 duplicated OPTIONS+check_auth blocks |
 | #790 | docs(architecture): comprehensive C4 review (Level 1–4 + code analysis) — confirms #779–#785 and surfaces new code-hygiene issues #791, #792, #793 |

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -1085,6 +1085,22 @@ resource "azuread_application_redirect_uris" "ciam_spa" {
   redirect_uris  = local.ciam_spa_redirect_uris
 }
 
+# One-time state adoption: the SPA redirect URI block was set in Azure manually
+# (via `az ad app update --set spa.redirectUris=...` during the original CIAM
+# bootstrap) BEFORE the matching resource existed in Tofu config, so the first
+# real apply after #799 merged failed with "resource already exists - to be
+# managed via Terraform this resource needs to be imported into the State".
+#
+# This import block (OpenTofu 1.6+ syntax) adopts the existing redirect URI
+# block into state on next plan/apply. After the first successful apply it
+# becomes a no-op (Tofu detects the resource is already in state). The block
+# can be removed in a follow-up PR once dev + prd have both reconciled.
+import {
+  for_each = local.ciam_redirect_enabled ? toset(["spa"]) : toset([])
+  to       = azuread_application_redirect_uris.ciam_spa[0]
+  id       = "${data.azuread_application.ciam[0].id}/redirectUris/SPA"
+}
+
 resource "azurerm_role_assignment" "storage_blob_data_owner" {
   scope                = azurerm_storage_account.main.id
   role_definition_name = "Storage Blob Data Owner"


### PR DESCRIPTION
## Problem

The post-#799 deploy ([run 25780479067](https://github.com/Hardcoreprawn/azure-workflow-for-kml-satellite/actions/runs/25780479067)) failed at **Tofu Apply** with:

```
Error: A resource with the ID "/applications/7ce73a2a-b80a-4b6f-afb7-eccf74bfaf47/redirectUris/SPA" already exists - to be managed via Terraform this resource needs to be imported into the State.
  with azuread_application_redirect_uris.ciam_spa[0],
```

**Root cause:** state drift. The SPA redirect URI block exists in Azure because it was created by the manual `az ad app update --set spa.redirectUris=...` bootstrap documented in #799's body — but it was never imported into Tofu state. Now that #799 has merged and the matching `azuread_application_redirect_uris.ciam_spa` resource exists in config, Tofu wants to **create** it → Azure rejects.

## Fix

Add an OpenTofu `import` block to `main.tf` that adopts the existing resource on next plan. Conditional on `local.ciam_redirect_enabled` so cost-estimate runs (which don't have `TF_VAR_CIAM_DEPLOY_CLIENT_ID`) are unaffected, mirroring the resource's own `count`.

Idempotent — after the first successful apply, Tofu sees the resource is already in state and skips the import. The block can be removed in a follow-up PR once both dev and prd have reconciled (or left as documentation; both are fine).

## Scope

- 1 file changed (`infra/tofu/main.tf`) + ROADMAP entry
- No behavior change beyond unblocking the deploy
- No new tests (state-management plumbing; existing CI tofu plan exercises it)

## Verification

- `tofu fmt -recursive`: clean
- Imported ID matches the one the provider reported in the error
- Cost-estimate path: `for_each` empty → no import attempted

## After merge

Watch the Deploy workflow for the post-merge run; expect Apply to succeed with `Import successful!` for `azuread_application_redirect_uris.ciam_spa[0]`. Verify CIAM sign-in still works end-to-end on dev.

## Refs

- Failed deploy: run 25780479067 / job 75721969638
- Parent PR: #799
- Standing follow-ups (unchanged): #804 (federated creds into Tofu), #806 (full SPA app `tofu import`)
