### PR TITLE
fix(auth): include tenant ID in CIAM authority so MSAL accepts post-redirect tokens

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -104,6 +104,7 @@ portfolio-level risk visibility.
 
 | PR | Summary |
 |----|---------|  
+| #808 | fix(auth): include tenant ID in CIAM authority URL so MSAL can validate id_token issuer post-redirect — without the tenant path, `handleRedirectPromise()` rejected silently (swallowed by `.catch(warn)`) and users returning from CIAM landed back on the home page logged-out; also unswallowed the catch and wired auth failures to AppInsights via `trackException` so future regressions are visible server-side |
 | #807 | fix(infra): import existing CIAM SPA redirect URIs into Tofu state — `import` block adopts the resource that was created via the manual `az ad app update` bootstrap before #799 took ownership, unblocking the failed post-merge deploy (Tofu Apply was erroring with "resource already exists - to be managed via Terraform this resource needs to be imported into the State") |
 | #799 | chore(infra): refactor CIAM tenant config to HashiCorp/MS reference architecture — bake public CIAM IDs into tfvars (no Key Vault, no GH-secrets injection), derive `ciam_authority` from tenant subdomain, surface single `ciam_page_config` Tofu output for SWA HTML injection, drop dead `auth_mode` variable, simplify redirect-URI gate (closes #801, #802, #803, #805) |
 | #796 | refactor(blueprints): migrate `org.py` handlers to `@require_auth` decorator (pilot for #791) — removes 4 duplicated OPTIONS+check_auth blocks |

--- a/infra/tofu/locals.tf
+++ b/infra/tofu/locals.tf
@@ -40,10 +40,18 @@ locals {
 
   primary_site_url = var.custom_domain != "" ? "https://${var.custom_domain}" : "https://${azurerm_static_web_app.main.default_host_name}"
 
-  # CIAM authority URL is computed from the tenant subdomain. Entra External ID
-  # tenants use the canonical https://<subdomain>.ciamlogin.com/ host; the
-  # trailing slash matters for MSAL's authority parsing.
-  ciam_authority = var.ciam_tenant_subdomain != "" ? "https://${var.ciam_tenant_subdomain}.ciamlogin.com/" : ""
+  # CIAM authority URL is computed from the tenant subdomain + tenant ID.
+  # Entra External ID tenants use https://<subdomain>.ciamlogin.com/<tenant-id>/.
+  # The tenant-id segment is REQUIRED: MSAL.js validates the id_token `iss`
+  # claim against the authority, and CIAM's issuer is tenant-scoped
+  # (https://<tenant-id>.ciamlogin.com/<tenant-id>/v2.0). Without the tenant
+  # path, handleRedirectPromise() rejects post-login and no session is
+  # established. The trailing slash matters for MSAL's authority parsing.
+  ciam_authority = (
+    var.ciam_tenant_subdomain != "" && var.ciam_tenant_id != ""
+    ? "https://${var.ciam_tenant_subdomain}.ciamlogin.com/${var.ciam_tenant_id}/"
+    : ""
+  )
 
   # Page-level CIAM bootstrap config, injected into website HTML at deploy time
   # via `tofu output -raw ciam_page_config`. The SWA workflow substitutes this

--- a/treesight/security/auth.py
+++ b/treesight/security/auth.py
@@ -133,9 +133,19 @@ def _jwks_client(jwks_url: str):
 
 @lru_cache(maxsize=2)
 def _oidc_metadata(authority: str, tenant_id: str) -> dict[str, str]:
-    """Fetch OIDC metadata and return issuer/JWKS values."""
-    authority = authority.rstrip("/")
-    url = f"{authority}/{tenant_id}/v2.0/.well-known/openid-configuration"
+    """Fetch OIDC metadata and return issuer/JWKS values.
+
+    Accepts authority either as the bare host
+    (``https://<sub>.ciamlogin.com/``) or with the tenant path already
+    appended (``https://<sub>.ciamlogin.com/<tenant-id>/``). The latter is
+    the recommended Entra External ID form because MSAL.js requires the
+    tenant in the authority to validate id_token issuers.
+    """
+    base = authority.rstrip("/")
+    suffix = f"/{tenant_id}"
+    if not base.endswith(suffix):
+        base = f"{base}{suffix}"
+    url = f"{base}/v2.0/.well-known/openid-configuration"
     response = requests.get(url, timeout=10)
     response.raise_for_status()
     metadata = response.json()

--- a/website/js/canopex-auth.js
+++ b/website/js/canopex-auth.js
@@ -177,7 +177,13 @@
     if (!_msalInitPromise) {
       _msalInitPromise = app.initialize().then(function () {
         return app.handleRedirectPromise().catch(function (redirectErr) {
-          console.warn('[CanopexCiam] handleRedirectPromise error:', redirectErr);
+          // Surface to console.error AND to AppInsights so the failure is
+          // visible server-side. handleRedirectPromise rejection means the
+          // user came back from CIAM but the response was rejected (e.g.
+          // issuer mismatch, state mismatch). Silent warns hid an outage
+          // in production — see fix/ciam-authority-tenant-path.
+          console.error('[CanopexCiam] handleRedirectPromise error:', redirectErr);
+          reportAuthFailure('handleRedirectPromise', redirectErr);
           return null;
         });
       }).then(function () {
@@ -185,10 +191,32 @@
         return app;
       }).catch(function (initErr) {
         _msalInitPromise = null;
+        console.error('[CanopexCiam] MSAL init failed:', initErr);
+        reportAuthFailure('msalInitialize', initErr);
         throw initErr;
       });
     }
     return _msalInitPromise;
+  }
+
+  function reportAuthFailure(phase, err) {
+    try {
+      // analytics.js exposes the AppInsights SDK on window.__ai once loaded.
+      var ai = window.__ai;
+      if (ai && typeof ai.trackException === 'function') {
+        ai.trackException({
+          exception: err instanceof Error ? err : new Error(String(err)),
+          properties: {
+            phase: phase,
+            errorCode: (err && err.errorCode) || '',
+            errorMessage: (err && err.errorMessage) || (err && err.message) || '',
+            subError: (err && err.subError) || '',
+          },
+        });
+      }
+    } catch (_) {
+      /* never let telemetry break auth */
+    }
   }
 
   function getAccount() {
@@ -211,6 +239,7 @@
       return app.loginRedirect({ scopes: buildApiScopes(getCiamConfig()) });
     }).catch(function (err) {
       console.error('[CanopexCiam] loginRedirect failed:', err);
+      reportAuthFailure('loginRedirect', err);
       return null;
     });
   }
@@ -229,6 +258,7 @@
       });
     }).catch(function (err) {
       console.error('[CanopexCiam] logoutRedirect failed:', err);
+      reportAuthFailure('logoutRedirect', err);
       return null;
     });
   }

--- a/website/js/canopex-auth.js
+++ b/website/js/canopex-auth.js
@@ -180,8 +180,8 @@
           // Surface to console.error AND to AppInsights so the failure is
           // visible server-side. handleRedirectPromise rejection means the
           // user came back from CIAM but the response was rejected (e.g.
-          // issuer mismatch, state mismatch). Silent warns hid an outage
-          // in production — see fix/ciam-authority-tenant-path.
+          // issuer mismatch, state mismatch). Silent warns previously hid
+          // an outage in production (PR #808).
           console.error('[CanopexCiam] handleRedirectPromise error:', redirectErr);
           reportAuthFailure('handleRedirectPromise', redirectErr);
           return null;
@@ -206,6 +206,10 @@
       if (ai && typeof ai.trackException === 'function') {
         ai.trackException({
           exception: err instanceof Error ? err : new Error(String(err)),
+          // Match the severity used by the global onerror/unhandledrejection
+          // handlers in analytics.js so auth failures are filterable as
+          // errors in AppInsights.
+          severityLevel: 3,
           properties: {
             phase: phase,
             errorCode: (err && err.errorCode) || '',


### PR DESCRIPTION
## Symptom

User reports: home page loads correctly (Online badge shows). Click **Sign In** → CIAM login flow runs → CIAM redirects back to `/` → user is back on the home page, **not logged in**. No error visible to the user.

## Root cause

MSAL `authority` was `https://treesightauth.ciamlogin.com/` with no tenant path.

For Entra External ID (CIAM), MSAL's `handleRedirectPromise()` validates the id_token `iss` claim against the configured authority. CIAM issues tokens with `iss = https://<tenant-id>.ciamlogin.com/<tenant-id>/v2.0`. Without the tenant path on the authority, validation fails and `handleRedirectPromise()` rejects.

That rejection was then **silently swallowed** by `.catch(redirectErr → console.warn(...); return null)` in `canopex-auth.js#ensureMsalReady`, so:

- nothing reached AppInsights (verified — last 6h shows zero browser exceptions, zero `/api/me` traffic, only repeated `nav_sign_in` events)
- the user just sees themselves logged out with no explanation

## Fix

1. **`infra/tofu/locals.tf`** — `ciam_authority` now includes the tenant ID, matching Microsoft's published CIAM JS sample (`https://<sub>.ciamlogin.com/<tenant-id>/`). This is the documented correct shape for Entra External ID.
2. **`treesight/security/auth.py`** — `_oidc_metadata()` now tolerates either authority form (with or without trailing tenant ID), so the change is backward-compatible if any environment is still set to the bare host.
3. **`website/js/canopex-auth.js`** — unswallow `handleRedirectPromise` and `initialize` errors: log to `console.error` AND push to AppInsights via `window.__ai.trackException` (same global `analytics.js` already exposes). Same instrumentation added to `loginRedirect`/`logoutRedirect` catches. The next regression of this class will be visible server-side without needing the user's browser console.

## Validation

- CIAM OIDC discovery returns 200 at the new authority URL (manually `curl`'d).
- Backend tests: `tests/test_auth.py`, `tests/test_config.py`, `tests/test_e2e_smoke_gate.py` — 48 passed.
- Lint clean (`ruff check` + `ruff format --check`).
- Pre-commit hooks all pass (ruff, pyright, detect-secrets, markdownlint).

## Risk / rollout

- **Existing CIAM tokens cached in user localStorage will be invalidated** (good — they were already useless). Users will see a clean re-login on next visit.
- The Tofu change re-emits `ciam_page_config` JSON with a new `authority` value; the deploy step's HTML `sed` injection picks it up automatically. No infra resource churn.
- Backend change is defensive — accepts both old and new authority shapes — so deploy ordering between front-end and back-end doesn't matter.

## Roadmap

Logged in `docs/ROADMAP.md` Recently Landed table.
