### PR TITLE
fix(ciam): switch redirect-URI import to for_each so it actually triggers

### DIFF
--- a/infra/tofu/README.md
+++ b/infra/tofu/README.md
@@ -83,7 +83,7 @@ Deploy` (appId `b49dea4a-81af-445c-acfe-29db8301c7f4`, SP id
 on Microsoft Graph), Owner of SPA app `1b51e2e8-…`, and federated GitHub OIDC
 credentials for `repo:Hardcoreprawn/azure-workflow-for-kml-satellite:environment:{dev,prd}`.
 Both GitHub Environments have `TF_VAR_CIAM_DEPLOY_CLIENT_ID` set. Tofu manages
-`azuread_application_redirect_uris.ciam_spa[0]` from
+`azuread_application_redirect_uris.ciam_spa["spa"]` from
 `local.ciam_spa_redirect_uris` in `locals.tf`.
 
 If the deploy SP needs to be re-created (e.g. for a new tenant or rotated):

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -1094,7 +1094,7 @@ data "azuread_application" "ciam" {
 }
 
 resource "azuread_application_redirect_uris" "ciam_spa" {
-  count          = local.ciam_redirect_enabled ? 1 : 0
+  for_each       = local.ciam_redirect_enabled ? toset(["spa"]) : toset([])
   application_id = data.azuread_application.ciam[0].id
   type           = "SPA"
   redirect_uris  = local.ciam_spa_redirect_uris
@@ -1109,10 +1109,14 @@ resource "azuread_application_redirect_uris" "ciam_spa" {
 # This import block (OpenTofu 1.6+ syntax) adopts the existing redirect URI
 # block into state on next plan/apply. After the first successful apply it
 # becomes a no-op (Tofu detects the resource is already in state). The block
-# can be removed in a follow-up PR once dev + prd have both reconciled.
+# can be removed in a follow-up PR once dev has reconciled.
+#
+# NOTE: import blocks support `for_each` only (not `count`), and `to` must
+# reference `each.key`. The matching resource above therefore also uses
+# `for_each` so the addresses align (`...ciam_spa["spa"]`).
 import {
   for_each = local.ciam_redirect_enabled ? toset(["spa"]) : toset([])
-  to       = azuread_application_redirect_uris.ciam_spa[0]
+  to       = azuread_application_redirect_uris.ciam_spa[each.key]
   id       = "${data.azuread_application.ciam[0].id}/redirectUris/SPA"
 }
 

--- a/infra/tofu/providers.tf
+++ b/infra/tofu/providers.tf
@@ -16,7 +16,12 @@ provider "azapi" {
 # When ciam_deploy_client_id is empty (e.g. cost-estimate CI, bootstrap), the
 # azuread provider stays unconfigured and no OIDC exchange is attempted.
 locals {
-  ciam_redirect_enabled = var.ciam_deploy_client_id != ""
+  # nonsensitive() is safe here: the result is a boolean derived from a
+  # zero-length check, which leaks no secret material. Required so the
+  # boolean can be used as a `for_each` / `count` driver downstream
+  # (Tofu refuses to use values derived from sensitive vars in those
+  # contexts otherwise).
+  ciam_redirect_enabled = nonsensitive(var.ciam_deploy_client_id != "")
 }
 
 provider "azuread" {


### PR DESCRIPTION
## Why

Deploy on `main` (commit 2079a94) failed with:

```
azuread_application_redirect_uris.ciam_spa[0]: A resource with the ID
'/applications/ad0396db-.../redirectUris/SPA' already exists - to be managed
via Terraform this resource needs to be imported into the State.
```

[Failed run](https://github.com/Hardcoreprawn/azure-workflow-for-kml-satellite/actions/runs/25845351240)

## Root cause

The import block in #811 used:

```hcl
import {
  for_each = local.ciam_redirect_enabled ? toset(["spa"]) : toset([])
  to       = azuread_application_redirect_uris.ciam_spa[0]   # <-- count-style addr
  id       = "${data.azuread_application.ciam[0].id}/redirectUris/SPA"
}
```

OpenTofu requires `for_each` import blocks to address the target via `each.key`, not a count index. The mismatch caused the import to be silently skipped on plan, and apply then tried to create a resource that already existed in Azure (set via Graph PATCH during the canopex bootstrap).

## Fix

- Convert `azuread_application_redirect_uris.ciam_spa` from `count` to `for_each = toset(["spa"])`.
- Update import block to use `to = azuread_application_redirect_uris.ciam_spa[each.key]`.
- Wrap `local.ciam_redirect_enabled` in `nonsensitive()` so it can be used in `for_each` (it's derived from a sensitive var via a zero-length check — no secret material leaks).
- Update README reference from `[0]` to `["spa"]`.

## Validation

- `tofu fmt` clean
- `tofu validate` passes
- `ruff check` + `ruff format --check` clean
- Resource address change is safe: state currently has no entry for this resource (the failure was on first create), so the new for_each-keyed address will adopt cleanly via the import block.

## Risk

Low. Single-resource state-shape change for a resource that doesn't yet exist in Tofu state. Worst case: if the import still skips for an unforeseen reason, apply re-fails the same way and we iterate.