### PR TITLE
fix(ciam): align ciam_api_audience tfvars with hot-patched value

### DIFF
--- a/infra/tofu/environments/dev.tfvars
+++ b/infra/tofu/environments/dev.tfvars
@@ -32,4 +32,6 @@ orch_min_instances           = 0
 ciam_tenant_subdomain = "canopex"
 ciam_tenant_id        = "98a402ed-45fb-4cf8-bbfe-2b4c19bc36c7"
 ciam_client_id        = "1b51e2e8-15af-448b-8886-1345aeda73ba"
-ciam_api_audience     = "api://canopex"
+# CIAM External ID issues access tokens with `aud=<clientId>` when a SPA calls
+# its own backend (no separate API app reg). Backend validates against this aud.
+ciam_api_audience     = "1b51e2e8-15af-448b-8886-1345aeda73ba"

--- a/infra/tofu/environments/prd.tfvars
+++ b/infra/tofu/environments/prd.tfvars
@@ -25,4 +25,6 @@ enable_cosmos_db      = true
 ciam_tenant_subdomain = "canopex"
 ciam_tenant_id        = "98a402ed-45fb-4cf8-bbfe-2b4c19bc36c7"
 ciam_client_id        = "1b51e2e8-15af-448b-8886-1345aeda73ba"
-ciam_api_audience     = "api://canopex"
+# CIAM External ID issues access tokens with `aud=<clientId>` when a SPA calls
+# its own backend (no separate API app reg). Backend validates against this aud.
+ciam_api_audience     = "1b51e2e8-15af-448b-8886-1345aeda73ba"


### PR DESCRIPTION
## What

Aligns `ciam_api_audience` in `dev.tfvars` and `prd.tfvars` with the value already hot-patched on `func-kmlsat-dev` and `func-kmlsat-dev-orch` (the CIAM SPA `clientId`).

## Why

CIAM External ID issues access tokens with `aud=<clientId>` when a SPA calls its own backend (no separate API app registration). The previous value (`api://canopex`) caused the backend to reject every authenticated request with 401 — discovered after the CIAM rebuild (#811, #812).

The function apps were hot-patched live to unblock the dashboard. This PR brings IaC back in sync so the next deploy doesn't reintroduce the 401 cascade.

## Verification

- Hot-patch already verified live: `/api/billing/status`, `/api/eudr/billing`, `/api/analysis/history` returned 200 after the env var change.
- No code changes; tfvars only.

## Risk

Low. Single env var. Reverts to the value that's already running in dev.

## Approval gate

Infra change — needs review per standing orders.
