### PR TITLE
docs(roadmap): update Recently Landed — add #821, remove #776

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,7 @@
 **Single source of truth for what to build next.**
 Issues hold the detail. This list holds the order.
 
-Last updated: 2026-05-10
+Last updated: 2026-05-14
 
 ---
 
@@ -104,15 +104,13 @@ portfolio-level risk visibility.
 
 | PR | Summary |
 |----|---------|  
+| #821 | feat(billing): stage 1 — org-pooled run accounting (umbrella #814) — `reserve_run` / `finalize_run` / `get_pool_status` API with per-member caps (persistent counter survives finalize), ETag optimistic-concurrency Cosmos helpers (`read_item_with_etag` / `replace_item_with_etag`), and 31-test suite covering pool maths, rejections, rollover, concurrency, finalize idempotency, and status snapshots. No callers wired yet; Stages 2–4 of #814 (wire orchestrator, deprecate legacy quota, frontend display) follow. Fixed Copilot review findings: cap-binding across finalize, SDK contract tests, docstring xref. |
 | (this PR) | feat(ciam): rebuild tenant as `canopex` — replaces `treesightauth` (in-development, no users) — new tenant `98a402ed-…`, new SPA app `1b51e2e8-…`, new audience `api://canopex`, new email-OTP user flow `Canopex SUSI`, new tofu deploy SP `b49dea4a-…` (federated for dev+prd GitHub envs, Owner of SPA app, `Application.ReadWrite.OwnedBy` admin-consented); tfvars/CSP/workflows/docs swept; old tenant slated for deletion post-merge |
 | #808 | fix(auth): include tenant ID in CIAM authority URL so MSAL can validate id_token issuer post-redirect — without the tenant path, `handleRedirectPromise()` rejected silently (swallowed by `.catch(warn)`) and users returning from CIAM landed back on the home page logged-out; also unswallowed the catch and wired auth failures to AppInsights via `trackException` so future regressions are visible server-side |
 | #807 | fix(infra): import existing CIAM SPA redirect URIs into Tofu state — `import` block adopts the resource that was created via the manual `az ad app update` bootstrap before #799 took ownership, unblocking the failed post-merge deploy (Tofu Apply was erroring with "resource already exists - to be managed via Terraform this resource needs to be imported into the State") |
 | #799 | chore(infra): refactor CIAM tenant config to HashiCorp/MS reference architecture — bake public CIAM IDs into tfvars (no Key Vault, no GH-secrets injection), derive `ciam_authority` from tenant subdomain, surface single `ciam_page_config` Tofu output for SWA HTML injection, drop dead `auth_mode` variable, simplify redirect-URI gate (closes #801, #802, #803, #805) |
 | #796 | refactor(blueprints): migrate `org.py` handlers to `@require_auth` decorator (pilot for #791) — removes 4 duplicated OPTIONS+check_auth blocks |
 | #790 | docs(architecture): comprehensive C4 review (Level 1–4 + code analysis) — confirms #779–#785 and surfaces new code-hygiene issues #791, #792, #793 |
-| #797 | ci: stub `Lint`/`Test` checks for docs-only PRs to satisfy branch protection (`paths-ignore` in ci.yml left required checks unreported, blocking docs-only auto-merge) |
-| #787 | feat(analytics+docs): harden frontend telemetry (`window.onerror` + `unhandledrejection` + `data-track` CTAs) and add C4 architecture review (2026-05-11) — files arch findings as #779/#780/#782/#784/#785 |
-| #776 | fix(infra): CIAM SPA redirect URI management via Tofu — conditional azuread provider, lockfile, all-or-nothing validation (closes #777) |
 
 ---
 


### PR DESCRIPTION
Updates the Recently Landed section in the roadmap to document the merge of PR #821 (org-pooled run accounting, stage 1 of #814).

- Adds #821 entry with summary of reserve/finalize/status API, per-member caps, ETag helpers, and 31-test suite
- Removes #776 (oldest entry) to keep the Recently Landed table at 6 entries
- Updates Last updated timestamp to 2026-05-14