### PR TITLE
Refactor to a single parcel accounting gate

### DIFF
--- a/blueprints/eudr.py
+++ b/blueprints/eudr.py
@@ -251,7 +251,7 @@ def _eudr_usage_payload(user_id: str) -> dict:
 
     org = get_user_org(user_id)
     org_id = org.get("org_id") if isinstance(org, dict) else ""
-    billing = get_eudr_billing_status(org_id or "")
+    billing = get_eudr_billing_status(org_id or "", user_id=user_id)
 
     period_used = int(billing.get("period_parcels_used", 0) or 0)
     included = int(billing.get("included_parcels", EUDR_INCLUDED_PARCELS) or EUDR_INCLUDED_PARCELS)
@@ -352,13 +352,13 @@ def eudr_billing_status(req: func.HttpRequest) -> func.HttpResponse:
     org = get_user_org(user_id)
     if not org:
         return func.HttpResponse(
-            json.dumps(get_eudr_billing_status("")),
+            json.dumps(get_eudr_billing_status("", user_id=user_id)),
             status_code=200,
             mimetype="application/json",
             headers=cors_headers(req),
         )
 
-    status = get_eudr_billing_status(org["org_id"])
+    status = get_eudr_billing_status(org["org_id"], user_id=user_id)
     return func.HttpResponse(
         json.dumps(status),
         status_code=200,
@@ -394,7 +394,7 @@ def eudr_entitlement_check(req: func.HttpRequest) -> func.HttpResponse:
             headers=cors_headers(req),
         )
 
-    result = check_eudr_entitlement(org["org_id"])
+    result = check_eudr_entitlement(org["org_id"], user_id=user_id)
     return func.HttpResponse(
         json.dumps(result),
         status_code=200,

--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -30,7 +30,6 @@ from treesight.billing.accounting import (
 )
 from treesight.config import STORAGE_ACCOUNT_NAME
 from treesight.constants import DEFAULT_INPUT_CONTAINER, DEFAULT_PROVIDER, MAX_KML_FILE_SIZE_BYTES
-from treesight.security.eudr_billing import check_eudr_entitlement
 from treesight.security.orgs import get_user_org
 from treesight.security.redact import redact_user_id as _redact
 from treesight.storage import cosmos as _cosmos_mod
@@ -204,69 +203,6 @@ def _build_ticket(body: dict, user_id: str, submission_context: dict, org_id: st
     return ticket
 
 
-def _check_eudr_entitlement(
-    user_id: str, req: func.HttpRequest
-) -> tuple[str, dict, func.HttpResponse | None]:
-    """Validate EUDR entitlement for the requesting user's org.
-
-    Returns (org_id, entitlement_dict, error_response_or_None).
-    """
-    try:
-        org = get_user_org(user_id)
-    except Exception:
-        logger.exception(
-            "Failed to resolve org for EUDR entitlement",
-            extra={"user_id": _redact(user_id)},
-        )
-        return (
-            "",
-            {},
-            error_response(
-                503,
-                "Unable to verify EUDR entitlement right now. Please retry shortly.",
-                req=req,
-            ),
-        )
-    if not org:
-        return (
-            "",
-            {},
-            error_response(
-                403,
-                "EUDR assessments require an org. Create or join an org first.",
-                req=req,
-            ),
-        )
-    org_id = org["org_id"]
-    try:
-        entitlement = check_eudr_entitlement(org_id, user_id=user_id)
-    except Exception:
-        logger.exception(
-            "EUDR entitlement check failed during upload flow",
-            extra={"org_id": org_id, "user_id": _redact(user_id)},
-        )
-        return (
-            org_id,
-            {},
-            error_response(
-                503,
-                "EUDR entitlement service is temporarily unavailable. Please retry.",
-                req=req,
-            ),
-        )
-    if not entitlement["allowed"]:
-        return (
-            org_id,
-            entitlement,
-            error_response(
-                403,
-                "EUDR entitlement exhausted — subscription required",
-                req=req,
-            ),
-        )
-    return org_id, entitlement, None
-
-
 def _write_ticket_and_mint_sas(
     body: dict,
     user_id: str,
@@ -359,12 +295,6 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
         body = {}
 
     is_eudr = body.get("eudr_mode") is True
-
-    # ── EUDR entitlement gate ──────────────────────────────────────
-    if is_eudr:
-        _, _, err = _check_eudr_entitlement(user_id, req)
-        if err:
-            return err
 
     # ── Org-pooled run accounting (reserve_run) ────────────────────
     try:

--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -239,7 +239,7 @@ def _check_eudr_entitlement(
         )
     org_id = org["org_id"]
     try:
-        entitlement = check_eudr_entitlement(org_id)
+        entitlement = check_eudr_entitlement(org_id, user_id=user_id)
     except Exception:
         logger.exception(
             "EUDR entitlement check failed during upload flow",

--- a/tests/test_eudr_billing.py
+++ b/tests/test_eudr_billing.py
@@ -13,7 +13,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from treesight.constants import EUDR_FREE_ASSESSMENTS, EUDR_INCLUDED_PARCELS
+from treesight.billing.accounting import OrgNotFoundError
+from treesight.constants import EUDR_FREE_ASSESSMENTS
 
 _UPSERT_ITEM = "treesight.storage.cosmos.upsert_item"
 _GET_ORG = "treesight.security.orgs.get_org"
@@ -176,85 +177,34 @@ class TestConsumeEudrTrial:
 class TestCheckEudrEntitlement:
     """Check whether an org can submit an EUDR assessment."""
 
-    @patch(_GET_ORG)
-    def test_free_trial_allows_assessment(self, mock_get_org):
+    @patch("treesight.billing.accounting.get_pool_status")
+    def test_pool_availability_allows_assessment(self, mock_pool):
         from treesight.security.eudr_billing import check_eudr_entitlement
 
-        mock_get_org.return_value = {
-            "id": "org-1",
-            "org_id": "org-1",
-            "eudr_assessments_used": 0,
-        }
+        mock_pool.return_value = {"available": 4}
         result = check_eudr_entitlement("org-1")
         assert result["allowed"] is True
-        assert result["reason"] == "free_trial"
+        assert result["reason"] == "pool_available"
 
-    @patch(_GET_ORG)
-    def test_trial_exhausted_no_subscription_blocked(self, mock_get_org):
+    @patch("treesight.billing.accounting.get_pool_status")
+    def test_pool_exhausted_blocks_assessment(self, mock_pool):
         from treesight.security.eudr_billing import check_eudr_entitlement
 
-        mock_get_org.return_value = {
-            "id": "org-1",
-            "org_id": "org-1",
-            "eudr_assessments_used": EUDR_FREE_ASSESSMENTS,
-            "billing": {},
-        }
+        mock_pool.return_value = {"available": 0}
         result = check_eudr_entitlement("org-1")
         assert result["allowed"] is False
-        assert result["reason"] == "subscription_required"
-
-    @patch(_GET_ORG)
-    def test_active_subscription_allows_assessment(self, mock_get_org):
-        from treesight.security.eudr_billing import check_eudr_entitlement
-
-        mock_get_org.return_value = {
-            "id": "org-1",
-            "org_id": "org-1",
-            "eudr_assessments_used": EUDR_FREE_ASSESSMENTS,
-            "billing": {
-                "eudr_tier": "eudr_pro",
-                "eudr_status": "active",
-                "stripe_subscription_id": "sub_123",
-            },
-        }
-        result = check_eudr_entitlement("org-1")
-        assert result["allowed"] is True
-        assert result["reason"] == "subscription"
-
-    @patch(_GET_ORG)
-    def test_cancelled_subscription_blocked(self, mock_get_org):
-        from treesight.security.eudr_billing import check_eudr_entitlement
-
-        mock_get_org.return_value = {
-            "id": "org-1",
-            "org_id": "org-1",
-            "eudr_assessments_used": EUDR_FREE_ASSESSMENTS,
-            "billing": {
-                "eudr_tier": "eudr_pro",
-                "eudr_status": "canceled",
-            },
-        }
-        result = check_eudr_entitlement("org-1")
-        assert result["allowed"] is False
-        assert result["reason"] == "subscription_required"
+        assert result["reason"] == "pool_exhausted"
 
     @patch(
-        "treesight.security.billing.get_effective_subscription",
-        return_value={"tier": "enterprise", "status": "active", "emulated": True},
+        "treesight.billing.accounting.get_pool_status",
+        side_effect=OrgNotFoundError(),
     )
-    @patch(_GET_ORG)
-    def test_active_enterprise_emulation_allows_assessment(self, mock_get_org, _effective_sub):
+    def test_missing_org_is_blocked(self, mock_pool):
         from treesight.security.eudr_billing import check_eudr_entitlement
 
-        mock_get_org.return_value = {
-            "id": "org-1",
-            "org_id": "org-1",
-            "eudr_assessments_used": EUDR_FREE_ASSESSMENTS,
-            "billing": {},
-        }
-        result = check_eudr_entitlement("org-1", user_id="user-1")
-        assert result["allowed"] is True
-        assert result["reason"] == "subscription"
+        result = check_eudr_entitlement("org-1")
+        assert result["allowed"] is False
+        assert result["reason"] == "org_not_found"
 
 
 # ---------------------------------------------------------------------------
@@ -265,60 +215,53 @@ class TestCheckEudrEntitlement:
 class TestGetEudrBillingStatus:
     """Billing status payload for the EUDR frontend."""
 
+    @patch("treesight.billing.accounting.get_pool_status")
     @patch(_GET_ORG)
-    def test_free_trial_status(self, mock_get_org):
+    def test_status_uses_pool_counters(self, mock_get_org, mock_pool):
         from treesight.security.eudr_billing import get_eudr_billing_status
 
         mock_get_org.return_value = {
             "id": "org-1",
             "org_id": "org-1",
-            "eudr_assessments_used": 1,
+            "billing": {"stripe_customer_id": "cus_abc"},
+        }
+        mock_pool.return_value = {
+            "allowance": 12,
+            "available": 5,
+            "completed": 6,
+            "reserved": 1,
         }
         status = get_eudr_billing_status("org-1")
-        assert status["plan"] == "free_trial"
-        assert status["assessments_used"] == 1
-        assert status["trial_remaining"] == 1
+        assert status["plan"] == "parcel_pool"
+        assert status["assessments_used"] == 7
+        assert status["trial_remaining"] == 5
         assert status["subscribed"] is False
-
-    @patch(_GET_ORG)
-    def test_subscribed_status(self, mock_get_org):
-        from treesight.security.eudr_billing import get_eudr_billing_status
-
-        mock_get_org.return_value = {
-            "id": "org-1",
-            "org_id": "org-1",
-            "eudr_assessments_used": 5,
-            "billing": {
-                "eudr_tier": "eudr_pro",
-                "eudr_status": "active",
-                "eudr_period_parcels": 7,
-                "stripe_customer_id": "cus_abc",
-            },
-        }
-        status = get_eudr_billing_status("org-1")
-        assert status["plan"] == "eudr_pro"
-        assert status["subscribed"] is True
+        assert status["included_parcels"] == 12
         assert status["period_parcels_used"] == 7
-        assert status["included_parcels"] == EUDR_INCLUDED_PARCELS
         assert status["overage_parcels"] == 0
+        assert status["stripe_customer_id"] == "cus_abc"
 
+    @patch("treesight.billing.accounting.get_pool_status")
     @patch(_GET_ORG)
-    def test_overage_calculation(self, mock_get_org):
+    def test_status_reports_overage_when_reserved_plus_completed_exceeds_allowance(
+        self, mock_get_org, mock_pool
+    ):
         from treesight.security.eudr_billing import get_eudr_billing_status
 
         mock_get_org.return_value = {
             "id": "org-1",
             "org_id": "org-1",
-            "eudr_assessments_used": 15,
-            "billing": {
-                "eudr_tier": "eudr_pro",
-                "eudr_status": "active",
-                "eudr_period_parcels": 15,
-            },
+            "billing": {},
+        }
+        mock_pool.return_value = {
+            "allowance": 8,
+            "available": 0,
+            "completed": 7,
+            "reserved": 3,
         }
         status = get_eudr_billing_status("org-1")
-        assert status["period_parcels_used"] == 15
-        assert status["overage_parcels"] == 5
+        assert status["period_parcels_used"] == 10
+        assert status["overage_parcels"] == 2
 
     @patch(_GET_ORG)
     def test_nonexistent_org_returns_empty(self, mock_get_org):
@@ -328,25 +271,6 @@ class TestGetEudrBillingStatus:
         status = get_eudr_billing_status("missing")
         assert status["plan"] == "none"
         assert status["subscribed"] is False
-
-    @patch(
-        "treesight.security.billing.get_effective_subscription",
-        return_value={"tier": "enterprise", "status": "active", "emulated": True},
-    )
-    @patch(_GET_ORG)
-    def test_active_enterprise_emulation_sets_subscribed(self, mock_get_org, _effective_sub):
-        from treesight.security.eudr_billing import get_eudr_billing_status
-
-        mock_get_org.return_value = {
-            "id": "org-1",
-            "org_id": "org-1",
-            "eudr_assessments_used": EUDR_FREE_ASSESSMENTS,
-            "billing": {},
-        }
-        status = get_eudr_billing_status("org-1", user_id="user-1")
-        assert status["plan"] == "eudr_pro"
-        assert status["subscribed"] is True
-        assert status["trial_remaining"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_eudr_billing.py
+++ b/tests/test_eudr_billing.py
@@ -238,6 +238,24 @@ class TestCheckEudrEntitlement:
         assert result["allowed"] is False
         assert result["reason"] == "subscription_required"
 
+    @patch(
+        "treesight.security.billing.get_effective_subscription",
+        return_value={"tier": "enterprise", "status": "active", "emulated": True},
+    )
+    @patch(_GET_ORG)
+    def test_active_enterprise_emulation_allows_assessment(self, mock_get_org, _effective_sub):
+        from treesight.security.eudr_billing import check_eudr_entitlement
+
+        mock_get_org.return_value = {
+            "id": "org-1",
+            "org_id": "org-1",
+            "eudr_assessments_used": EUDR_FREE_ASSESSMENTS,
+            "billing": {},
+        }
+        result = check_eudr_entitlement("org-1", user_id="user-1")
+        assert result["allowed"] is True
+        assert result["reason"] == "subscription"
+
 
 # ---------------------------------------------------------------------------
 # §3 — EUDR billing status
@@ -310,6 +328,25 @@ class TestGetEudrBillingStatus:
         status = get_eudr_billing_status("missing")
         assert status["plan"] == "none"
         assert status["subscribed"] is False
+
+    @patch(
+        "treesight.security.billing.get_effective_subscription",
+        return_value={"tier": "enterprise", "status": "active", "emulated": True},
+    )
+    @patch(_GET_ORG)
+    def test_active_enterprise_emulation_sets_subscribed(self, mock_get_org, _effective_sub):
+        from treesight.security.eudr_billing import get_eudr_billing_status
+
+        mock_get_org.return_value = {
+            "id": "org-1",
+            "org_id": "org-1",
+            "eudr_assessments_used": EUDR_FREE_ASSESSMENTS,
+            "billing": {},
+        }
+        status = get_eudr_billing_status("org-1", user_id="user-1")
+        assert status["plan"] == "eudr_pro"
+        assert status["subscribed"] is True
+        assert status["trial_remaining"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_upload_endpoints.py
+++ b/tests/test_upload_endpoints.py
@@ -276,14 +276,10 @@ class TestUploadToken:
         assert record["feature_count"] == 3
         assert record["aoi_count"] == 2
 
-    @patch(
-        "blueprints.upload.check_eudr_entitlement",
-        return_value={"allowed": True, "reason": "free_trial"},
-    )
     @patch("blueprints.upload.get_user_org", return_value={"org_id": "org-1", "name": "Test Org"})
     @patch("blueprints.upload.generate_blob_sas")
     @patch("blueprints.upload.get_blob_service_client")
-    def test_eudr_mode_true_in_ticket(self, mock_bsc, mock_gen_sas, mock_org, mock_ent):
+    def test_eudr_mode_true_in_ticket(self, mock_bsc, mock_gen_sas, mock_org):
         from blueprints.upload import upload_token
 
         mock_blob_client = MagicMock()
@@ -339,14 +335,10 @@ class TestUploadToken:
         ticket_data = json.loads(mock_blob_client.upload_blob.call_args[0][0])
         assert "eudr_mode" not in ticket_data
 
-    @patch(
-        "blueprints.upload.check_eudr_entitlement",
-        return_value={"allowed": True, "reason": "free_trial"},
-    )
     @patch("blueprints.upload.get_user_org", return_value={"org_id": "org-1", "name": "Test Org"})
     @patch("blueprints.upload.generate_blob_sas")
     @patch("blueprints.upload.get_blob_service_client")
-    def test_eudr_mode_stored_in_run_record(self, mock_bsc, mock_gen_sas, mock_org, mock_ent):
+    def test_eudr_mode_stored_in_run_record(self, mock_bsc, mock_gen_sas, mock_org):
         from blueprints.upload import upload_token
 
         mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
@@ -455,12 +447,12 @@ class TestUploadToken:
 
 
 # ===================================================================
-# EUDR entitlement enforcement on upload/token
+# Single parcel gate enforcement on upload/token
 # ===================================================================
 
 
-class TestUploadTokenEudrEntitlement:
-    """Server-side EUDR entitlement gate (#664)."""
+class TestUploadTokenSingleGate:
+    """Server-side parcel gate is enforced only through reserve_run."""
 
     def setup_method(self):
         self._org_patcher = patch("blueprints.upload.get_user_org")
@@ -480,7 +472,7 @@ class TestUploadTokenEudrEntitlement:
         self._org_patcher.stop()
 
     @patch("blueprints.upload.get_user_org", return_value=None)
-    def test_eudr_mode_rejects_user_without_org(self, mock_org):
+    def test_rejects_user_without_org(self, mock_org):
         from blueprints.upload import upload_token
 
         req = _make_req("/api/upload/token", method="POST", body={"eudr_mode": True})
@@ -492,77 +484,27 @@ class TestUploadTokenEudrEntitlement:
         assert "org" in data["error"].lower()
         self.mock_reserve_run.assert_not_called()
 
-    @patch(
-        "blueprints.upload.check_eudr_entitlement",
-        return_value={"allowed": False, "reason": "subscription_required"},
-    )
     @patch("blueprints.upload.get_user_org", return_value={"org_id": "org-1", "name": "Test Org"})
-    def test_eudr_mode_rejects_when_entitlement_denied(self, mock_org, mock_ent):
+    def test_eudr_mode_marks_reservation_as_eudr(self, mock_org):
         from blueprints.upload import upload_token
 
         req = _make_req("/api/upload/token", method="POST", body={"eudr_mode": True})
-        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
-            resp = upload_token(req)
-
-        assert resp.status_code == 403
-        data = json.loads(resp.get_body())
-        assert "subscription" in data["error"].lower() or "entitlement" in data["error"].lower()
-        self.mock_reserve_run.assert_not_called()
-
-    @patch(
-        "blueprints.upload.check_eudr_entitlement",
-        return_value={"allowed": True, "reason": "free_trial"},
-    )
-    @patch("blueprints.upload.get_user_org", return_value={"org_id": "org-1", "name": "Test Org"})
-    @patch("blueprints.upload.generate_blob_sas")
-    @patch("blueprints.upload.get_blob_service_client")
-    def test_eudr_mode_marks_reservation_as_eudr_when_entitled(
-        self, mock_bsc, mock_gen_sas, mock_org, mock_ent
-    ):
-        from blueprints.upload import upload_token
-
-        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
-        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
-
-        req = _make_req("/api/upload/token", method="POST", body={"eudr_mode": True})
-        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+        with (
+            patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"),
+            patch("blueprints.upload.generate_blob_sas", return_value="sv=2024&sig=fakesig"),
+            patch("blueprints.upload.get_blob_service_client") as mock_bsc,
+        ):
+            mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
             resp = upload_token(req)
 
         assert resp.status_code == 200
-        # Check that reserve_run was called with EUDR mode
         self.mock_reserve_run.assert_called_once()
-        call_kwargs = self.mock_reserve_run.call_args.kwargs
-        assert call_kwargs["is_eudr"] is True
+        assert self.mock_reserve_run.call_args.kwargs["is_eudr"] is True
 
-    @patch(
-        "blueprints.upload.check_eudr_entitlement",
-        return_value={"allowed": True, "reason": "subscription"},
-    )
     @patch("blueprints.upload.get_user_org", return_value={"org_id": "org-1", "name": "Test Org"})
     @patch("blueprints.upload.generate_blob_sas")
     @patch("blueprints.upload.get_blob_service_client")
-    def test_eudr_mode_skips_trial_when_subscribed(
-        self, mock_bsc, mock_gen_sas, mock_org, mock_ent
-    ):
-        from blueprints.upload import upload_token
-
-        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
-        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
-
-        req = _make_req("/api/upload/token", method="POST", body={"eudr_mode": True})
-        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
-            resp = upload_token(req)
-
-        assert resp.status_code == 200
-        # Check that reserve_run was called
-        self.mock_reserve_run.assert_called_once()
-        call_kwargs = self.mock_reserve_run.call_args.kwargs
-        assert call_kwargs["is_eudr"] is True
-
-    @patch("blueprints.upload.generate_blob_sas")
-    @patch("blueprints.upload.get_blob_service_client")
-    def test_non_eudr_mode_skips_entitlement_check(self, mock_bsc, mock_gen_sas):
-        """Non-EUDR submissions should not check EUDR entitlement."""
+    def test_non_eudr_mode_marks_reservation_as_non_eudr(self, mock_bsc, mock_gen_sas, mock_org):
         from blueprints.upload import upload_token
 
         mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
@@ -573,23 +515,14 @@ class TestUploadTokenEudrEntitlement:
             resp = upload_token(req)
 
         assert resp.status_code == 200
+        self.mock_reserve_run.assert_called_once()
+        assert self.mock_reserve_run.call_args.kwargs["is_eudr"] is False
 
-    @patch(
-        "blueprints.upload.check_eudr_entitlement",
-        return_value={"allowed": True, "reason": "free_trial"},
-    )
     @patch("blueprints.upload.get_user_org", return_value={"org_id": "org-1", "name": "Test Org"})
-    @patch("blueprints.upload.generate_blob_sas")
-    @patch("blueprints.upload.get_blob_service_client")
-    def test_eudr_mode_refunds_quota_on_trial_consume_failure(
-        self, mock_bsc, mock_gen_sas, mock_org, mock_ent
-    ):
-        """If trial consumption fails after quota was consumed, quota is refunded."""
+    def test_eudr_mode_rejected_when_parcel_pool_rejects(self, mock_org):
         from blueprints.upload import upload_token
         from treesight.billing.accounting import MemberCapExceededError
 
-        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
-        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
         self.mock_reserve_run.side_effect = MemberCapExceededError("Member cap exceeded")
 
         req = _make_req("/api/upload/token", method="POST", body={"eudr_mode": True})

--- a/treesight/security/eudr_billing.py
+++ b/treesight/security/eudr_billing.py
@@ -126,27 +126,19 @@ def check_eudr_entitlement(org_id: str, *, user_id: str | None = None) -> dict[s
 
     Returns a dict with ``allowed`` (bool) and ``reason`` (str).
     """
-    from treesight.security.orgs import get_org
+    del user_id  # Reserved for compatibility with existing call sites.
 
-    org = get_org(org_id)
-    if not org:
+    from treesight.billing.accounting import OrgNotFoundError, get_pool_status
+
+    try:
+        status = get_pool_status(org_id)
+    except OrgNotFoundError:
         return {"allowed": False, "reason": "org_not_found"}
 
-    # Check active subscription first
-    billing = org.get("billing", {})
-    if _has_active_eudr_subscription(billing):
-        return {"allowed": True, "reason": "subscription"}
-
-    # Local paid-tier emulation should unlock EUDR for operator testing.
-    if _has_emulated_eudr_access(user_id):
-        return {"allowed": True, "reason": "subscription"}
-
-    # Fall back to free trial
-    used = org.get("eudr_assessments_used", 0)
-    if used < EUDR_FREE_ASSESSMENTS:
-        return {"allowed": True, "reason": "free_trial"}
-
-    return {"allowed": False, "reason": "subscription_required"}
+    available = int(status.get("available", 0) or 0)
+    if available > 0:
+        return {"allowed": True, "reason": "pool_available"}
+    return {"allowed": False, "reason": "pool_exhausted"}
 
 
 # ---------------------------------------------------------------------------
@@ -156,6 +148,9 @@ def check_eudr_entitlement(org_id: str, *, user_id: str | None = None) -> dict[s
 
 def get_eudr_billing_status(org_id: str, *, user_id: str | None = None) -> dict[str, Any]:
     """Return EUDR billing status for the frontend."""
+    del user_id  # Reserved for compatibility with existing call sites.
+
+    from treesight.billing.accounting import OrgNotFoundError, get_pool_status
     from treesight.security.orgs import get_org
 
     org = get_org(org_id)
@@ -170,21 +165,30 @@ def get_eudr_billing_status(org_id: str, *, user_id: str | None = None) -> dict[
             "overage_parcels": 0,
         }
 
+    try:
+        pool = get_pool_status(org_id)
+    except OrgNotFoundError:
+        pool = {
+            "allowance": 0,
+            "available": 0,
+            "completed": 0,
+            "reserved": 0,
+        }
+
     billing = org.get("billing", {})
-    used = org.get("eudr_assessments_used", 0)
-    subscribed = _has_active_eudr_subscription(billing)
-    if not subscribed and _has_emulated_eudr_access(user_id):
-        subscribed = True
-    period_parcels = billing.get("eudr_period_parcels", 0) if subscribed else 0
-    overage = max(period_parcels - EUDR_INCLUDED_PARCELS, 0) if subscribed else 0
+    allowance = int(pool.get("allowance", 0) or 0)
+    available = int(pool.get("available", 0) or 0)
+    used = max(allowance - available, 0)
+    period_parcels = int(pool.get("completed", 0) or 0) + int(pool.get("reserved", 0) or 0)
+    overage = max(period_parcels - allowance, 0)
 
     return {
-        "plan": "eudr_pro" if subscribed else "free_trial",
-        "subscribed": subscribed,
+        "plan": "parcel_pool",
+        "subscribed": False,
         "assessments_used": used,
-        "trial_remaining": max(EUDR_FREE_ASSESSMENTS - used, 0),
+        "trial_remaining": available,
         "period_parcels_used": period_parcels,
-        "included_parcels": EUDR_INCLUDED_PARCELS,
+        "included_parcels": allowance,
         "overage_parcels": overage,
         "stripe_customer_id": billing.get("stripe_customer_id"),
     }

--- a/treesight/security/eudr_billing.py
+++ b/treesight/security/eudr_billing.py
@@ -25,6 +25,8 @@ from treesight.constants import (
 
 logger = logging.getLogger(__name__)
 
+_EUDR_EMULATION_TIERS: frozenset[str] = frozenset({"eudr_pro", "pro", "team", "enterprise"})
+
 
 # ---------------------------------------------------------------------------
 # Tier helpers
@@ -101,7 +103,25 @@ def consume_eudr_trial(org_id: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def check_eudr_entitlement(org_id: str) -> dict[str, Any]:
+def _has_active_eudr_subscription(billing: dict[str, Any]) -> bool:
+    """Return True when org billing has an active EUDR Pro subscription."""
+    return billing.get("eudr_status") == "active" and billing.get("eudr_tier") == "eudr_pro"
+
+
+def _has_emulated_eudr_access(user_id: str | None) -> bool:
+    """Return True when user has active paid-tier emulation for EUDR testing."""
+    if not user_id:
+        return False
+
+    from treesight.security.billing import get_effective_subscription
+
+    sub = get_effective_subscription(user_id)
+    tier = str(sub.get("tier", "")).strip().lower()
+    status = str(sub.get("status", "")).strip().lower()
+    return bool(sub.get("emulated")) and status == "active" and tier in _EUDR_EMULATION_TIERS
+
+
+def check_eudr_entitlement(org_id: str, *, user_id: str | None = None) -> dict[str, Any]:
     """Check whether an org can submit an EUDR assessment.
 
     Returns a dict with ``allowed`` (bool) and ``reason`` (str).
@@ -114,7 +134,11 @@ def check_eudr_entitlement(org_id: str) -> dict[str, Any]:
 
     # Check active subscription first
     billing = org.get("billing", {})
-    if billing.get("eudr_status") == "active" and billing.get("eudr_tier") == "eudr_pro":
+    if _has_active_eudr_subscription(billing):
+        return {"allowed": True, "reason": "subscription"}
+
+    # Local paid-tier emulation should unlock EUDR for operator testing.
+    if _has_emulated_eudr_access(user_id):
         return {"allowed": True, "reason": "subscription"}
 
     # Fall back to free trial
@@ -130,7 +154,7 @@ def check_eudr_entitlement(org_id: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def get_eudr_billing_status(org_id: str) -> dict[str, Any]:
+def get_eudr_billing_status(org_id: str, *, user_id: str | None = None) -> dict[str, Any]:
     """Return EUDR billing status for the frontend."""
     from treesight.security.orgs import get_org
 
@@ -148,7 +172,9 @@ def get_eudr_billing_status(org_id: str) -> dict[str, Any]:
 
     billing = org.get("billing", {})
     used = org.get("eudr_assessments_used", 0)
-    subscribed = billing.get("eudr_status") == "active" and billing.get("eudr_tier") == "eudr_pro"
+    subscribed = _has_active_eudr_subscription(billing)
+    if not subscribed and _has_emulated_eudr_access(user_id):
+        subscribed = True
     period_parcels = billing.get("eudr_period_parcels", 0) if subscribed else 0
     overage = max(period_parcels - EUDR_INCLUDED_PARCELS, 0) if subscribed else 0
 

--- a/website/js/app-run-lifecycle.js
+++ b/website/js/app-run-lifecycle.js
@@ -493,34 +493,6 @@
       return;
     }
 
-    // EUDR entitlement gate: show subscribe modal when trial is exhausted.
-    // If billing hasn't loaded yet, fetch it before deciding.
-    var activeProfile = _d.getActiveProfile ? _d.getActiveProfile() : {};
-    if (activeProfile.requiresEudrBillingGate && typeof window.eudrBillingData === 'function') {
-      var billing = window.eudrBillingData();
-      if (!billing) {
-        try {
-          var apiReady0 = _d.getApiReady ? _d.getApiReady() : Promise.resolve();
-          await apiReady0;
-          var billingRes = await _d.apiFetch('/api/eudr/billing');
-          billing = await billingRes.json();
-        } catch (_) { /* proceed — server will enforce */ }
-      }
-      if (billing && !billing.subscribed && billing.trial_remaining != null && billing.trial_remaining <= 0) {
-        if (_d.setAnalysisStatus) {
-          _d.setAnalysisStatus(
-            'Your free EUDR reports have been used. Subscribe to run more assessments.',
-            'error'
-          );
-        }
-        if (_d.resetAnalysisProgress) _d.resetAnalysisProgress();
-        if (typeof window.showEudrSubscribeModal === 'function') {
-          window.showEudrSubscribeModal();
-        }
-        return;
-      }
-    }
-
     var button = document.getElementById('app-analysis-submit-btn');
     var textarea = document.getElementById('app-analysis-kml');
     if (!button || !textarea) return;


### PR DESCRIPTION
## Summary
- consolidate parcel accounting control to a single gate: org pooled reserve_run/finalize_run
- remove separate EUDR entitlement pre-gate from upload and frontend queueing flow
- make EUDR status/entitlement derive from pooled accounting availability/counters
- keep EUDR as a pipeline package mode flag only (is_eudr on reservations/tickets)

## Why
Parcels are the only billing/accounting model currently in production, so we now enforce one control path and one counter source to avoid drift and regressions.

## Changes
- blueprints/upload.py
  - remove dedicated EUDR entitlement gate
  - rely on reserve_run as submission-time gate for all runs
- website/js/app-run-lifecycle.js
  - remove client-side EUDR trial/subscription pre-block
- treesight/security/eudr_billing.py
  - entitlement/status now read org pool availability/counters via billing.accounting.get_pool_status
- tests/test_upload_endpoints.py
  - remove legacy entitlement-mock assumptions; assert single-gate behavior
- tests/test_eudr_billing.py
  - replace trial/subscription expectations with pool-based assertions

## Validation
- /home/opr/projects/kml-satellites/.venv/bin/python -m pytest tests/test_upload_endpoints.py tests/test_eudr_billing.py -q
- /home/opr/projects/kml-satellites/.venv/bin/python -m pytest tests/test_frontend_config.py tests/test_launch_readiness.py -q
- /home/opr/projects/kml-satellites/.venv/bin/python -m ruff check blueprints/upload.py treesight/security/eudr_billing.py tests/test_upload_endpoints.py tests/test_eudr_billing.py

## Linked Issue
fixes #827
