### PR TITLE
fix(upload): auto-create personal org for unaffiliated users on submission

### DIFF
--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -318,7 +318,23 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
             email = user_doc.get("email", "")
             display_name = user_doc.get("display_name", "")
             org_name = f"{display_name}'s Organisation" if display_name else "My Organisation"
-            user_org = create_org(user_id, name=org_name, email=email)
+            create_org(user_id, name=org_name, email=email)
+            # Re-read to verify the association persisted.  _set_user_org() swallows
+            # its own exceptions, so we cannot trust the return value of create_org().
+            # Re-reading also handles concurrent submissions: if a racing request
+            # already stamped a different org on the user record, we adopt that org
+            # rather than the one we just created, avoiding split reservations.
+            user_org = get_user_org(user_id)
+            if not user_org:
+                logger.error(
+                    "Auto-created org for user=%s but association was not persisted",
+                    _redact(user_id),
+                )
+                return error_response(
+                    503,
+                    "Unable to set up your organisation. Please try again or contact support.",
+                    req=req,
+                )
             logger.info(
                 "Auto-created personal org for user=%s org_id=%s",
                 _redact(user_id),

--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -30,7 +30,7 @@ from treesight.billing.accounting import (
 )
 from treesight.config import STORAGE_ACCOUNT_NAME
 from treesight.constants import DEFAULT_INPUT_CONTAINER, DEFAULT_PROVIDER, MAX_KML_FILE_SIZE_BYTES
-from treesight.security.orgs import get_user_org
+from treesight.security.orgs import create_org, get_user_org
 from treesight.security.redact import redact_user_id as _redact
 from treesight.storage import cosmos as _cosmos_mod
 from treesight.storage.client import get_blob_service_client
@@ -309,11 +309,28 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
         )
 
     if not user_org:
-        return error_response(
-            403,
-            "You must belong to an organisation to submit analyses. Create or join an org first.",
-            req=req,
-        )
+        # Auto-create a personal org so existing users aren't blocked.
+        # They can rename or share it from the account dashboard.
+        try:
+            from treesight.security.users import get_user
+
+            user_doc = get_user(user_id) or {}
+            email = user_doc.get("email", "")
+            display_name = user_doc.get("display_name", "")
+            org_name = f"{display_name}'s Organisation" if display_name else "My Organisation"
+            user_org = create_org(user_id, name=org_name, email=email)
+            logger.info(
+                "Auto-created personal org for user=%s org_id=%s",
+                _redact(user_id),
+                user_org["org_id"],
+            )
+        except Exception:
+            logger.exception("Failed to auto-create org for user=%s", _redact(user_id))
+            return error_response(
+                503,
+                "Unable to set up your organisation. Please try again or contact support.",
+                req=req,
+            )
 
     org_id = user_org["org_id"]
     submission_id = str(uuid.uuid4())

--- a/tests/test_upload_endpoints.py
+++ b/tests/test_upload_endpoints.py
@@ -226,13 +226,15 @@ class TestUploadToken:
         """Users without an org get a personal org auto-created on first submission."""
         from blueprints.upload import upload_token
 
-        self.mock_get_user_org.return_value = None  # no org yet
+        auto_org = {"org_id": "auto-org-1", "name": "Test User's Organisation"}
+        # First call returns None (no org yet); second call (post-creation verification)
+        # returns the newly created org.
+        self.mock_get_user_org.side_effect = [None, auto_org]
         mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
         mock_gen_sas.return_value = "sv=2024&sig=fakesig"
 
-        auto_org = {"org_id": "auto-org-1", "name": "Test User's Organisation"}
         with (
-            patch("blueprints.upload.create_org", return_value=auto_org) as mock_create,
+            patch("blueprints.upload.create_org") as mock_create,
             patch(
                 "treesight.security.users.get_user",
                 return_value={"email": "t@example.com", "display_name": "Test User"},
@@ -246,6 +248,27 @@ class TestUploadToken:
         mock_create.assert_called_once_with(
             "test-user", name="Test User's Organisation", email="t@example.com"
         )
+
+    def test_auto_create_org_association_failure_returns_503(self):
+        """If create_org succeeds but _set_user_org silently failed, return 503."""
+        from blueprints.upload import upload_token
+
+        # First call: no org. Second call (verification after create): still no org
+        # because _set_user_org swallowed its failure.
+        self.mock_get_user_org.side_effect = [None, None]
+
+        with (
+            patch("blueprints.upload.create_org"),
+            patch(
+                "treesight.security.users.get_user",
+                return_value={"display_name": "Test User", "email": "t@example.com"},
+            ),
+            patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"),
+        ):
+            req = _make_req("/api/upload/token", method="POST")
+            resp = upload_token(req)
+
+        assert resp.status_code == 503
 
     def test_auto_create_org_failure_returns_503(self):
         """If org auto-creation fails, return 503 rather than 403."""
@@ -517,15 +540,16 @@ class TestUploadTokenSingleGate:
         self._reserve_patcher.stop()
         self._org_patcher.stop()
 
-    @patch("blueprints.upload.get_user_org", return_value=None)
-    def test_auto_creates_org_when_none_and_proceeds(self, mock_org):
+    def test_auto_creates_org_when_none_and_proceeds(self):
         """Users without an org get one auto-created; submission then succeeds."""
         from blueprints.upload import upload_token
 
         auto_org = {"org_id": "new-org-1", "name": "Test User's Organisation"}
+        # First call: no org. Second call (post-creation verification): org exists.
+        self.mock_get_user_org.side_effect = [None, auto_org]
         req = _make_req("/api/upload/token", method="POST", body={"eudr_mode": True})
         with (
-            patch("blueprints.upload.create_org", return_value=auto_org),
+            patch("blueprints.upload.create_org"),
             patch(
                 "treesight.security.users.get_user",
                 return_value={"display_name": "Test User", "email": "t@example.com"},
@@ -540,11 +564,11 @@ class TestUploadTokenSingleGate:
         assert resp.status_code == 200
         self.mock_reserve_run.assert_called_once()
 
-    @patch("blueprints.upload.get_user_org", return_value=None)
-    def test_returns_503_when_auto_create_org_fails(self, mock_org):
+    def test_returns_503_when_auto_create_org_fails(self):
         """If org auto-creation fails, 503 is returned and reserve_run is not called."""
         from blueprints.upload import upload_token
 
+        self.mock_get_user_org.return_value = None
         req = _make_req("/api/upload/token", method="POST")
         with (
             patch("blueprints.upload.create_org", side_effect=RuntimeError("cosmos down")),

--- a/tests/test_upload_endpoints.py
+++ b/tests/test_upload_endpoints.py
@@ -220,6 +220,52 @@ class TestUploadToken:
         call_kwargs = self.mock_reserve_run.call_args.kwargs
         assert call_kwargs["is_eudr"] is False  # Default: not EUDR mode
 
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_auto_creates_org_for_unaffiliated_user(self, mock_bsc, mock_gen_sas):
+        """Users without an org get a personal org auto-created on first submission."""
+        from blueprints.upload import upload_token
+
+        self.mock_get_user_org.return_value = None  # no org yet
+        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
+
+        auto_org = {"org_id": "auto-org-1", "name": "Test User's Organisation"}
+        with (
+            patch("blueprints.upload.create_org", return_value=auto_org) as mock_create,
+            patch(
+                "treesight.security.users.get_user",
+                return_value={"email": "t@example.com", "display_name": "Test User"},
+            ),
+            patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"),
+        ):
+            req = _make_req("/api/upload/token", method="POST")
+            resp = upload_token(req)
+
+        assert resp.status_code == 200
+        mock_create.assert_called_once_with(
+            "test-user", name="Test User's Organisation", email="t@example.com"
+        )
+
+    def test_auto_create_org_failure_returns_503(self):
+        """If org auto-creation fails, return 503 rather than 403."""
+        from blueprints.upload import upload_token
+
+        self.mock_get_user_org.return_value = None
+
+        with (
+            patch("blueprints.upload.create_org", side_effect=RuntimeError("cosmos down")),
+            patch(
+                "treesight.security.users.get_user",
+                return_value={},
+            ),
+            patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"),
+        ):
+            req = _make_req("/api/upload/token", method="POST")
+            resp = upload_token(req)
+
+        assert resp.status_code == 503
+
     def test_returns_403_when_quota_exhausted(self):
         from blueprints.upload import upload_token
         from treesight.billing.accounting import QuotaExhaustedError
@@ -472,16 +518,42 @@ class TestUploadTokenSingleGate:
         self._org_patcher.stop()
 
     @patch("blueprints.upload.get_user_org", return_value=None)
-    def test_rejects_user_without_org(self, mock_org):
+    def test_auto_creates_org_when_none_and_proceeds(self, mock_org):
+        """Users without an org get one auto-created; submission then succeeds."""
         from blueprints.upload import upload_token
 
+        auto_org = {"org_id": "new-org-1", "name": "Test User's Organisation"}
         req = _make_req("/api/upload/token", method="POST", body={"eudr_mode": True})
-        with patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"):
+        with (
+            patch("blueprints.upload.create_org", return_value=auto_org),
+            patch(
+                "treesight.security.users.get_user",
+                return_value={"display_name": "Test User", "email": "t@example.com"},
+            ),
+            patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"),
+            patch("blueprints.upload.generate_blob_sas", return_value="sv=2024&sig=fakesig"),
+            patch("blueprints.upload.get_blob_service_client") as mock_bsc,
+        ):
+            mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
             resp = upload_token(req)
 
-        assert resp.status_code == 403
-        data = json.loads(resp.get_body())
-        assert "org" in data["error"].lower()
+        assert resp.status_code == 200
+        self.mock_reserve_run.assert_called_once()
+
+    @patch("blueprints.upload.get_user_org", return_value=None)
+    def test_returns_503_when_auto_create_org_fails(self, mock_org):
+        """If org auto-creation fails, 503 is returned and reserve_run is not called."""
+        from blueprints.upload import upload_token
+
+        req = _make_req("/api/upload/token", method="POST")
+        with (
+            patch("blueprints.upload.create_org", side_effect=RuntimeError("cosmos down")),
+            patch("treesight.security.users.get_user", return_value={}),
+            patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"),
+        ):
+            resp = upload_token(req)
+
+        assert resp.status_code == 503
         self.mock_reserve_run.assert_not_called()
 
     @patch("blueprints.upload.get_user_org", return_value={"org_id": "org-1", "name": "Test Org"})


### PR DESCRIPTION
## Problem

Existing users (those created before #831 merged the org system) had no `org_id` on their user record. When they clicked **Confirm & Queue**, the upload endpoint returned a hard `403 You must belong to an organisation to submit analyses` — blocking them from their core workflow.

This was a regression introduced in #831 when org-pooled run accounting replaced the previous user-level accounting.

## Fix

Instead of blocking, auto-create a personal org at first submission:

- Reads the user's display name and email from the Cosmos `users` record
- Creates an org named `"{display_name}'s Organisation"` (falls back to `"My Organisation"`)
- Sets `org_id` and `org_role = "owner"` on the user record via the existing `create_org()` path
- Submission then proceeds normally with the new org's quota

If org auto-creation itself fails (e.g. Cosmos transient error), returns `503` so the user can retry — not a misleading `403`.

Users can rename or share the auto-created org from the account dashboard at any time.

## Tests

- `test_auto_creates_org_for_unaffiliated_user` — verifies `create_org` is called with display name + email, submission returns 200
- `test_auto_create_org_failure_returns_503` — verifies infra failure returns 503, not 403
- `TestUploadTokenSingleGate` — replaces `test_rejects_user_without_org` (now obsolete) with equivalent coverage of auto-create success and failure paths; `reserve_run` still not called on failure path

## Validation

```
1782 passed, 28 skipped
```
