### PR TITLE
security: accept Debian bookworm CVEs pending base image rebuild + daily schedule

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -19,8 +19,9 @@ on:
       - "Dockerfile.base"
       - "scripts/container_smoke_test.py"
   schedule:
-    # Weekly Monday 05:00 UTC — picks up MS image updates and new .NET patches
-    - cron: "0 5 * * 1"
+    # Daily 05:00 UTC — picks up upstream python:3.12-slim-bookworm rebuilds and
+    # new Debian bookworm security fixes within ~24 h of release.
+    - cron: "0 5 * * *"
   workflow_dispatch:
 
 permissions:

--- a/.trivyignore
+++ b/.trivyignore
@@ -42,3 +42,21 @@ CVE-2026-33636 # exp:2026-06-16 libpng16-16 HIGH — tracking #355
 # image build. Upgrade when Microsoft publishes a patched Functions base image.
 CVE-2025-8869 # exp:2026-06-16 pip symlink extraction — medium
 CVE-2026-1703 # exp:2026-06-16 pip path traversal via crafted wheels — low
+
+# Debian bookworm package CVEs — all have fixed versions in the archive.
+# Dockerfile.base runs apt-get upgrade -y; these clear on the next base image rebuild.
+# Base rebuild triggered 2026-05-16. Remove these entries once the rebuilt image deploys.
+#
+# systemd: Arbitrary code execution or DoS via spurious IPC API call data.
+# libsystemd0/libudev1 are present in the Debian base but the systemd IPC attack
+# surface is not reachable inside a container (no systemd daemon running).
+CVE-2026-29111 # exp:2026-05-30 libsystemd0+libudev1 HIGH — fixed in deb12u2, base rebuild pending
+#
+# libcap: Privilege escalation via TOCTOU race in cap_set_file().
+# Application code does not call cap_set_file(); not reachable.
+CVE-2026-4878 # exp:2026-05-30 libcap2 HIGH — fixed in deb12u3, base rebuild pending
+#
+# glibc: Integer overflow in memalign leads to heap corruption.
+# Requires attacker-controlled memalign call size. Not directly reachable
+# via our application but glibc is load-bearing — base rebuild prioritised.
+CVE-2026-0861 # exp:2026-05-30 libc6+libc-bin HIGH — fixed in deb12u14, base rebuild pending


### PR DESCRIPTION
## Summary

Five new HIGH Trivy findings opened on `main` today (2026-05-16) against the deployed container image. All are Debian bookworm packages with fixed versions available in the archive.

### Findings

| CVE | Package(s) | Fixed in | Notes |
|-----|-----------|----------|-------|
| CVE-2026-29111 | `libsystemd0`, `libudev1` | deb12u2 | Arbitrary code execution/DoS via spurious IPC data — no systemd daemon runs in our container |
| CVE-2026-4878 | `libcap2` | deb12u3 | TOCTOU race in `cap_set_file()` — application does not call this |
| CVE-2026-0861 | `libc6`, `libc-bin` | deb12u14 | glibc `memalign` integer overflow — base rebuild prioritised |

### Root cause

`Dockerfile.base` uses `FROM python:3.12-slim-bookworm` and runs `apt-get upgrade -y`. The base image is rebuilt on a **weekly** schedule (Mondays). Debian pushed fixes for all three CVE groups this week — after Monday's rebuild. The 7-day window is the gap.

### This PR

1. **`.trivyignore`** — short 14-day entries (`exp:2026-05-30`) with safety rationale. These are distinct from the Go stdlib CVEs (Microsoft binaries we cannot patch) and from `libpng16` (mirror propagation delay). These ARE fixable; ignores are a temporary hold while the base image rebuild propagates.

2. **`base-image.yml`** — bumps rebuild schedule from weekly (Monday) to **daily (05:00 UTC)**. This reduces the CVE-to-fix window from ≤7 days to ≤24 h. The `apt-get upgrade -y` in `Dockerfile.base` handles any fixes that land between Docker Hub upstream rebuilds of `python:3.12-slim-bookworm`.

A manual `workflow_dispatch` base image rebuild was also triggered separately today so the fixes land in `hardcoreprawn/treesight` without waiting for the next scheduled run.

### After merge

Once the rebuilt base image is deployed and Trivy clears the findings, the three `.trivyignore` entries should be removed (they expire 2026-05-30 as a backstop).
