### PR TITLE
fix(upload): use create_org return value as fallback when Cosmos query lags

### DIFF
--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -318,13 +318,14 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
             email = user_doc.get("email", "")
             display_name = user_doc.get("display_name", "")
             org_name = f"{display_name}'s Organisation" if display_name else "My Organisation"
-            create_org(user_id, name=org_name, email=email)
-            # Re-read to verify the association persisted.  _set_user_org() swallows
-            # its own exceptions, so we cannot trust the return value of create_org().
-            # Re-reading also handles concurrent submissions: if a racing request
-            # already stamped a different org on the user record, we adopt that org
-            # rather than the one we just created, avoiding split reservations.
-            user_org = get_user_org(user_id)
+            new_org = create_org(user_id, name=org_name, email=email)
+            # Re-read to handle concurrent submissions: if a racing request already
+            # stamped a different org on the user record, adopt that org rather than
+            # the one we just created (avoids split reservations).
+            # Fall back to new_org if the membership query lags the write — Cosmos
+            # cross-partition queries can briefly trail a direct upsert, causing
+            # get_user_org's slow path to return None even though the org exists.
+            user_org = get_user_org(user_id) or new_org
             if not user_org:
                 logger.error(
                     "Auto-created org for user=%s but association was not persisted",

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -104,6 +104,7 @@ portfolio-level risk visibility.
 
 | PR | Summary |
 |----|---------|
+| #837 | fix(upload): Cosmos cross-partition query-lag fallback — `create_org` return value captured as `new_org` and used as `user_org` fallback when `get_user_org`'s `ARRAY_CONTAINS` membership query lags behind the write; eliminates residual "Unable to set up your organisation" 503 that survived #836. Updated test to assert 200 (fallback path) instead of 503. |
 | #836 | fix(orgs): repair `_set_user_org` partition-key bug + self-healing `get_user_org` — root cause of "Unable to set up your organisation" 503: legacy user docs missing `user_id` field caused `upsert_item` to raise (Cosmos SDK can't extract `/user_id`), exception swallowed, user doc never stamped. Fix: `setdefault` before upsert (matches `record_user_sign_in`). Also adds membership-query fallback in `get_user_org` to recover when user doc has no org_id, with best-effort doc repair. 5 new tests. 1788 tests passing. |
 | #835 | fix(ci): add `.trivyignore` entries for 3 new Debian bookworm CVEs (exp:2026-05-30) + switch base-image rebuild schedule from weekly to daily — CVEs cleared within ≤24h of Debian publishing fixes. |
 | #833 | fix(ci): extend expired `.trivyignore` entries (exp:2026-05-01/09) to 2026-06-16 — unblocked Deploy workflow after #831 merge; filed #834 for pre-expiry CI warning. |

--- a/tests/test_upload_endpoints.py
+++ b/tests/test_upload_endpoints.py
@@ -276,6 +276,9 @@ class TestUploadToken:
 
         # Should succeed despite query lag — fallback to new_org is used.
         assert resp.status_code == 200
+        # Reserve was called with the fallback org_id from create_org, not an empty/wrong value.
+        self.mock_reserve_run.assert_called_once()
+        assert self.mock_reserve_run.call_args.kwargs["org_id"] == "new-org-1"
 
     def test_auto_create_org_failure_returns_503(self):
         """If org auto-creation fails, return 503 rather than 403."""

--- a/tests/test_upload_endpoints.py
+++ b/tests/test_upload_endpoints.py
@@ -249,16 +249,22 @@ class TestUploadToken:
             "test-user", name="Test User's Organisation", email="t@example.com"
         )
 
-    def test_auto_create_org_association_failure_returns_503(self):
-        """If create_org succeeds but _set_user_org silently failed, return 503."""
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_cosmos_query_lag_falls_back_to_created_org(self, mock_bsc, mock_gen_sas):
+        """If get_user_org returns None after create_org (Cosmos query consistency lag),
+        the org returned by create_org is used as a fallback so the request succeeds."""
         from blueprints.upload import upload_token
 
-        # First call: no org. Second call (verification after create): still no org
-        # because _set_user_org swallowed its failure.
+        new_org = {"org_id": "new-org-1", "name": "Test User's Organisation"}
+        # Both get_user_org calls return None (simulates cross-partition query lag).
+        # The fallback to create_org's return value should carry the request through.
         self.mock_get_user_org.side_effect = [None, None]
+        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
 
         with (
-            patch("blueprints.upload.create_org"),
+            patch("blueprints.upload.create_org", return_value=new_org),
             patch(
                 "treesight.security.users.get_user",
                 return_value={"display_name": "Test User", "email": "t@example.com"},
@@ -268,7 +274,8 @@ class TestUploadToken:
             req = _make_req("/api/upload/token", method="POST")
             resp = upload_token(req)
 
-        assert resp.status_code == 503
+        # Should succeed despite query lag — fallback to new_org is used.
+        assert resp.status_code == 200
 
     def test_auto_create_org_failure_returns_503(self):
         """If org auto-creation fails, return 503 rather than 403."""


### PR DESCRIPTION
## Problem

After merging #836 (which fixed `_set_user_org` and added a self-healing slow path to `get_user_org`), the "Unable to set up your organisation" 503 was still appearing in production on first submission.

## Root cause

`create_org()` return value was discarded. The verification re-read after org creation uses `get_user_org()`, whose slow path runs a **cross-partition `ARRAY_CONTAINS` query** via `list_orgs_for_user()`. Cosmos DB can briefly lag on cross-partition queries following a direct point-write. If the query index hasn't caught up, it returns empty — `get_user_org` returns `None` — 503, even though the org was successfully created and is already in Cosmos.

## Fix

```python
# Before: return value discarded; query lag → still 503
create_org(user_id, ...)
user_org = get_user_org(user_id)

# After: create_org return value used as fallback
new_org = create_org(user_id, ...)
user_org = get_user_org(user_id) or new_org
```

`get_user_org` still runs first — it handles race conditions by adopting any org a concurrent request may have already stamped on the user doc. If the membership query returns `None` due to consistency lag, `new_org` (just written, guaranteed valid) is used instead.

## Test change

`test_auto_create_org_association_failure_returns_503` was testing the old buggy behaviour (both `get_user_org` calls return `None` → 503). Renamed to `test_cosmos_query_lag_falls_back_to_created_org` and updated to verify the correct behaviour: both calls return `None` but `create_org` returns a valid org → request succeeds with 200.

1788 tests passing.
