### PR TITLE
ci(deploy): retry SWA upload once on timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1167,6 +1167,20 @@ jobs:
             's|{"clientId":"","authority":"","tenantId":"","apiAudience":""}|'"${ESCAPED}"'|' {} +
 
       - name: Deploy to Azure Static Web Apps
+        id: swa-deploy
+        continue-on-error: true
+        uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.SWA_DEPLOYMENT_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: upload
+          app_location: /website
+          skip_app_build: true
+
+      # Azure SWA upload can stall with a hard 600s server-side timeout on slow days.
+      # Retry once — the re-upload is fast if the previous attempt partially staged content.
+      - name: Deploy to Azure Static Web Apps (retry on timeout)
+        if: steps.swa-deploy.outcome == 'failure'
         uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.SWA_DEPLOYMENT_TOKEN }}


### PR DESCRIPTION
## Problem

The Azure Static Web Apps deploy action has a hard **600s server-side upload timeout**. On slow Azure infrastructure days the upload stalls and the job fails with:

```
Upload Timed Out. Unsure if deployment was successful or not.
```

This happened during the #837 deploy (run [25968812017](https://github.com/Hardcoreprawn/azure-workflow-for-kml-satellite/actions/runs/25968812017)). The re-run completed in **1m18s** — Azure SWA caches partial staged content so retries are fast.

Our static site upload averages ~8min total job time, leaving only a ~2min margin before the 600s cap.

## Fix

Add a one-retry pattern directly in the workflow — no external action needed:

1. Add `id: swa-deploy` + `continue-on-error: true` to the existing step
2. Add a second identical step with `if: steps.swa-deploy.outcome == 'failure'` — only runs on timeout/failure
3. If both attempts fail (genuine outage), the job still fails as expected

## Notes

- This is a workflow-only change — no code, no tests, no infra
- The retry step only fires on actual failure; happy-path deploys are unaffected