### PR TITLE
docs(roadmap): add #839 to Recently Landed

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,7 @@
 **Single source of truth for what to build next.**
 Issues hold the detail. This list holds the order.
 
-Last updated: 2026-05-16
+Last updated: 2026-05-17
 
 ---
 
@@ -104,6 +104,7 @@ portfolio-level risk visibility.
 
 | PR | Summary |
 |----|---------|
+| #839 | ci(deploy): retry SWA upload once on timeout — adds `continue-on-error: true` to the Azure Static Web Apps deploy step and a second identical retry step (`if: steps.swa-deploy.outcome == 'failure'`) to survive the hard 600s server-side upload timeout seen on slow days. |
 | #837 | fix(upload): Cosmos cross-partition query-lag fallback — `create_org` return value captured as `new_org` and used as `user_org` fallback when `get_user_org`'s `ARRAY_CONTAINS` membership query lags behind the write; eliminates residual "Unable to set up your organisation" 503 that survived #836. Updated test to assert 200 (fallback path) instead of 503. |
 | #836 | fix(orgs): repair `_set_user_org` partition-key bug + self-healing `get_user_org` — root cause of "Unable to set up your organisation" 503: legacy user docs missing `user_id` field caused `upsert_item` to raise (Cosmos SDK can't extract `/user_id`), exception swallowed, user doc never stamped. Fix: `setdefault` before upsert (matches `record_user_sign_in`). Also adds membership-query fallback in `get_user_org` to recover when user doc has no org_id, with best-effort doc repair. 5 new tests. 1788 tests passing. |
 | #835 | fix(ci): add `.trivyignore` entries for 3 new Debian bookworm CVEs (exp:2026-05-30) + switch base-image rebuild schedule from weekly to daily — CVEs cleared within ≤24h of Debian publishing fixes. |


### PR DESCRIPTION
Updates ROADMAP.md: adds PR #839 (SWA deploy retry) to Recently Landed, bumps date to 2026-05-17.