### PR TITLE
ci(deploy): retry ARM PATCH on 409 ConflictingConcurrentWriteNotAllowed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -510,7 +510,7 @@ jobs:
             --argjson ready "$ALWAYS_READY" \
             '{properties:{siteConfig:{cors:{allowedOrigins:$origins,supportCredentials:false}},functionAppConfig:{scaleAndConcurrency:{maximumInstanceCount:$max,alwaysReady:$ready}}}}')
           FUNC_ID=$(az functionapp show --name "$FUNC_NAME" --resource-group "$FUNC_RG" --query id -o tsv)
-          # Retry with backoff: transient ARM 409 can still occur under concurrent platform writes.
+          # Retry with fixed 20s delay: transient ARM 409 can still occur under concurrent platform writes.
           for attempt in 1 2 3; do
             az rest --method PATCH --url "${FUNC_ID}?api-version=2024-04-01" --body "$PATCH_BODY" && break
             [ "$attempt" -lt 3 ] || { echo "❌ PATCH failed after 3 attempts"; exit 1; }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -492,22 +492,11 @@ jobs:
             exit 1
           fi
 
-          FUNC_ID=$(az functionapp show --name "$FUNC_NAME" --resource-group "$FUNC_RG" --query id -o tsv)
-          CORS_BODY=$(jq -cn --argjson origins "$ALLOWED_ORIGINS_JSON" '{properties:{cors:{allowedOrigins:$origins,supportCredentials:false}}}')
-          # ARM returns 409 ConflictingConcurrentWriteNotAllowed when two writes land
-          # on the same resource in quick succession. Retry up to 3 times with backoff.
-          az_patch_with_retry() {
-            local url="$1" body="$2" attempt
-            for attempt in 1 2 3; do
-              if az rest --method PATCH --url "$url" --body "$body"; then return 0; fi
-              [ "$attempt" -lt 3 ] && echo "⚠️  PATCH attempt $attempt failed, retrying in 20s..." && sleep 20
-            done
-            echo "❌ PATCH failed after 3 attempts: $url"; return 1
-          }
-          az_patch_with_retry "${FUNC_ID}/config/web?api-version=2024-04-01" "$CORS_BODY"
-
-          # Apply scaling config from Terraform outputs (body is ignore_changes
-          # in tofu due to the azapi identity bug).
+          # CORS and scaling are combined into a single root-resource PATCH.
+          # Two back-to-back PATCHes on the same entity cause ARM's
+          # ConflictingConcurrentWriteNotAllowed (409). siteConfig.cors is the
+          # root-resource equivalent of /config/web — same data path that tofu
+          # already uses in the initial body.
           MAX_INSTANCES=$(tofu output -raw function_app_cli_maximum_instance_count)
           MIN_INSTANCES=$(tofu output -raw function_app_cli_minimum_instance_count)
           if [ "$MIN_INSTANCES" -gt 0 ]; then
@@ -515,11 +504,19 @@ jobs:
           else
             ALWAYS_READY='[]'
           fi
-          SCALE_BODY=$(jq -cn \
+          PATCH_BODY=$(jq -cn \
+            --argjson origins "$ALLOWED_ORIGINS_JSON" \
             --argjson max "$MAX_INSTANCES" \
             --argjson ready "$ALWAYS_READY" \
-            '{properties:{functionAppConfig:{scaleAndConcurrency:{maximumInstanceCount:$max,alwaysReady:$ready}}}}')
-          az_patch_with_retry "${FUNC_ID}?api-version=2024-04-01" "$SCALE_BODY"
+            '{properties:{siteConfig:{cors:{allowedOrigins:$origins,supportCredentials:false}},functionAppConfig:{scaleAndConcurrency:{maximumInstanceCount:$max,alwaysReady:$ready}}}}')
+          FUNC_ID=$(az functionapp show --name "$FUNC_NAME" --resource-group "$FUNC_RG" --query id -o tsv)
+          # Retry with backoff: transient ARM 409 can still occur under concurrent platform writes.
+          for attempt in 1 2 3; do
+            az rest --method PATCH --url "${FUNC_ID}?api-version=2024-04-01" --body "$PATCH_BODY" && break
+            [ "$attempt" -lt 3 ] || { echo "❌ PATCH failed after 3 attempts"; exit 1; }
+            echo "⚠️  PATCH attempt $attempt failed (transient ARM conflict), retrying in 20s..."
+            sleep 20
+          done
 
           # Verify scaling config applied
           ACTUAL=$(az rest --method GET --url "${FUNC_ID}?api-version=2024-04-01" \
@@ -559,20 +556,7 @@ jobs:
             exit 1
           fi
 
-          ORCH_ID=$(az functionapp show --name "$ORCH_NAME" --resource-group "$FUNC_RG" --query id -o tsv)
-          CORS_BODY=$(jq -cn --argjson origins "$ALLOWED_ORIGINS_JSON" '{properties:{cors:{allowedOrigins:$origins,supportCredentials:false}}}')
-          # ARM returns 409 ConflictingConcurrentWriteNotAllowed when two writes land
-          # on the same resource in quick succession. Retry up to 3 times with backoff.
-          az_patch_with_retry() {
-            local url="$1" body="$2" attempt
-            for attempt in 1 2 3; do
-              if az rest --method PATCH --url "$url" --body "$body"; then return 0; fi
-              [ "$attempt" -lt 3 ] && echo "⚠️  PATCH attempt $attempt failed, retrying in 20s..." && sleep 20
-            done
-            echo "❌ PATCH failed after 3 attempts: $url"; return 1
-          }
-          az_patch_with_retry "${ORCH_ID}/config/web?api-version=2024-04-01" "$CORS_BODY"
-
+          # Single PATCH combining CORS + scaling (same rationale as Configure Function App).
           MAX_INSTANCES=$(tofu output -raw function_app_cli_maximum_instance_count)
           ORCH_MIN_INSTANCES=$(tofu output -raw function_app_orch_minimum_instance_count)
           if [ "$ORCH_MIN_INSTANCES" -gt 0 ]; then
@@ -580,11 +564,18 @@ jobs:
           else
             ALWAYS_READY='[]'
           fi
-          SCALE_BODY=$(jq -cn \
+          PATCH_BODY=$(jq -cn \
+            --argjson origins "$ALLOWED_ORIGINS_JSON" \
             --argjson max "$MAX_INSTANCES" \
             --argjson ready "$ALWAYS_READY" \
-            '{properties:{functionAppConfig:{scaleAndConcurrency:{maximumInstanceCount:$max,alwaysReady:$ready}}}}')
-          az_patch_with_retry "${ORCH_ID}?api-version=2024-04-01" "$SCALE_BODY"
+            '{properties:{siteConfig:{cors:{allowedOrigins:$origins,supportCredentials:false}},functionAppConfig:{scaleAndConcurrency:{maximumInstanceCount:$max,alwaysReady:$ready}}}}')
+          ORCH_ID=$(az functionapp show --name "$ORCH_NAME" --resource-group "$FUNC_RG" --query id -o tsv)
+          for attempt in 1 2 3; do
+            az rest --method PATCH --url "${ORCH_ID}?api-version=2024-04-01" --body "$PATCH_BODY" && break
+            [ "$attempt" -lt 3 ] || { echo "❌ PATCH failed after 3 attempts"; exit 1; }
+            echo "⚠️  PATCH attempt $attempt failed (transient ARM conflict), retrying in 20s..."
+            sleep 20
+          done
 
       - name: Verify Function App config contract
         id: verify-config-contract

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -494,13 +494,20 @@ jobs:
 
           FUNC_ID=$(az functionapp show --name "$FUNC_NAME" --resource-group "$FUNC_RG" --query id -o tsv)
           CORS_BODY=$(jq -cn --argjson origins "$ALLOWED_ORIGINS_JSON" '{properties:{cors:{allowedOrigins:$origins,supportCredentials:false}}}')
-          az rest --method PATCH \
-            --url "${FUNC_ID}/config/web?api-version=2024-04-01" \
-            --body "$CORS_BODY"
+          # ARM returns 409 ConflictingConcurrentWriteNotAllowed when two writes land
+          # on the same resource in quick succession. Retry up to 3 times with backoff.
+          az_patch_with_retry() {
+            local url="$1" body="$2" attempt
+            for attempt in 1 2 3; do
+              if az rest --method PATCH --url "$url" --body "$body"; then return 0; fi
+              [ "$attempt" -lt 3 ] && echo "⚠️  PATCH attempt $attempt failed, retrying in 20s..." && sleep 20
+            done
+            echo "❌ PATCH failed after 3 attempts: $url"; return 1
+          }
+          az_patch_with_retry "${FUNC_ID}/config/web?api-version=2024-04-01" "$CORS_BODY"
 
           # Apply scaling config from Terraform outputs (body is ignore_changes
-          # in tofu due to the azapi identity bug).  Single PATCH to avoid 409
-          # Conflict race between back-to-back updates on the same resource.
+          # in tofu due to the azapi identity bug).
           MAX_INSTANCES=$(tofu output -raw function_app_cli_maximum_instance_count)
           MIN_INSTANCES=$(tofu output -raw function_app_cli_minimum_instance_count)
           if [ "$MIN_INSTANCES" -gt 0 ]; then
@@ -512,9 +519,7 @@ jobs:
             --argjson max "$MAX_INSTANCES" \
             --argjson ready "$ALWAYS_READY" \
             '{properties:{functionAppConfig:{scaleAndConcurrency:{maximumInstanceCount:$max,alwaysReady:$ready}}}}')
-          az rest --method PATCH \
-            --url "${FUNC_ID}?api-version=2024-04-01" \
-            --body "$SCALE_BODY"
+          az_patch_with_retry "${FUNC_ID}?api-version=2024-04-01" "$SCALE_BODY"
 
           # Verify scaling config applied
           ACTUAL=$(az rest --method GET --url "${FUNC_ID}?api-version=2024-04-01" \
@@ -556,9 +561,17 @@ jobs:
 
           ORCH_ID=$(az functionapp show --name "$ORCH_NAME" --resource-group "$FUNC_RG" --query id -o tsv)
           CORS_BODY=$(jq -cn --argjson origins "$ALLOWED_ORIGINS_JSON" '{properties:{cors:{allowedOrigins:$origins,supportCredentials:false}}}')
-          az rest --method PATCH \
-            --url "${ORCH_ID}/config/web?api-version=2024-04-01" \
-            --body "$CORS_BODY"
+          # ARM returns 409 ConflictingConcurrentWriteNotAllowed when two writes land
+          # on the same resource in quick succession. Retry up to 3 times with backoff.
+          az_patch_with_retry() {
+            local url="$1" body="$2" attempt
+            for attempt in 1 2 3; do
+              if az rest --method PATCH --url "$url" --body "$body"; then return 0; fi
+              [ "$attempt" -lt 3 ] && echo "⚠️  PATCH attempt $attempt failed, retrying in 20s..." && sleep 20
+            done
+            echo "❌ PATCH failed after 3 attempts: $url"; return 1
+          }
+          az_patch_with_retry "${ORCH_ID}/config/web?api-version=2024-04-01" "$CORS_BODY"
 
           MAX_INSTANCES=$(tofu output -raw function_app_cli_maximum_instance_count)
           ORCH_MIN_INSTANCES=$(tofu output -raw function_app_orch_minimum_instance_count)
@@ -571,9 +584,7 @@ jobs:
             --argjson max "$MAX_INSTANCES" \
             --argjson ready "$ALWAYS_READY" \
             '{properties:{functionAppConfig:{scaleAndConcurrency:{maximumInstanceCount:$max,alwaysReady:$ready}}}}')
-          az rest --method PATCH \
-            --url "${ORCH_ID}?api-version=2024-04-01" \
-            --body "$SCALE_BODY"
+          az_patch_with_retry "${ORCH_ID}?api-version=2024-04-01" "$SCALE_BODY"
 
       - name: Verify Function App config contract
         id: verify-config-contract


### PR DESCRIPTION
## Problem

The `Configure Function App` step fails intermittently with:
```
ERROR: Operation returned an invalid status 'Conflict'
ConflictingConcurrentWriteNotAllowed: The operation was interrupted by a
conflicting concurrent write on the same entity. Please retry later.
```

This happens because two back-to-back `az rest PATCH` calls land on the same
Function App resource (CORS to `/config/web`, then scaling to the root resource).
Azure ARM serialises writes per entity and returns 409 when the second write
arrives before the first is committed.

The Orchestrator Function App step has the same pattern and the same exposure.

## Fix

Add `az_patch_with_retry()` in both configure steps: retries the `az rest PATCH`
up to 3 times with a 20 s sleep between attempts before propagating failure.

Closes #841 (if created) or tracked as fix for deploy run 25976040709.