### PR TITLE
fix: layout flash and org 503 on first-time upload

### DIFF
--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -177,6 +177,28 @@ def _resolve_provider(body: dict, submission_context: dict) -> str:
     return submission_context.get("provider_name", DEFAULT_PROVIDER)
 
 
+def _create_org_with_retry(user_id: str, org_name: str, email: str) -> dict:
+    """Call create_org with one retry on transient Cosmos failures."""
+    import time
+
+    last_exc: Exception | None = None
+    for attempt in range(2):
+        try:
+            return create_org(user_id, name=org_name, email=email)
+        except Exception as exc:
+            last_exc = exc
+            logger.warning(
+                "create_org attempt %d failed for user=%s: %s: %s",
+                attempt + 1,
+                _redact(user_id),
+                type(exc).__name__,
+                exc,
+            )
+            if attempt == 0:
+                time.sleep(0.5)
+    raise last_exc  # type: ignore[misc]
+
+
 def _build_ticket(body: dict, user_id: str, submission_context: dict, org_id: str = "") -> dict:
     """Assemble the ticket blob payload from request body and user metadata."""
     ticket: dict = {
@@ -318,7 +340,7 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
             email = user_doc.get("email", "")
             display_name = user_doc.get("display_name", "")
             org_name = f"{display_name}'s Organisation" if display_name else "My Organisation"
-            new_org = create_org(user_id, name=org_name, email=email)
+            new_org = _create_org_with_retry(user_id, org_name, email)
             # Re-read to handle concurrent submissions: if a racing request already
             # stamped a different org on the user record, adopt that org rather than
             # the one we just created (avoids split reservations).

--- a/website/js/app-msal.js
+++ b/website/js/app-msal.js
@@ -47,6 +47,7 @@
   var _clearClientAuth = null;
   var _setAnalysisStatus = null;
   var _setGetToken = null; // wire getToken into the API client
+  var _applyFirstRunLayout = null;
 
   // ── MSAL primitives delegated to window.CanopexCiam (canopex-auth.js) ──
   if (!window.CanopexCiam) {
@@ -109,6 +110,7 @@
     _setAnalysisStatus = deps.setAnalysisStatus;
     // New dep: wire getToken into the API client so apiFetch can call it.
     _setGetToken = deps.setGetToken;
+    _applyFirstRunLayout = deps.applyFirstRunLayout;
     if (_setGetToken) {
       _setGetToken(getToken);
     }
@@ -234,7 +236,7 @@
     }
     if (elements.analysisAuthGate) elements.analysisAuthGate.hidden = true;
     if (elements.analysisFormFields) elements.analysisFormFields.hidden = false;
-    if (elements.historyCard) elements.historyCard.hidden = false;
+    if (_applyFirstRunLayout) _applyFirstRunLayout();
 
     if (!historyLoaded && !latestRun) {
       if (_setHeroRunSummary) _setHeroRunSummary('Checking recent runs', 'Loading your recent runs.');

--- a/website/js/app-run-lifecycle.js
+++ b/website/js/app-run-lifecycle.js
@@ -367,9 +367,8 @@
     var activeRunPill = document.getElementById('app-hero-active-run');
     if (!firstRun) return;
 
-    var historyLoaded = _d.getAnalysisHistoryLoaded ? _d.getAnalysisHistoryLoaded() : false;
     var historyRuns = _d.getAnalysisHistoryRuns ? _d.getAnalysisHistoryRuns() : [];
-    var isEmpty = historyLoaded && historyRuns.length === 0 && !latestAnalysisRun;
+    var isEmpty = historyRuns.length === 0 && !latestAnalysisRun;
     firstRun.hidden = !isEmpty;
     if (evidenceHero) evidenceHero.hidden = isEmpty;
 
@@ -636,7 +635,6 @@
       if (_d.clearCacheKey) { _d.clearCacheKey('history'); _d.clearCacheKey('billing'); }
       var data = { instance_id: submissionId };
       if (_d.setAnalysisHistoryLoaded) _d.setAnalysisHistoryLoaded(true);
-      applyFirstRunLayout();
       var queuedAt = new Date().toISOString();
       upsertHistoryRun({
         instanceId: data.instance_id,

--- a/website/js/app-shell.js
+++ b/website/js/app-shell.js
@@ -443,6 +443,7 @@
       postLoginDestinationKey: POST_LOGIN_DESTINATION_KEY,
       setAnalysisStatus: setAnalysisStatus,
       clearAnalysisState: runtimeModule.clearAnalysisState,
+      applyFirstRunLayout: runLifecycleModule.applyFirstRunLayout,
     });
   }
 


### PR DESCRIPTION
## Problem

Two UX bugs reported after the Stage 2C deploy:

### 1. Layout keeps switching between 1-column and 2-column

**Root cause**: Two issues combined:
- `renderSignedInUI` in `app-msal.js` unconditionally set `historyCard.hidden = false`, forcing the 2-column layout to show with an empty history rail before history was loaded
- `applyFirstRunLayout`'s `isEmpty` formula gated on `historyLoaded`, so it returned `isEmpty = false` (2-col) on every call before history loaded, meaning the 2-col flash couldn't be corrected until the API response arrived

**Result**: every page load for a first-time user (or any user with no cache) showed: 2-col empty layout → single-col first-run hero, once per load. Since the user was reloading repeatedly due to the org error, they saw this on every attempt.

### 2. "Unable to set up your organisation" 503

**Root cause**: `create_org()` calls `upsert_item("orgs", doc)` which can throw a Cosmos exception (transient throttle / cold-start timeout). That exception propagates out of `create_org` and is caught by `upload_token`'s outer `except Exception`, returning 503.

This is a first-time user path — only fires once per user if Cosmos is under load or cold.

---

## Changes

### `website/js/app-run-lifecycle.js`
- **`applyFirstRunLayout`**: Remove `historyLoaded` gate from `isEmpty`. New formula: `historyRuns.length === 0 && !latestAnalysisRun`. Layout now defaults to single-column (first-run hero, showing "Checking recent runs") until history is confirmed to have content.
- **`queueAnalysis`**: Remove premature standalone `applyFirstRunLayout()` call before `upsertHistoryRun` — `upsertHistoryRun` calls it anyway.

### `website/js/app-msal.js`
- Add `_applyFirstRunLayout` dep var and wire from `init()`
- **`renderSignedInUI`**: Replace `historyCard.hidden = false` with `if (_applyFirstRunLayout) _applyFirstRunLayout()`. This applies correct layout (1-col for new users, 2-col for returning users whose cache has already populated `historyRuns`) immediately on sign-in instead of forcing 2-col unconditionally.

### `website/js/app-shell.js`
- Pass `applyFirstRunLayout: runLifecycleModule.applyFirstRunLayout` into `authModule.init()`.

### `blueprints/upload.py`
- Extract `_create_org_with_retry(user_id, org_name, email)` helper: attempts `create_org` up to 2 times (0.5s pause between attempts) to survive transient Cosmos throttles and cold-start timeouts.
- Logs `type(exc).__name__` and message on each failed attempt — this makes Log Analytics KQL able to surface the exact exception class (e.g. `CosmosHttpResponseError`, 429, ServiceUnavailable) once the retry path is exercised in production.
- `upload_token` complexity drops back below threshold by calling the helper instead of inlining the loop.

---

## Validation

- `ruff check blueprints/upload.py` — clean
- `pytest tests/` — 1788 passed, 28 skipped

---

## Log Analytics KQL (for diagnosing org errors after deploy)

Run these in Azure Monitor → Logs against the App Insights workspace:

```kql
// Find all auto-create org failures and their exception types
traces
| where timestamp > ago(4h)
| where message has "create_org attempt" or message has "Failed to auto-create org"
| project timestamp, message, customDimensions, severityLevel
| order by timestamp desc
| take 30
```

```kql
// Find the underlying Cosmos exception type
exceptions
| where timestamp > ago(4h)
| where operation_Name has "upload"
| project timestamp, type, outerType, outerMessage, innermostType, innermostMessage, customDimensions
| order by timestamp desc
| take 20
```

```kql
// Cosmos-specific errors (429 throttle, 503, etc.)
traces
| where timestamp > ago(4h)
| where message has "RequestRateTooLarge" or message has "CosmosHttpResponseError" or message has "ServiceUnavailable"
| project timestamp, message, severityLevel, customDimensions
| order by timestamp desc
| take 20
```

If the retry fix resolves the 503, you'll see `create_org attempt 1 failed` warnings followed by successful `Auto-created personal org` info lines. If it still fails after the retry, the exception class in the warning will pinpoint the root cause.
