### PR TITLE
fix(infra): add missing orgs Cosmos container

### DIFF
--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -721,6 +721,39 @@ resource "azurerm_cosmosdb_sql_container" "catalogue" {
   }
 }
 
+resource "azurerm_cosmosdb_sql_container" "orgs" {
+  count               = var.enable_cosmos_db ? 1 : 0
+  name                = "orgs"
+  resource_group_name = azurerm_resource_group.main.name
+  account_name        = azurerm_cosmosdb_account.main[0].name
+  database_name       = azurerm_cosmosdb_sql_database.main[0].name
+  partition_key_paths = ["/org_id"]
+
+  # Queries served:
+  #   O1: Point read by (org_id, org_id) — get_org fast path
+  #   O2: Cross-partition ARRAY_CONTAINS(c.members, {"user_id": @uid}, true) — list_orgs_for_user
+  #   O3: Upsert by org_id — create_org, add_member, remove_member, reserve_run
+  indexing_policy {
+    indexing_mode = "consistent"
+
+    included_path {
+      path = "/doc_type/?"
+    }
+
+    included_path {
+      path = "/members/[]/user_id/?"
+    }
+
+    included_path {
+      path = "/created_at/?"
+    }
+
+    excluded_path {
+      path = "/*"
+    }
+  }
+}
+
 resource "azurerm_container_app_environment" "main" {
   name                       = local.names.container_apps_environment
   location                   = azurerm_resource_group.main.location


### PR DESCRIPTION
## Root cause

The `orgs` Cosmos DB container was **never provisioned**. It exists in code (`orgs.py`, `billing/accounting.py`, `eudr_billing.py`) but was absent from `infra/tofu/main.tf`. This means:

- `upsert_item("orgs", doc)` → `CosmosResourceNotFoundError` → create_org fails
- `reserve_run` reads the org document → also fails
- All org management endpoints (member CRUD, etc.) fail silently or with 503

This is the **true root cause** of the persistent "Unable to set up your organisation" 503. Previous PRs (#836, #837, #843) retried and papered over the error but couldn't fix a missing container.

## Change

Add `azurerm_cosmosdb_sql_container.orgs` to `main.tf`:

- Partition key: `/org_id` (matches `create_org` document structure)
- Index: `doc_type`, `members[]/user_id` (supports `list_orgs_for_user` ARRAY_CONTAINS query), `created_at`

## ⚠️ Immediate action

This is an infra-only PR — it will apply when the Deploy workflow runs on merge. If the error needs to be fixed **before merge**, create the container manually in the Azure Portal:

1. Open the Cosmos DB account → Data Explorer
2. New Container → Database: `treesight`, Container ID: `orgs`, Partition key: `/org_id`

## Validation

- `tofu validate` — passes
- No Python changes; no tests needed for the container definition itself
