### PR TITLE
fix: declare appRuns in app-history-ui.js to prevent ReferenceError

### DIFF
--- a/website/js/app-history-ui.js
+++ b/website/js/app-history-ui.js
@@ -138,6 +138,7 @@
   // Load history payload, apply selection logic, update UI.
 
   function applyAnalysisHistory(payload, options) {
+    var appRuns = window.CanopexAppRuns || {};
     options = options || {};
     var readRunSelectionFromLocation = _d.readRunSelectionFromLocation || function() { return { instanceId: '' }; };
     var locationSelection = readRunSelectionFromLocation();
@@ -241,6 +242,7 @@
   }
 
   function historyRunIsActive(run) {
+    var appRuns = window.CanopexAppRuns || {};
     if (typeof appRuns.isRunActive === 'function') {
       return appRuns.isRunActive(run);
     }


### PR DESCRIPTION
## Root cause

`historyRunIsActive()` and `applyAnalysisHistory()` in `app-history-ui.js` referenced `appRuns` as a free variable. Under `'use strict'` this throws `ReferenceError: appRuns is not defined`.

### Call chain that produced "Could not queue analysis request."

```
queueAnalysis()
  → upsertHistoryRun()          ← adds new run to history list
  → _d.selectAnalysisRun()      ← calls app-history-ui selectAnalysisRun
    → renderAnalysisHistoryList()
      → historyRunIsActive(run)
        → appRuns.isRunActive() ← ReferenceError: appRuns is not defined
  → caught by outer catch(err)
  → setAnalysisStatus('Could not queue analysis request.', 'error')
```

Root cause confirmed via `AppExceptions` table in Log Analytics (`log-kmlsat-dev`):
```
ReferenceError: appRuns is not defined   2026-05-17T22:15:13Z
```

## Fix

Add `var appRuns = window.CanopexAppRuns || {};` at the top of both affected functions, matching the pattern already used in `app-run-lifecycle.js`.

## Impact

- Submission was actually succeeding (KML uploaded, orchestrator triggered) but the UI threw before showing the success message
- No backend changes required
- No server-side regression risk

## Testing

- No JS test suite for the vanilla website
- Manually verify: after merge + deploy, "Confirm & Queue" should complete without error and show "Analysis queued."