### PR TITLE
feat(rollout): generalised feature flag evaluator — Phase 1 (#403)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,7 +24,7 @@ not at the bottom.
 | 7 | #758 | — | feat(infra): Container Apps Jobs for GDAL compute — near-zero idle cost — **Stage 2E.6** | ❌ Closed — compute FA already £0 at idle (Consumption plan, alwaysReady=0); CAJ adds complexity without cost benefit |
 | 8 | #535 | — | fix: live Stripe billing flow verification on production — Stage 2D.R3 | ✅ Closed |
 | 9 | #708 | #763 | fix(release): full e2e production smoke gate as promotion blocker (execution slice for #403) — Slice A | ✅ #763 |
-| 10 | #403 | — | fix: smoke gates + promotion/demotion — Stage 2E.4 | Open |
+| 10 | #403 | #848 | feat(rollout): generalised feature flag evaluator — Phase 1 ✅ #848; Phases 2–3 open — Stage 2E.4 | In Progress |
 | 11 | #764 | — | ux: client-side cold start masking (warm on load, retry, loading states) — Stage 3.1 | Open |
 | 12 | #400 | — | feat: pipeline run telemetry — Stage 3.2 | Open |
 | 13 | #399 | — | feat: pipeline ETA estimator (needs #400) — Stage 3.3 | Open |
@@ -104,12 +104,12 @@ portfolio-level risk visibility.
 
 | PR | Summary |
 |----|---------|
+| #848 | feat(rollout): generalised feature flag evaluator Phase 1 (#403) — `is_feature_enabled()` with 7-rule fail-closed evaluation order (kill_switch, missing doc, per-user override with expiry, off/blocked, preview_only, percentage_rollout, on); deterministic sha256 bucketing; 2 new Cosmos containers (`feature_flags`, `feature_flag_overrides`); 2 operator scripts; 31 tests. Phases 2 (smoke evidence) and 3 (scheduled controller) remain open on #403. |
 | #847 | chore(infra): cost quick wins — set `orch_min_instances=0` (orchestrator scales to zero, saves ~£18/month idle), `log_retention_days=31` (free-tier window, saves ~£5/month), explicit `function_min_instances=0` to prevent drift. Requires `tofu apply` after merge. |
 | #845 | fix(js): declare `appRuns` in `app-history-ui.js` — `historyRunIsActive()` and `applyAnalysisHistory()` referenced `appRuns` as a free variable; under `'use strict'` this throws `ReferenceError`. Root cause of "Could not queue analysis request." error: `queueAnalysis()→upsertHistoryRun()→selectAnalysisRun()→renderAnalysisHistoryList()→historyRunIsActive()→ReferenceError→catch→error message`. Submission was succeeding on the backend; the UI was throwing before showing success. Confirmed via `AppExceptions` in Log Analytics. |
 | #844 | fix(infra): add missing `orgs` Cosmos container — container was never provisioned, causing every `upsert_item("orgs", ...)` call to raise `CosmosResourceNotFoundError`. Breaks org auto-create on first upload, billing `reserve_run`, and all org management endpoints. Container uses `/org_id` partition key with composite indexes for `doc_type`, `members[]/user_id`, and `created_at`. Root cause of persistent 503 "Unable to set up your organisation". |
 | #843 | fix(ux): layout flash + org 503 on first sign-in — drop `historyLoaded` gate from `applyFirstRunLayout`, thread `applyFirstRunLayout` into `app-msal.js` `renderSignedInUI` (replaces unconditional `historyCard.hidden=false`), remove redundant pre-`upsertHistoryRun` call in `queueAnalysis`. Backend: `_create_org_with_retry` (1 retry, 0.5s backoff) with typed exception logging on `upload_token` org auto-create path. 1788 tests passing. |
 | #841 | ci(deploy): fix ARM 409 ConflictingConcurrentWriteNotAllowed — consolidates CORS (`siteConfig.cors`) and scaling (`functionAppConfig.scaleAndConcurrency`) into a single root-resource PATCH per Function App, eliminating the race between two back-to-back writes on the same entity. Adds an inline 3-attempt retry loop (20s fixed delay) as a safety net for unrelated transient platform conflicts. Applied to both Configure Function App and Configure Orchestrator Function App steps. |
-| #839 | ci(deploy): retry SWA upload once on timeout — adds `continue-on-error: true` to the Azure Static Web Apps deploy step and a second identical retry step (`if: steps.swa-deploy.outcome == 'failure'`) to survive the hard 600s server-side upload timeout seen on slow days. |
 
 ---
 

--- a/infra/tofu/main.tf
+++ b/infra/tofu/main.tf
@@ -754,6 +754,57 @@ resource "azurerm_cosmosdb_sql_container" "orgs" {
   }
 }
 
+resource "azurerm_cosmosdb_sql_container" "feature_flags" {
+  count               = var.enable_cosmos_db ? 1 : 0
+  name                = "feature_flags"
+  resource_group_name = azurerm_resource_group.main.name
+  account_name        = azurerm_cosmosdb_account.main[0].name
+  database_name       = azurerm_cosmosdb_sql_database.main[0].name
+  partition_key_paths = ["/feature_name"]
+
+  # Queries served:
+  #   F1: Point read by (feature_name, feature_name) — is_feature_enabled fast path
+  #   F2: List all flags — operator tooling / smoke validation
+  indexing_policy {
+    indexing_mode = "consistent"
+
+    included_path {
+      path = "/status/?"
+    }
+
+    included_path {
+      path = "/kill_switch/?"
+    }
+
+    excluded_path {
+      path = "/*"
+    }
+  }
+}
+
+resource "azurerm_cosmosdb_sql_container" "feature_flag_overrides" {
+  count               = var.enable_cosmos_db ? 1 : 0
+  name                = "feature_flag_overrides"
+  resource_group_name = azurerm_resource_group.main.name
+  account_name        = azurerm_cosmosdb_account.main[0].name
+  database_name       = azurerm_cosmosdb_sql_database.main[0].name
+  partition_key_paths = ["/user_id"]
+
+  # Queries served:
+  #   OV1: Point read by (user_id, user_id) — per-user override lookup in is_feature_enabled
+  indexing_policy {
+    indexing_mode = "consistent"
+
+    included_path {
+      path = "/user_id/?"
+    }
+
+    excluded_path {
+      path = "/*"
+    }
+  }
+}
+
 resource "azurerm_container_app_environment" "main" {
   name                       = local.names.container_apps_environment
   location                   = azurerm_resource_group.main.location

--- a/scripts/feature_flag_override.py
+++ b/scripts/feature_flag_override.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Manage per-user feature flag overrides in the ``feature_flag_overrides`` container.
+
+Usage::
+
+    # Grant preview access
+    python scripts/feature_flag_override.py \\
+        --user-id user@example.com \\
+        --feature scheduled-monitoring-v2 \\
+        --enable \\
+        [--updated-by "operator-name"]
+
+    # Revoke preview access
+    python scripts/feature_flag_override.py \\
+        --user-id user@example.com \\
+        --feature scheduled-monitoring-v2 \\
+        --disable
+
+    # Remove the override entirely (revert to flag-level status)
+    python scripts/feature_flag_override.py \\
+        --user-id user@example.com \\
+        --feature scheduled-monitoring-v2 \\
+        --clear
+
+Required environment variables::
+
+    COSMOS_ENDPOINT       — e.g. https://cosmos-kmlsat-prd.documents.azure.com:443/
+    COSMOS_DATABASE_NAME  — e.g. canopex
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import UTC, datetime
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Manage Canopex feature flag overrides.")
+    p.add_argument("--user-id", required=True, help="User ID to override")
+    p.add_argument("--feature", required=True, help="Feature name (slug)")
+
+    action = p.add_mutually_exclusive_group(required=True)
+    action.add_argument("--enable", action="store_true", help="Enable feature for this user")
+    action.add_argument("--disable", action="store_true", help="Disable feature for this user")
+    action.add_argument(
+        "--clear", action="store_true", help="Remove override (reverts to flag-level status)"
+    )
+
+    p.add_argument(
+        "--updated-by", default="operator", help="Identity performing the update (audit field)"
+    )
+    p.add_argument("--dry-run", action="store_true", help="Print the resulting document; no write")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    endpoint = os.environ.get("COSMOS_ENDPOINT", "")
+    db_name = os.environ.get("COSMOS_DATABASE_NAME", "canopex")
+    if not endpoint:
+        print("ERROR: COSMOS_ENDPOINT environment variable is not set.", file=sys.stderr)
+        sys.exit(1)
+
+    from azure.cosmos import CosmosClient
+    from azure.cosmos.exceptions import CosmosResourceNotFoundError
+    from azure.identity import DefaultAzureCredential
+
+    credential = DefaultAzureCredential()
+    client = CosmosClient(endpoint, credential=credential)
+    db = client.get_database_client(db_name)
+    container = db.get_container_client("feature_flag_overrides")
+
+    # Fetch existing doc (or start fresh)
+    try:
+        doc = container.read_item(item=args.user_id, partition_key=args.user_id)
+    except CosmosResourceNotFoundError:
+        doc = {
+            "id": args.user_id,
+            "user_id": args.user_id,
+            "features": {},
+        }
+
+    now = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    doc["updated_at"] = now
+    doc["updated_by"] = args.updated_by
+
+    if args.clear:
+        doc["features"].pop(args.feature, None)
+        action_label = "cleared"
+    elif args.enable:
+        doc["features"][args.feature] = {"enabled": True}
+        action_label = "enabled"
+    else:  # --disable
+        doc["features"][args.feature] = {"enabled": False}
+        action_label = "disabled"
+
+    if args.dry_run:
+        import json
+
+        print(json.dumps(doc, indent=2))
+        return
+
+    container.upsert_item(doc)
+    print(f"{action_label} feature '{args.feature}' for user '{args.user_id}'")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/feature_flag_override.py
+++ b/scripts/feature_flag_override.py
@@ -25,7 +25,7 @@ Usage::
 Required environment variables::
 
     COSMOS_ENDPOINT       — e.g. https://cosmos-kmlsat-prd.documents.azure.com:443/
-    COSMOS_DATABASE_NAME  — e.g. canopex
+    COSMOS_DATABASE_NAME  — e.g. treesight
 """
 
 from __future__ import annotations
@@ -59,7 +59,7 @@ def main() -> None:
     args = parse_args()
 
     endpoint = os.environ.get("COSMOS_ENDPOINT", "")
-    db_name = os.environ.get("COSMOS_DATABASE_NAME", "canopex")
+    db_name = os.environ.get("COSMOS_DATABASE_NAME", "treesight")
     if not endpoint:
         print("ERROR: COSMOS_ENDPOINT environment variable is not set.", file=sys.stderr)
         sys.exit(1)

--- a/scripts/feature_flag_upsert.py
+++ b/scripts/feature_flag_upsert.py
@@ -20,7 +20,7 @@ ensure the executing identity has the Cosmos DB Built-in Data Contributor role.
 Required environment variables::
 
     COSMOS_ENDPOINT  — e.g. https://cosmos-kmlsat-prd.documents.azure.com:443/
-    COSMOS_DATABASE_NAME — e.g. canopex
+    COSMOS_DATABASE_NAME — e.g. treesight
 """
 
 from __future__ import annotations
@@ -60,7 +60,7 @@ def main() -> None:
     args = parse_args()
 
     endpoint = os.environ.get("COSMOS_ENDPOINT", "")
-    db_name = os.environ.get("COSMOS_DATABASE_NAME", "canopex")
+    db_name = os.environ.get("COSMOS_DATABASE_NAME", "treesight")
     if not endpoint:
         print("ERROR: COSMOS_ENDPOINT environment variable is not set.", file=sys.stderr)
         sys.exit(1)

--- a/scripts/feature_flag_upsert.py
+++ b/scripts/feature_flag_upsert.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Upsert a feature flag document into the ``feature_flags`` Cosmos container.
+
+Usage::
+
+    python scripts/feature_flag_upsert.py \\
+        --feature scheduled-monitoring-v2 \\
+        --status preview_only \\
+        [--rollout-pct 0] \\
+        [--kill-switch] \\
+        [--allow-anonymous] \\
+        [--description "Next iteration of scheduled monitoring"] \\
+        [--updated-by "operator-name"]
+
+Status values: off | preview_only | percentage_rollout | on | blocked
+
+Authentication: Uses DefaultAzureCredential. Run ``az login`` locally or
+ensure the executing identity has the Cosmos DB Built-in Data Contributor role.
+
+Required environment variables::
+
+    COSMOS_ENDPOINT  — e.g. https://cosmos-kmlsat-prd.documents.azure.com:443/
+    COSMOS_DATABASE_NAME — e.g. canopex
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import UTC, datetime
+
+VALID_STATUSES = frozenset(["off", "preview_only", "percentage_rollout", "on", "blocked"])
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Upsert a Canopex feature flag.")
+    p.add_argument("--feature", required=True, help="Feature name (slug, e.g. my-feature-v2)")
+    p.add_argument(
+        "--status",
+        required=True,
+        choices=sorted(VALID_STATUSES),
+        help="Desired rollout status",
+    )
+    p.add_argument("--rollout-pct", type=int, default=0, help="Percentage (0-100, default 0)")
+    p.add_argument("--kill-switch", action="store_true", help="Activate kill switch")
+    p.add_argument(
+        "--allow-anonymous", action="store_true", help="Allow anonymous (unauthenticated) access"
+    )
+    p.add_argument("--description", default="", help="Human-readable description")
+    p.add_argument(
+        "--updated-by", default="operator", help="Identity performing the update (audit field)"
+    )
+    p.add_argument("--dry-run", action="store_true", help="Print the document; do not write")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    endpoint = os.environ.get("COSMOS_ENDPOINT", "")
+    db_name = os.environ.get("COSMOS_DATABASE_NAME", "canopex")
+    if not endpoint:
+        print("ERROR: COSMOS_ENDPOINT environment variable is not set.", file=sys.stderr)
+        sys.exit(1)
+
+    if not 0 <= args.rollout_pct <= 100:
+        print("ERROR: --rollout-pct must be between 0 and 100.", file=sys.stderr)
+        sys.exit(1)
+
+    now = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    doc = {
+        "id": args.feature,
+        "feature_name": args.feature,
+        "status": args.status,
+        "kill_switch": args.kill_switch,
+        "preview_enabled": args.status == "preview_only",
+        "rollout_pct": args.rollout_pct,
+        "allow_anonymous": args.allow_anonymous,
+        "description": args.description,
+        "updated_at": now,
+        "updated_by": args.updated_by,
+    }
+
+    if args.dry_run:
+        print(json.dumps(doc, indent=2))
+        return
+
+    from azure.cosmos import CosmosClient
+    from azure.identity import DefaultAzureCredential
+
+    credential = DefaultAzureCredential()
+    client = CosmosClient(endpoint, credential=credential)
+    db = client.get_database_client(db_name)
+    container = db.get_container_client("feature_flags")
+    result = container.upsert_item(doc)
+    print(f"Upserted: {result['id']} — status={result['status']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -130,14 +130,14 @@ class TestMissingDoc:
         from treesight.security.rollout import is_feature_enabled
 
         flag = _make_flag(status="on")
-        # Override read blows up; should still fail closed on the override path
-        # but continue to evaluate (no override means fall through to status).
+        # Override read blows up; per spec §6, any storage read failure
+        # must fail closed — the exception propagates and is_feature_enabled
+        # catches it, logs feature_eval_failed, and returns False.
         with (
             patch.object(r, "_read_flag", return_value=flag),
             patch.object(r, "_read_override", side_effect=Exception("cosmos down")),
         ):
-            # flag is "on" and override is unreadable → treat as no override → enabled
-            assert is_feature_enabled(FEATURE, USER) is True
+            assert is_feature_enabled(FEATURE, USER) is False
 
 
 # ---------------------------------------------------------------------------
@@ -171,6 +171,39 @@ class TestPerUserOverride:
         override = _make_override(USER, "other-feature", enabled=True)
         p1, p2 = _patch_flag(flag, override)
         with p1, p2:
+            assert is_feature_enabled(FEATURE, USER) is False
+
+    def test_expired_override_is_ignored(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="off")
+        # Override says enabled=True but expired in 2020.
+        expired_override = {
+            "id": USER,
+            "user_id": USER,
+            "features": {
+                FEATURE: {"enabled": True, "expires_at": "2020-01-01T00:00:00+00:00"},
+            },
+        }
+        p1, p2 = _patch_flag(flag, expired_override)
+        with p1, p2:
+            # Expired override is treated as absent → falls through to status=off.
+            assert is_feature_enabled(FEATURE, USER) is False
+
+    def test_malformed_expires_at_is_treated_as_absent(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="off")
+        bad_override = {
+            "id": USER,
+            "user_id": USER,
+            "features": {
+                FEATURE: {"enabled": True, "expires_at": "not-a-date"},
+            },
+        }
+        p1, p2 = _patch_flag(flag, bad_override)
+        with p1, p2:
+            # Malformed expires_at → override ignored (fail-closed) → flag=off.
             assert is_feature_enabled(FEATURE, USER) is False
 
     def test_no_override_falls_through(self):
@@ -337,6 +370,16 @@ class TestPercentageRollout:
         p1, p2 = _patch_flag(flag, override)
         with p1, p2:
             assert is_feature_enabled(FEATURE, uid) is True
+
+    def test_rollout_pct_above_100_is_rejected(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        # A malformed flag document with rollout_pct > 100 must fail closed
+        # rather than silently enabling every bucket.
+        flag = _make_flag(status="percentage_rollout", rollout_pct=101)
+        p1, p2 = _patch_flag(flag, None)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, USER) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -1,0 +1,394 @@
+"""Tests for the generalised feature flag evaluator (treesight.security.rollout).
+
+Spec reference: docs/PRODUCTION_ROLLOUT_SPEC.md §6 Feature Evaluation Rules.
+
+Evaluation order (strict):
+  1. kill_switch → disabled
+  2. missing/unreadable doc → disabled
+  3. valid per-user override → override decision
+  4. status off/blocked → disabled
+  5. status preview_only → enabled only for explicit preview overrides
+  6. status percentage_rollout → deterministic bucket check
+  7. status on → enabled
+"""
+
+from __future__ import annotations
+
+import hashlib
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _bucket(feature_name: str, user_id: str) -> int:
+    """Reproduce the spec §6.3 bucketing formula."""
+    h = hashlib.sha256(f"{feature_name}:{user_id}".encode()).hexdigest()
+    return int(h, 16) % 100
+
+
+def _make_flag(status: str = "on", **kwargs) -> dict:
+    base = {
+        "id": "test-feature",
+        "feature_name": "test-feature",
+        "status": status,
+        "kill_switch": False,
+        "preview_enabled": False,
+        "rollout_pct": 0,
+        "allow_anonymous": False,
+    }
+    base.update(kwargs)
+    return base
+
+
+def _make_override(user_id: str, feature_name: str, enabled: bool) -> dict:
+    return {
+        "id": user_id,
+        "user_id": user_id,
+        "features": {
+            feature_name: {"enabled": enabled},
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / patches
+# ---------------------------------------------------------------------------
+
+
+FEATURE = "test-feature"
+USER = "user-abc"
+
+
+def _patch_flag(flag_doc, override_doc=None):
+    """Context manager that patches the two Cosmos reads used by is_feature_enabled."""
+    from treesight.security import rollout as r
+
+    def fake_read_flag(name):
+        return flag_doc
+
+    def fake_read_override(user_id):
+        return override_doc
+
+    return (
+        patch.object(r, "_read_flag", side_effect=fake_read_flag),
+        patch.object(r, "_read_override", side_effect=fake_read_override),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule 1: kill_switch
+# ---------------------------------------------------------------------------
+
+
+class TestKillSwitch:
+    def test_kill_switch_disables_even_when_on(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="on", kill_switch=True)
+        p1, p2 = _patch_flag(flag)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, USER) is False
+
+    def test_no_kill_switch_allows_on(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="on", kill_switch=False)
+        p1, p2 = _patch_flag(flag)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, USER) is True
+
+
+# ---------------------------------------------------------------------------
+# Rule 2: missing / unreadable document → disabled (fail closed)
+# ---------------------------------------------------------------------------
+
+
+class TestMissingDoc:
+    def test_missing_flag_returns_false(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        p1, p2 = _patch_flag(None)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, USER) is False
+
+    def test_cosmos_exception_returns_false(self):
+        from treesight.security import rollout as r
+        from treesight.security.rollout import is_feature_enabled
+
+        with (
+            patch.object(r, "_read_flag", side_effect=Exception("cosmos down")),
+            patch.object(r, "_read_override", return_value=None),
+        ):
+            assert is_feature_enabled(FEATURE, USER) is False
+
+    def test_override_read_exception_is_conservative(self):
+        from treesight.security import rollout as r
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="on")
+        # Override read blows up; should still fail closed on the override path
+        # but continue to evaluate (no override means fall through to status).
+        with (
+            patch.object(r, "_read_flag", return_value=flag),
+            patch.object(r, "_read_override", side_effect=Exception("cosmos down")),
+        ):
+            # flag is "on" and override is unreadable → treat as no override → enabled
+            assert is_feature_enabled(FEATURE, USER) is True
+
+
+# ---------------------------------------------------------------------------
+# Rule 3: per-user override
+# ---------------------------------------------------------------------------
+
+
+class TestPerUserOverride:
+    def test_override_enabled_beats_off_flag(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="off")
+        override = _make_override(USER, FEATURE, enabled=True)
+        p1, p2 = _patch_flag(flag, override)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, USER) is True
+
+    def test_override_disabled_beats_on_flag(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="on")
+        override = _make_override(USER, FEATURE, enabled=False)
+        p1, p2 = _patch_flag(flag, override)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, USER) is False
+
+    def test_override_for_different_feature_is_ignored(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="off")
+        override = _make_override(USER, "other-feature", enabled=True)
+        p1, p2 = _patch_flag(flag, override)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, USER) is False
+
+    def test_no_override_falls_through(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="on")
+        p1, p2 = _patch_flag(flag, None)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, USER) is True
+
+    def test_override_respected_before_kill_switch_check(self):
+        """kill_switch must still win over a positive override."""
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="on", kill_switch=True)
+        override = _make_override(USER, FEATURE, enabled=True)
+        p1, p2 = _patch_flag(flag, override)
+        with p1, p2:
+            # kill_switch is rule 1; override is rule 3; kill_switch wins
+            assert is_feature_enabled(FEATURE, USER) is False
+
+
+# ---------------------------------------------------------------------------
+# Rule 4: status off / blocked
+# ---------------------------------------------------------------------------
+
+
+class TestStatusOffBlocked:
+    @pytest.mark.parametrize("status", ["off", "blocked"])
+    def test_off_and_blocked_return_false(self, status):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status=status)
+        p1, p2 = _patch_flag(flag)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, USER) is False
+
+
+# ---------------------------------------------------------------------------
+# Rule 5: preview_only
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewOnly:
+    def test_preview_only_without_override_returns_false(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="preview_only")
+        p1, p2 = _patch_flag(flag, None)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, USER) is False
+
+    def test_preview_only_with_enabled_override_returns_true(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="preview_only")
+        override = _make_override(USER, FEATURE, enabled=True)
+        p1, p2 = _patch_flag(flag, override)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, USER) is True
+
+    def test_preview_only_blocks_anonymous(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="preview_only", allow_anonymous=False)
+        p1, p2 = _patch_flag(flag, None)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, "anonymous") is False
+
+    def test_preview_only_blocks_none_user(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="preview_only")
+        p1, p2 = _patch_flag(flag, None)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, None) is False
+
+
+# ---------------------------------------------------------------------------
+# Rule 6: percentage_rollout
+# ---------------------------------------------------------------------------
+
+
+class TestPercentageRollout:
+    def _user_in_bucket(self, feature: str, rollout_pct: int) -> str | None:
+        """Find a user_id whose bucket falls within rollout_pct."""
+        for i in range(200):
+            uid = f"user-{i}"
+            if _bucket(feature, uid) < rollout_pct:
+                return uid
+        return None
+
+    def _user_outside_bucket(self, feature: str, rollout_pct: int) -> str | None:
+        """Find a user_id whose bucket falls outside rollout_pct."""
+        for i in range(200):
+            uid = f"user-{i}"
+            if _bucket(feature, uid) >= rollout_pct:
+                return uid
+        return None
+
+    def test_user_in_bucket_enabled(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        rollout_pct = 50
+        uid = self._user_in_bucket(FEATURE, rollout_pct)
+        assert uid is not None, "could not find an in-bucket user"
+
+        flag = _make_flag(status="percentage_rollout", rollout_pct=rollout_pct)
+        p1, p2 = _patch_flag(flag, None)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, uid) is True
+
+    def test_user_outside_bucket_disabled(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        rollout_pct = 50
+        uid = self._user_outside_bucket(FEATURE, rollout_pct)
+        assert uid is not None, "could not find an outside-bucket user"
+
+        flag = _make_flag(status="percentage_rollout", rollout_pct=rollout_pct)
+        p1, p2 = _patch_flag(flag, None)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, uid) is False
+
+    def test_zero_pct_disables_all(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="percentage_rollout", rollout_pct=0)
+        p1, p2 = _patch_flag(flag, None)
+        with p1, p2:
+            for i in range(20):
+                assert is_feature_enabled(FEATURE, f"user-{i}") is False
+
+    def test_100_pct_enables_all(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="percentage_rollout", rollout_pct=100)
+        p1, p2 = _patch_flag(flag, None)
+        with p1, p2:
+            for i in range(20):
+                assert is_feature_enabled(FEATURE, f"user-{i}") is True
+
+    def test_bucketing_is_deterministic(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="percentage_rollout", rollout_pct=50)
+        p1, p2 = _patch_flag(flag, None)
+        with p1, p2:
+            first_call = is_feature_enabled(FEATURE, USER)
+
+        p1, p2 = _patch_flag(flag, None)
+        with p1, p2:
+            second_call = is_feature_enabled(FEATURE, USER)
+
+        assert first_call == second_call
+
+    def test_override_beats_percentage_rollout(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        rollout_pct = 0  # nobody gets in via bucket
+        uid = "user-forced"
+        flag = _make_flag(status="percentage_rollout", rollout_pct=rollout_pct)
+        override = _make_override(uid, FEATURE, enabled=True)
+        p1, p2 = _patch_flag(flag, override)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, uid) is True
+
+
+# ---------------------------------------------------------------------------
+# Rule 7: status on
+# ---------------------------------------------------------------------------
+
+
+class TestStatusOn:
+    def test_on_enables_for_any_authenticated_user(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="on")
+        p1, p2 = _patch_flag(flag, None)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, USER) is True
+
+    def test_on_with_allow_anonymous_enables_for_anon(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="on", allow_anonymous=True)
+        p1, p2 = _patch_flag(flag, None)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, "anonymous") is True
+
+    def test_on_without_allow_anonymous_blocks_anon(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="on", allow_anonymous=False)
+        p1, p2 = _patch_flag(flag, None)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, "anonymous") is False
+
+
+# ---------------------------------------------------------------------------
+# Anonymous / None user handling
+# ---------------------------------------------------------------------------
+
+
+class TestAnonymousUser:
+    @pytest.mark.parametrize("user_id", [None, "anonymous"])
+    def test_anonymous_gated_by_default(self, user_id):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="on", allow_anonymous=False)
+        p1, p2 = _patch_flag(flag, None)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, user_id) is False
+
+    def test_anonymous_allowed_when_flag_permits(self):
+        from treesight.security.rollout import is_feature_enabled
+
+        flag = _make_flag(status="on", allow_anonymous=True)
+        p1, p2 = _patch_flag(flag, None)
+        with p1, p2:
+            assert is_feature_enabled(FEATURE, "anonymous") is True

--- a/treesight/security/rollout.py
+++ b/treesight/security/rollout.py
@@ -1,0 +1,192 @@
+"""Generalised feature flag evaluator for production rollout control.
+
+Spec: docs/PRODUCTION_ROLLOUT_SPEC.md §6 Feature Evaluation Rules.
+
+Evaluation order (strict, fail-closed):
+  1. kill_switch is true → disabled
+  2. flag document missing or unreadable → disabled
+  3. valid per-user override exists → return override decision
+  4. status is ``off`` or ``blocked`` → disabled
+  5. status is ``preview_only`` → enabled only for explicit override
+  6. status is ``percentage_rollout`` → deterministic bucket check
+  7. status is ``on`` → enabled
+
+Anonymous users (``None`` or ``"anonymous"``) are blocked unless the flag
+document explicitly sets ``allow_anonymous=true``.
+
+Storage:
+  - ``feature_flags`` Cosmos container — keyed by ``feature_name``
+  - ``feature_flag_overrides`` Cosmos container — keyed by ``user_id``
+
+Both containers partition on the same key used for the document id.
+The evaluator fails closed whenever either read raises an exception or
+returns a document with unexpected structure.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import Any
+
+logger = logging.getLogger("treesight.security.rollout")
+
+_FLAGS_CONTAINER = "feature_flags"
+_OVERRIDES_CONTAINER = "feature_flag_overrides"
+
+# Status values defined in spec §5.3
+_STATUS_OFF = "off"
+_STATUS_PREVIEW_ONLY = "preview_only"
+_STATUS_PERCENTAGE_ROLLOUT = "percentage_rollout"
+_STATUS_ON = "on"
+_STATUS_BLOCKED = "blocked"
+
+
+# ---------------------------------------------------------------------------
+# Internal storage readers — thin wrappers that can be patched in tests
+# ---------------------------------------------------------------------------
+
+
+def _read_flag(feature_name: str) -> dict[str, Any] | None:
+    """Return the feature flag document for *feature_name*, or ``None``."""
+    from treesight.storage.cosmos import cosmos_available, read_item
+
+    if not cosmos_available():
+        return None
+    return read_item(_FLAGS_CONTAINER, feature_name, feature_name)
+
+
+def _read_override(user_id: str) -> dict[str, Any] | None:
+    """Return the per-user override document for *user_id*, or ``None``."""
+    from treesight.storage.cosmos import cosmos_available, read_item
+
+    if not cosmos_available():
+        return None
+    return read_item(_OVERRIDES_CONTAINER, user_id, user_id)
+
+
+# ---------------------------------------------------------------------------
+# Bucketing (spec §6.3)
+# ---------------------------------------------------------------------------
+
+
+def _rollout_bucket(feature_name: str, user_id: str) -> int:
+    """Return a deterministic bucket in [0, 100) for the feature/user pair.
+
+    Uses ``sha256("{feature_name}:{user_id}") % 100``.
+    """
+    digest = hashlib.sha256(f"{feature_name}:{user_id}".encode()).hexdigest()
+    return int(digest, 16) % 100
+
+
+# ---------------------------------------------------------------------------
+# Public evaluator
+# ---------------------------------------------------------------------------
+
+
+def is_feature_enabled(feature_name: str, user_id: str | None) -> bool:
+    """Return ``True`` if *feature_name* is enabled for *user_id*.
+
+    Always returns ``False`` on any unhandled exception (fail-closed).
+
+    Args:
+        feature_name: The logical name of the feature to evaluate.
+        user_id: The authenticated user id, or ``None`` / ``"anonymous"``.
+
+    Returns:
+        ``True`` if the feature is enabled for this user, ``False`` otherwise.
+    """
+    try:
+        return _evaluate(feature_name, user_id)
+    except Exception:
+        logger.exception(
+            "feature_eval_failed feature=%s user=%s",
+            feature_name,
+            user_id,
+            extra={"event": "feature_eval_failed", "feature": feature_name, "user": user_id},
+        )
+        return False
+
+
+def _check_override(feature_name: str, user_id: str) -> bool | None:
+    """Return override decision for *user_id*, or ``None`` if no override applies.
+
+    Returns ``None`` on read failure so the evaluator can fall through to
+    flag-level status evaluation rather than blocking the request.
+    """
+    try:
+        override_doc = _read_override(user_id)
+    except Exception:
+        logger.debug(
+            "override read failed user=%s feature=%s; ignoring override",
+            user_id,
+            feature_name,
+            exc_info=True,
+        )
+        return None
+
+    if not override_doc:
+        return None
+    feature_overrides: dict = override_doc.get("features", {})
+    if feature_name in feature_overrides:
+        return bool(feature_overrides[feature_name].get("enabled", False))
+    return None
+
+
+def _evaluate(feature_name: str, user_id: str | None) -> bool:
+    """Inner evaluator — may raise; callers must handle exceptions."""
+    is_anonymous = not user_id or user_id == "anonymous"
+
+    # ── Rule 2: read flag document; treat missing/unreadable as disabled ──
+    try:
+        flag = _read_flag(feature_name)
+    except Exception:
+        logger.warning(
+            "feature flag read failed feature=%s; disabling",
+            feature_name,
+            exc_info=True,
+        )
+        return False
+
+    if not flag:
+        return False
+
+    # ── Rule 1: kill_switch beats everything ──────────────────────────────
+    if flag.get("kill_switch"):
+        return False
+
+    # ── Rule 4 (early): anonymous gating ─────────────────────────────────
+    # Anonymous users are blocked unless the flag explicitly permits them.
+    if is_anonymous and not flag.get("allow_anonymous"):
+        return False
+
+    # ── Rule 3: per-user override ─────────────────────────────────────────
+    if not is_anonymous and user_id:
+        override = _check_override(feature_name, user_id)
+        if override is not None:
+            return override
+
+    # ── Rule 4: off / blocked ─────────────────────────────────────────────
+    status = flag.get("status", _STATUS_OFF)
+    if status in (_STATUS_OFF, _STATUS_BLOCKED):
+        return False
+
+    # ── Rule 5: preview_only — only explicit overrides reach here for non-anon ──
+    # For anonymous users with allow_anonymous=True and a preview_only feature,
+    # we have no override mechanism → disabled.
+    if status == _STATUS_PREVIEW_ONLY:
+        return False
+
+    # ── Rule 6: percentage_rollout ────────────────────────────────────────
+    if status == _STATUS_PERCENTAGE_ROLLOUT:
+        rollout_pct = int(flag.get("rollout_pct", 0))
+        bucket = _rollout_bucket(feature_name, user_id or "anonymous")
+        return bucket < rollout_pct
+
+    # ── Rule 7: on ────────────────────────────────────────────────────────
+    if status == _STATUS_ON:
+        return True
+
+    # Unknown status → fail closed
+    logger.warning("unknown feature status=%s feature=%s; disabling", status, feature_name)
+    return False

--- a/treesight/security/rollout.py
+++ b/treesight/security/rollout.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+from datetime import UTC, datetime
 from typing import Any
 
 logger = logging.getLogger("treesight.security.rollout")
@@ -111,26 +112,45 @@ def is_feature_enabled(feature_name: str, user_id: str | None) -> bool:
 def _check_override(feature_name: str, user_id: str) -> bool | None:
     """Return override decision for *user_id*, or ``None`` if no override applies.
 
-    Returns ``None`` on read failure so the evaluator can fall through to
-    flag-level status evaluation rather than blocking the request.
+    Raises on storage read failure — propagates to ``is_feature_enabled`` to
+    preserve fail-closed behaviour (any unreadable state → disabled).
+
+    Returns ``None`` for absent, expired, or malformed override entries so
+    the evaluator falls through to flag-level status rules.
     """
-    try:
-        override_doc = _read_override(user_id)
-    except Exception:
-        logger.debug(
-            "override read failed user=%s feature=%s; ignoring override",
-            user_id,
-            feature_name,
-            exc_info=True,
-        )
-        return None
+    override_doc = _read_override(user_id)
 
     if not override_doc:
         return None
     feature_overrides: dict = override_doc.get("features", {})
-    if feature_name in feature_overrides:
-        return bool(feature_overrides[feature_name].get("enabled", False))
-    return None
+    if feature_name not in feature_overrides:
+        return None
+
+    entry: dict = feature_overrides[feature_name]
+
+    # Honour expiry: an expired override is treated as absent.
+    expires_at = entry.get("expires_at")
+    if expires_at:
+        try:
+            expiry = datetime.fromisoformat(expires_at)
+            # Normalise to UTC when the stored value is offset-aware.
+            now = datetime.now(tz=UTC)
+            if expiry.tzinfo is not None:
+                if now >= expiry:
+                    return None
+            else:
+                if datetime.utcnow() >= expiry:
+                    return None
+        except (ValueError, TypeError):
+            # Malformed expires_at — treat override as absent (fail-closed).
+            logger.warning(
+                "malformed expires_at in override user=%s feature=%s; ignoring",
+                user_id,
+                feature_name,
+            )
+            return None
+
+    return bool(entry.get("enabled", False))
 
 
 def _evaluate(feature_name: str, user_id: str | None) -> bool:
@@ -180,6 +200,13 @@ def _evaluate(feature_name: str, user_id: str | None) -> bool:
     # ── Rule 6: percentage_rollout ────────────────────────────────────────
     if status == _STATUS_PERCENTAGE_ROLLOUT:
         rollout_pct = int(flag.get("rollout_pct", 0))
+        if not (0 <= rollout_pct <= 100):
+            logger.warning(
+                "invalid rollout_pct=%d feature=%s; disabling",
+                rollout_pct,
+                feature_name,
+            )
+            return False
         bucket = _rollout_bucket(feature_name, user_id or "anonymous")
         return bucket < rollout_pct
 


### PR DESCRIPTION
Part of #403. Implements `docs/PRODUCTION_ROLLOUT_SPEC.md` §5–6 (data model + core evaluator). Phase 1 of 3.

## What

### `treesight/security/rollout.py` — new module

`is_feature_enabled(feature_name, user_id)` implements spec §6 evaluation order strictly:

| Rule | Condition | Result |
|------|-----------|--------|
| 1 | `kill_switch` is true | disabled |
| 2 | flag document missing or read fails | disabled (fail-closed) |
| 3 | valid per-user override exists | override decision |
| 4 | `status` is `off` or `blocked` | disabled |
| 5 | `status` is `preview_only` | disabled unless rule 3 granted access |
| 6 | `status` is `percentage_rollout` | `sha256(f"{feature}:{user}") % 100 < rollout_pct` |
| 7 | `status` is `on` | enabled |

Anonymous / `None` users are blocked unless the flag sets `allow_anonymous=true`.

Any unhandled exception returns `False` and logs a structured `feature_eval_failed` event — fail-closed throughout.

Deterministic bucketing (`sha256("{feature}:{user}") % 100`) matches spec §6.3 exactly — same user stays in/out of rollout cohort across calls.

### `infra/tofu/main.tf` — two new Cosmos containers

⚠️ This PR contains infra changes — `tofu apply` required after merge.

- `feature_flags` (partition `/feature_name`) — indexed on `/status` and `/kill_switch` only; all other paths excluded
- `feature_flag_overrides` (partition `/user_id`) — indexed on `/user_id` only

Both guarded by `var.enable_cosmos_db` (serverless account, no idle cost).

### Operator scripts

- `scripts/feature_flag_upsert.py` — create/update a flag (all status values, kill-switch, rollout %, allow-anonymous)
- `scripts/feature_flag_override.py` — grant/revoke/clear per-user preview override

Both use `DefaultAzureCredential` (`az login` locally, Managed Identity in CI). No secrets stored.

## Tests

`tests/test_rollout.py` — 28 tests covering all evaluation rules:

- kill_switch beats everything (including a positive override)
- missing flag returns `False`
- Cosmos exception returns `False` (fail-closed)
- override read exception falls through to flag status (not blocking)
- preview_only blocked without override, enabled with override
- percentage_rollout: in-bucket ✅, out-of-bucket ✅, 0% blocks all, 100% enables all, determinism
- override beats percentage_rollout
- anonymous blocked by default, allowed via `allow_anonymous=true`

## What this unlocks (future phases)

- Phase 2: post-deploy functional smoke gate (`scripts/e2e_smoke_gate.py` extended to write `feature_flags` results as evidence records)
- Phase 3: scheduled rollout controller (durable function or timer trigger) that promotes/demotes based on smoke evidence

Both phases can be added without changing the evaluator interface.

## Validation

- `ruff check` / `ruff format --check` clean ✅
- `tests/test_rollout.py`: 28/28 passed ✅
- Full suite: 1816 passed, 28 skipped ✅