### PR TITLE
fix: Fiona/GDAL parse hang — PROJ_NETWORK=OFF, 60s timeout, structured logging

### DIFF
--- a/blueprints/pipeline/activities.py
+++ b/blueprints/pipeline/activities.py
@@ -53,9 +53,19 @@ def parse_kml(payload: _Payload) -> list[dict[str, Any]] | dict[str, Any]:
     from treesight.storage.client import BlobStorageClient
     from treesight.storage.offload import PayloadOffloader
 
+    logger.info(
+        "parse_kml: started correlation_id=%s",
+        payload.get("correlation_id", "unknown"),
+    )
     blob_event = BlobEvent.model_validate(payload)
     storage = BlobStorageClient()
+    logger.info(
+        "parse_kml: parsing container=%s blob=%s",
+        blob_event.container_name,
+        blob_event.blob_name,
+    )
     features = parse_kml_from_blob(blob_event, storage)
+    logger.info("parse_kml: got features=%d", len(features))
 
     from treesight.constants import MAX_FEATURES_PER_KML
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -285,7 +285,7 @@ class TestFionaParserTimeout:
         import treesight.parsers.fiona_parser as fp_module
 
         def _slow_open(tmp_path: str, source_file: str) -> list:
-            time.sleep(5)  # simulate GDAL network hang
+            time.sleep(0.5)  # longer than 0.1s deadline; shorter than 5s (keeps tests fast)
             return []
 
         monkeypatch.setattr(fp_module, "_fiona_open_and_collect", _slow_open)
@@ -306,7 +306,7 @@ class TestFionaParserTimeout:
         from treesight.pipeline.ingestion import parse_kml_from_blob
 
         def _slow_open(tmp_path: str, source_file: str) -> list:
-            time.sleep(5)
+            time.sleep(0.5)
             return []
 
         monkeypatch.setattr(fp_module, "_fiona_open_and_collect", _slow_open)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -273,3 +273,56 @@ class TestKmlInputValidation:
           <Document><name>Test</name></Document>
         </kml>"""
         validate_kml_bytes(kml)
+
+
+class TestFionaParserTimeout:
+    """Fiona parser timeout and fallback behavior (\u00a77.1)."""
+
+    def test_fiona_timeout_raises_timeout_error(self, sample_kml_bytes: bytes, monkeypatch):
+        """parse_kml_fiona raises TimeoutError when GDAL hangs past the deadline."""
+        import time
+
+        import treesight.parsers.fiona_parser as fp_module
+
+        def _slow_open(tmp_path: str, source_file: str) -> list:
+            time.sleep(5)  # simulate GDAL network hang
+            return []
+
+        monkeypatch.setattr(fp_module, "_fiona_open_and_collect", _slow_open)
+        monkeypatch.setattr(fp_module, "_FIONA_TIMEOUT_SECONDS", 0.1)
+
+        with pytest.raises(TimeoutError, match="timed out"):
+            fp_module.parse_kml_fiona(sample_kml_bytes)
+
+    def test_ingestion_falls_back_to_lxml_on_fiona_timeout(
+        self, sample_kml_bytes: bytes, monkeypatch
+    ):
+        """When Fiona times out, parse_kml_from_blob falls back to lxml successfully."""
+        import time
+        from unittest.mock import MagicMock
+
+        import treesight.parsers.fiona_parser as fp_module
+        from treesight.models.blob_event import BlobEvent
+        from treesight.pipeline.ingestion import parse_kml_from_blob
+
+        def _slow_open(tmp_path: str, source_file: str) -> list:
+            time.sleep(5)
+            return []
+
+        monkeypatch.setattr(fp_module, "_fiona_open_and_collect", _slow_open)
+        monkeypatch.setattr(fp_module, "_FIONA_TIMEOUT_SECONDS", 0.1)
+
+        storage = MagicMock()
+        storage.download_bytes.return_value = sample_kml_bytes
+        blob_event = BlobEvent(
+            blob_url="https://teststorage.blob.core.windows.net/kml-input/analysis/test.kml",
+            container_name="kml-input",
+            blob_name="analysis/test.kml",
+            content_length=len(sample_kml_bytes),
+            content_type="application/vnd.google-earth.kml+xml",
+            event_time="2025-01-15T10:30:00Z",
+            correlation_id="test-123",
+        )
+
+        features = parse_kml_from_blob(blob_event, storage)
+        assert len(features) >= 1  # lxml fallback parsed at least one feature

--- a/treesight/parsers/fiona_parser.py
+++ b/treesight/parsers/fiona_parser.py
@@ -2,21 +2,41 @@
 
 from __future__ import annotations
 
+import concurrent.futures
+import os
 import tempfile
 from pathlib import Path
 from typing import Any, cast
+
+# Disable PROJ network access and cap GDAL HTTP before fiona/GDAL initialises.
+# Without these, GDAL silently blocks on network calls (datum grid downloads,
+# schema validation) for minutes to hours when container egress is restricted.
+os.environ.setdefault("PROJ_NETWORK", "OFF")
+os.environ.setdefault("GDAL_HTTP_TIMEOUT", "30")
+os.environ.setdefault("GDAL_MAX_HTTP_RETRY", "0")
+os.environ.setdefault("GDAL_DISABLE_READDIR_ON_OPEN", "EMPTY_DIR")
 
 from treesight.log import logger
 from treesight.models.feature import Feature
 from treesight.parsers import ensure_closed as _ensure_closed
 
 _NAME_KEYS = frozenset({"name", "description"})
+_FIONA_TIMEOUT_SECONDS = 60
+
+
+def _fiona_open_and_collect(tmp_path: str, source_file: str) -> list[dict[str, Any]]:
+    """Open the KML via Fiona and collect raw record dicts. Runs in a worker thread."""
+    import fiona  # type: ignore[import-untyped]  — fiona has no py.typed / type stubs
+
+    records: list[dict[str, Any]] = []
+    with fiona.open(tmp_path, driver="KML") as src:  # pyright: ignore[reportUnknownMemberType]
+        for record in cast(list[dict[str, Any]], src):
+            records.append(record)
+    return records
 
 
 def parse_kml_fiona(kml_bytes: bytes, source_file: str = "") -> list[Feature]:
     """Parse KML bytes using Fiona (GDAL driver). Returns list of Features."""
-    import fiona  # type: ignore[import-untyped]  — fiona has no py.typed / type stubs
-
     features: list[Feature] = []
 
     with tempfile.NamedTemporaryFile(suffix=".kml", delete=False) as tmp:
@@ -24,30 +44,51 @@ def parse_kml_fiona(kml_bytes: bytes, source_file: str = "") -> list[Feature]:
         tmp_path = tmp.name
 
     try:
-        with fiona.open(tmp_path, driver="KML") as src:  # pyright: ignore[reportUnknownMemberType]
-            for idx, record in enumerate(cast(list[dict[str, Any]], src)):
-                geom: dict[str, Any] = record.get("geometry", {})
-                props: dict[str, Any] = record.get("properties", {})
-                geom_type: str = str(geom.get("type", ""))
+        logger.info(
+            "fiona_parser: opening source=%s bytes=%d timeout=%ds",
+            source_file or "inline",
+            len(kml_bytes),
+            _FIONA_TIMEOUT_SECONDS,
+        )
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(_fiona_open_and_collect, tmp_path, source_file)
+            try:
+                records = future.result(timeout=_FIONA_TIMEOUT_SECONDS)
+            except concurrent.futures.TimeoutError as exc:
+                raise TimeoutError(
+                    f"Fiona/GDAL parse timed out after {_FIONA_TIMEOUT_SECONDS}s "
+                    f"for {source_file!r} — GDAL may be making a blocked network call"
+                ) from exc
 
-                if geom_type == "Polygon":
-                    features.append(_polygon_to_feature(geom, props, source_file, len(features)))
-                elif geom_type == "MultiPolygon":
-                    for poly_coords in geom.get("coordinates", []):
-                        features.append(
-                            _multi_polygon_part_to_feature(
-                                poly_coords, props, source_file, len(features)
-                            )
+        for idx, record in enumerate(records):
+            geom: dict[str, Any] = record.get("geometry", {})
+            props: dict[str, Any] = record.get("properties", {})
+            geom_type: str = str(geom.get("type", ""))
+
+            if geom_type == "Polygon":
+                features.append(_polygon_to_feature(geom, props, source_file, len(features)))
+            elif geom_type == "MultiPolygon":
+                for poly_coords in geom.get("coordinates", []):
+                    features.append(
+                        _multi_polygon_part_to_feature(
+                            poly_coords, props, source_file, len(features)
                         )
-                else:
-                    logger.warning(
-                        "Skipping non-polygon geometry type=%s index=%d",
-                        geom_type,
-                        idx,
                     )
+            else:
+                logger.warning(
+                    "fiona_parser: skipping non-polygon type=%s index=%d source=%s",
+                    geom_type,
+                    idx,
+                    source_file,
+                )
     finally:
         Path(tmp_path).unlink(missing_ok=True)
 
+    logger.info(
+        "fiona_parser: done source=%s features=%d",
+        source_file or "inline",
+        len(features),
+    )
     return features
 
 

--- a/treesight/parsers/fiona_parser.py
+++ b/treesight/parsers/fiona_parser.py
@@ -50,15 +50,21 @@ def parse_kml_fiona(kml_bytes: bytes, source_file: str = "") -> list[Feature]:
             len(kml_bytes),
             _FIONA_TIMEOUT_SECONDS,
         )
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            future = pool.submit(_fiona_open_and_collect, tmp_path, source_file)
-            try:
-                records = future.result(timeout=_FIONA_TIMEOUT_SECONDS)
-            except concurrent.futures.TimeoutError as exc:
-                raise TimeoutError(
-                    f"Fiona/GDAL parse timed out after {_FIONA_TIMEOUT_SECONDS}s "
-                    f"for {source_file!r} — GDAL may be making a blocked network call"
-                ) from exc
+        # Use an explicit executor (not a context manager) so that on timeout we
+        # call shutdown(wait=False) and return immediately. The context-manager form
+        # calls shutdown(wait=True) on __exit__, which would block until the stuck
+        # GDAL thread finally finishes — defeating the entire purpose of the timeout.
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        future = pool.submit(_fiona_open_and_collect, tmp_path, source_file)
+        try:
+            records = future.result(timeout=_FIONA_TIMEOUT_SECONDS)
+        except concurrent.futures.TimeoutError as exc:
+            pool.shutdown(wait=False)  # detach; worker stays alive until process exits
+            raise TimeoutError(
+                f"Fiona/GDAL parse timed out after {_FIONA_TIMEOUT_SECONDS}s "
+                f"for {source_file!r} — GDAL may be making a blocked network call"
+            ) from exc
+        pool.shutdown(wait=False)
 
         for idx, record in enumerate(records):
             geom: dict[str, Any] = record.get("geometry", {})

--- a/treesight/pipeline/ingestion.py
+++ b/treesight/pipeline/ingestion.py
@@ -31,27 +31,51 @@ def parse_kml_from_blob(blob_event: BlobEvent, storage: BlobStorageClient) -> li
 
     from treesight.parsers import maybe_unzip, validate_kml_bytes
 
+    logger.info(
+        "parse_kml_from_blob: downloading container=%s blob=%s",
+        blob_event.container_name,
+        blob_event.blob_name,
+    )
     raw_bytes = storage.download_bytes(blob_event.container_name, blob_event.blob_name)
+    logger.info(
+        "parse_kml_from_blob: downloaded bytes=%d blob=%s",
+        len(raw_bytes),
+        blob_event.blob_name,
+    )
     kml_bytes = maybe_unzip(raw_bytes)
     source_file = PurePosixPath(blob_event.blob_name).name
 
     # Reject malformed or dangerous XML before parser dispatch
     validate_kml_bytes(kml_bytes)
+    logger.info(
+        "parse_kml_from_blob: KML validated, dispatching Fiona parser blob=%s",
+        blob_event.blob_name,
+    )
 
     # Try Fiona first, fall back to lxml
     try:
         from treesight.parsers.fiona_parser import parse_kml_fiona
 
         features = parse_kml_fiona(kml_bytes, source_file=source_file)
+        logger.info(
+            "parse_kml_from_blob: Fiona parsed features=%d blob=%s",
+            len(features),
+            blob_event.blob_name,
+        )
     except Exception:
         logger.warning(
-            "Fiona parser failed for %s, falling back to lxml",
+            "parse_kml_from_blob: Fiona failed for %s, falling back to lxml",
             blob_event.blob_name,
             exc_info=True,
         )
         from treesight.parsers.lxml_parser import parse_kml_lxml
 
         features = parse_kml_lxml(kml_bytes, source_file=source_file)
+        logger.info(
+            "parse_kml_from_blob: lxml parsed features=%d blob=%s",
+            len(features),
+            blob_event.blob_name,
+        )
 
     log_phase("ingestion", "parse_kml", feature_count=len(features), blob_name=blob_event.blob_name)
     return features


### PR DESCRIPTION
Fixes #852

## Problem

The `parse_kml` activity has been stuck at `parsing_kml` for 75+ minutes on both observed pipeline runs (`f19ec91e`, `d95034ec`). The KML is clean (4 simple polygons, 3.3 KB, no NetworkLinks). No exceptions appear in Log Analytics — nothing is logged at all once the activity starts.

**Root cause:** GDAL/PROJ ≥ 7 defaults to `PROJ_NETWORK=ON`, enabling on-demand datum grid downloads from `cdn.proj.org`. In ACA, outbound TCP to that CDN is silently dropped (no RST, no ICMP unreachable) — GDAL's libcurl socket stays pending until the OS-level connection timeout, which can be hours. Since GDAL never raises a Python exception, the `except Exception` lxml fallback in `ingestion.py` is never triggered.

**Secondary problem:** Zero logging in the parse path means the hang is completely invisible in Log Analytics.

## Changes

### `treesight/parsers/fiona_parser.py`
- Set `PROJ_NETWORK=OFF`, `GDAL_HTTP_TIMEOUT=30`, `GDAL_MAX_HTTP_RETRY=0`, `GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR` at module level before GDAL initialises
- Extract `_fiona_open_and_collect()` — the blocking GDAL work runs in a `ThreadPoolExecutor` worker
- `future.result(timeout=60)` → raises `TimeoutError` on hang → caught by the `except Exception` in `ingestion.py` → lxml fallback
- `logger.info` at open and completion

### `treesight/pipeline/ingestion.py`
- Structured `logger.info` at every step: download start, bytes received, KML validated, Fiona dispatched, Fiona done, lxml fallback done

### `blueprints/pipeline/activities.py`
- `logger.info` at activity entry (with `correlation_id`), before parse, after parse (with feature count)

### `tests/test_parsers.py`
- `test_fiona_timeout_raises_timeout_error` — monkeypatches `_fiona_open_and_collect` to sleep, sets `_FIONA_TIMEOUT_SECONDS=0.1`, asserts `TimeoutError`
- `test_ingestion_falls_back_to_lxml_on_fiona_timeout` — same setup, calls `parse_kml_from_blob`, asserts lxml returns ≥1 feature

## Verification

```
1825 passed, 28 skipped in 106s
```
All pre-commit hooks pass (ruff, ruff-format, pyright, detect-secrets).

## After merge

The two stuck instances (`f19ec91e`, `d95034ec`) must be terminated and a fresh run submitted to verify the pipeline progresses past `parsing_kml`.