### PR TITLE
fix(deps): bump idna from 3.11 to 3.15

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -992,11 +992,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Resolves Dependabot alert #14 — `idna` 3.11 has a bypass of the CVE-2024-3651 fix that allows specially crafted inputs to `idna.encode()` to escape the security boundary.

## Change

- `uv lock --upgrade-package idna` → bumped `idna` 3.11 → 3.15 in `uv.lock`
- `idna` is a transitive dependency (pulled in by `httpx`, `anyio`, `requests`, `yarl`); no `pyproject.toml` change needed

## Verification

- 1826 tests pass, 28 skipped (full suite)
- `pip-audit` will clear on this PR — unblocks the `Dependency Audit` check and the deploy workflow

Closes Dependabot alert #14.

---
**Closing:** Duplicate of Dependabot PR #856 which covers the same change and will properly auto-dismiss the security advisory on merge.