### PR TITLE
fix: switch Container App scale-rule update from PUT to PATCH

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -552,10 +552,11 @@ jobs:
           STORAGE_ACCOUNT=$(tofu output -raw storage_account_name)
           CONTAINER_APP_ID="/subscriptions/${ARM_SUBSCRIPTION_ID}/resourceGroups/${FUNC_RG}/providers/Microsoft.App/containerApps/${FUNC_NAME}"
 
-          # GET current Container App, inject scale rules, PUT back.
-          # Strips ARM read-only fields; preserves existing containers/ingress/config.
+          # GET current Container App, inject scale rules, PATCH back.
+          # PATCH avoids replacing the whole resource while preserving existing
+          # containers/ingress/config and only updating the scale rules we own.
           CURRENT=$(az rest --method GET --url "${CONTAINER_APP_ID}?api-version=2024-03-01")
-          PUT_BODY=$(echo "$CURRENT" | jq \
+          PATCH_BODY=$(echo "$CURRENT" | jq \
             --arg  q   "$WORKITEMS_QUEUE" \
             --arg  sa  "$STORAGE_ACCOUNT" \
             --argjson max "$MAX_INSTANCES" \
@@ -590,11 +591,11 @@ jobs:
               )
             }')
           for attempt in 1 2 3; do
-            az rest --method PUT \
+            az rest --method PATCH \
               --url "${CONTAINER_APP_ID}?api-version=2024-03-01" \
-              --body "$PUT_BODY" && break
-            [ "$attempt" -lt 3 ] || { echo "❌ Container App scale rules PUT failed after 3 attempts"; exit 1; }
-            echo "⚠️  PUT attempt $attempt failed (transient ARM conflict), retrying in 20s..."
+              --body "$PATCH_BODY" && break
+            [ "$attempt" -lt 3 ] || { echo "❌ Container App scale rules PATCH failed after 3 attempts"; exit 1; }
+            echo "⚠️  PATCH attempt $attempt failed (transient ARM conflict), retrying in 20s..."
             sleep 20
           done
 

--- a/tests/test_launch_readiness.py
+++ b/tests/test_launch_readiness.py
@@ -460,6 +460,20 @@ class TestDeployWorkflowSettings:
             "body is ignore_changes in tofu"
         )
 
+    def test_deploy_updates_container_app_scale_rules_via_patch(self, deploy_yml):
+        patch_call = (
+            "az rest --method PATCH \\\n"
+            '              --url "${CONTAINER_APP_ID}?api-version=2024-03-01"'
+        )
+        assert patch_call in deploy_yml, (
+            "deploy.yml must use PATCH (not PUT) when wiring KEDA scale rules"
+            " on the backing Container App"
+        )
+        assert "az rest --method PUT" not in deploy_yml, (
+            "deploy.yml must not replace the entire Container App resource"
+            " when updating scale rules"
+        )
+
     def test_deploy_sources_cli_managed_function_settings_from_tofu_outputs(self, deploy_yml):
         assert "tofu output -json function_app_cli_app_settings" in deploy_yml, (
             "deploy.yml must source CLI-managed Function App app settings from tofu outputs "


### PR DESCRIPTION
The deploy workflow was issuing a full `PUT` to `Microsoft.App/containerApps` when wiring the KEDA `azure-queue` trigger for the compute Function App. A PUT replaces the resource body and fails with `ResourceNotFound` when ARM cannot accept the full replacement shape (e.g. read-only fields conflict).

Switched to `PATCH` so only the scale rules are updated without replacing the full resource, matching the ARM API contract for Container Apps.

Also adds a regression test to pin that `PATCH` is used and `PUT` is not.

closes #882