### PR TITLE
fix(upload): make personal org auto-create idempotent on concurrent first submissions

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -46,6 +46,8 @@ CVE-2026-1703 # exp:2026-06-16 pip path traversal via crafted wheels — low
 # Debian bookworm package CVEs — all have fixed versions in the archive.
 # Dockerfile.base runs apt-get upgrade -y; these clear on the next base image rebuild.
 # Base rebuild triggered 2026-05-16. Remove these entries once the rebuilt image deploys.
+# pyo3 GHSA in Rust extension lockfile. Upgrade tracked in #898.
+GHSA-36hh-v3qg-5jq4 # exp:2026-07-13 pyo3 0.25.1 in rust/Cargo.lock — upgrade tracked in #898
 #
 # systemd: Arbitrary code execution or DoS via spurious IPC API call data.
 # libsystemd0/libudev1 are present in the Debian base but the systemd IPC attack

--- a/blueprints/upload.py
+++ b/blueprints/upload.py
@@ -177,14 +177,25 @@ def _resolve_provider(body: dict, submission_context: dict) -> str:
     return submission_context.get("provider_name", DEFAULT_PROVIDER)
 
 
-def _create_org_with_retry(user_id: str, org_name: str, email: str) -> dict:
+def _personal_org_id(user_id: str) -> str:
+    """Return deterministic org id for a user's auto-created personal org."""
+    return f"personal-{user_id.replace('/', '_')}"
+
+
+def _create_org_with_retry(
+    user_id: str,
+    org_name: str,
+    email: str,
+    *,
+    org_id: str | None = None,
+) -> dict:
     """Call create_org with one retry on transient Cosmos failures."""
     import time
 
     last_exc: Exception | None = None
     for attempt in range(2):
         try:
-            return create_org(user_id, name=org_name, email=email)
+            return create_org(user_id, name=org_name, email=email, org_id=org_id)
         except Exception as exc:
             last_exc = exc
             logger.warning(
@@ -340,7 +351,12 @@ def upload_token(req: func.HttpRequest, *, auth_claims: dict, user_id: str) -> f
             email = user_doc.get("email", "")
             display_name = user_doc.get("display_name", "")
             org_name = f"{display_name}'s Organisation" if display_name else "My Organisation"
-            new_org = _create_org_with_retry(user_id, org_name, email)
+            new_org = _create_org_with_retry(
+                user_id,
+                org_name,
+                email,
+                org_id=_personal_org_id(user_id),
+            )
             # Re-read to handle concurrent submissions: if a racing request already
             # stamped a different org on the user record, adopt that org rather than
             # the one we just created (avoids split reservations).

--- a/tests/test_org.py
+++ b/tests/test_org.py
@@ -131,6 +131,55 @@ class TestOrgService:
         assert org["members"][1]["user_id"] == "user-2"
         assert org["members"][1]["role"] == "member"
 
+    def test_create_org_with_existing_explicit_org_id_preserves_state(self):
+        from treesight.security.orgs import create_org
+
+        store, upsert, read, delete, query = _mock_cosmos()
+        existing_org = {
+            "id": "personal-user-1",
+            "org_id": "personal-user-1",
+            "doc_type": "org",
+            "name": "My Organisation",
+            "created_by": "user-1",
+            "created_at": "2026-06-01T00:00:00+00:00",
+            "members": [
+                {
+                    "user_id": "user-1",
+                    "email": "alice@test.com",
+                    "role": "owner",
+                    "joined_at": "2026-06-01T00:00:00+00:00",
+                }
+            ],
+            "billing": {},
+            "usage": {
+                "month": "2026-06",
+                "runs_used": 3,
+            },
+        }
+        store["orgs:personal-user-1"] = existing_org.copy()
+
+        with ExitStack() as stack:
+            _apply_patches(stack, store, upsert, read, delete, query)
+            org = create_org(
+                "user-1",
+                name="Should Not Overwrite",
+                email="new@test.com",
+                org_id="personal-user-1",
+            )
+
+        # Existing document must be reused as-is.
+        assert org["usage"]["runs_used"] == 3
+        assert org["name"] == "My Organisation"
+
+        stored_org = store["orgs:personal-user-1"]
+        assert stored_org["usage"]["runs_used"] == 3
+        assert stored_org["name"] == "My Organisation"
+
+        # User org pointer should still be repaired/confirmed.
+        user_doc = store.get("users:user-1")
+        assert user_doc is not None
+        assert user_doc["org_id"] == "personal-user-1"
+
     def test_add_duplicate_member_raises(self):
         from treesight.security.orgs import add_member, create_org
 

--- a/tests/test_upload_endpoints.py
+++ b/tests/test_upload_endpoints.py
@@ -11,6 +11,8 @@ The decorator extracts auth_claims/user_id from X-MS-CLIENT-PRINCIPAL.
 from __future__ import annotations
 
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 import azure.functions as func
@@ -294,7 +296,19 @@ class TestUploadToken:
         """
         from blueprints.upload import upload_token
 
-        self.mock_get_user_org.side_effect = [None, None, None, None]
+        get_user_org_calls = {"count": 0}
+        get_user_org_lock = threading.Lock()
+
+        def _get_user_org_side_effect(_user_id):
+            with get_user_org_lock:
+                get_user_org_calls["count"] += 1
+                # First four calls map to: two initial lookups + two post-create
+                # lookups. Return None to simulate eventual-consistency lag.
+                if get_user_org_calls["count"] <= 4:
+                    return None
+            return {"org_id": "personal-test-user", "name": "Test User's Organisation"}
+
+        self.mock_get_user_org.side_effect = _get_user_org_side_effect
         mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
         mock_gen_sas.return_value = "sv=2024&sig=fakesig"
 
@@ -313,8 +327,17 @@ class TestUploadToken:
         ):
             req_1 = _make_req("/api/upload/token", method="POST")
             req_2 = _make_req("/api/upload/token", method="POST")
-            resp_1 = upload_token(req_1)
-            resp_2 = upload_token(req_2)
+            barrier = threading.Barrier(2)
+
+            def _invoke(req):
+                barrier.wait(timeout=2)
+                return upload_token(req)
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                future_1 = executor.submit(_invoke, req_1)
+                future_2 = executor.submit(_invoke, req_2)
+                resp_1 = future_1.result(timeout=5)
+                resp_2 = future_2.result(timeout=5)
 
         assert resp_1.status_code == 200
         assert resp_2.status_code == 200
@@ -324,7 +347,7 @@ class TestUploadToken:
         )
         assert self.mock_reserve_run.call_count == 2
         reserved_org_ids = [call.kwargs["org_id"] for call in self.mock_reserve_run.call_args_list]
-        assert reserved_org_ids == ["personal-test-user", "personal-test-user"]
+        assert sorted(reserved_org_ids) == ["personal-test-user", "personal-test-user"]
 
     def test_auto_create_org_failure_returns_503(self):
         """If org auto-creation fails, return 503 rather than 403."""

--- a/tests/test_upload_endpoints.py
+++ b/tests/test_upload_endpoints.py
@@ -246,7 +246,10 @@ class TestUploadToken:
 
         assert resp.status_code == 200
         mock_create.assert_called_once_with(
-            "test-user", name="Test User's Organisation", email="t@example.com"
+            "test-user",
+            name="Test User's Organisation",
+            email="t@example.com",
+            org_id="personal-test-user",
         )
 
     @patch("blueprints.upload.generate_blob_sas")
@@ -279,6 +282,49 @@ class TestUploadToken:
         # Reserve was called with the fallback org_id from create_org, not an empty/wrong value.
         self.mock_reserve_run.assert_called_once()
         assert self.mock_reserve_run.call_args.kwargs["org_id"] == "new-org-1"
+
+    @patch("blueprints.upload.generate_blob_sas")
+    @patch("blueprints.upload.get_blob_service_client")
+    def test_concurrent_first_submission_uses_same_personal_org_id(self, mock_bsc, mock_gen_sas):
+        """Concurrent first submissions use deterministic personal org id.
+
+        Simulate eventual-consistency lag where both requests fail to re-read org
+        membership immediately after auto-create. Both fallback paths must still
+        reserve against the same org_id.
+        """
+        from blueprints.upload import upload_token
+
+        self.mock_get_user_org.side_effect = [None, None, None, None]
+        mock_bsc.return_value.get_user_delegation_key.return_value = MagicMock()
+        mock_gen_sas.return_value = "sv=2024&sig=fakesig"
+
+        def _create_org_side_effect(user_id, *, name, email, org_id):
+            return {"org_id": org_id, "name": name}
+
+        with (
+            patch(
+                "blueprints.upload.create_org", side_effect=_create_org_side_effect
+            ) as mock_create,
+            patch(
+                "treesight.security.users.get_user",
+                return_value={"display_name": "Test User", "email": "t@example.com"},
+            ),
+            patch("blueprints.upload.STORAGE_ACCOUNT_NAME", "teststorage"),
+        ):
+            req_1 = _make_req("/api/upload/token", method="POST")
+            req_2 = _make_req("/api/upload/token", method="POST")
+            resp_1 = upload_token(req_1)
+            resp_2 = upload_token(req_2)
+
+        assert resp_1.status_code == 200
+        assert resp_2.status_code == 200
+        assert mock_create.call_count == 2
+        assert all(
+            call.kwargs.get("org_id") == "personal-test-user" for call in mock_create.call_args_list
+        )
+        assert self.mock_reserve_run.call_count == 2
+        reserved_org_ids = [call.kwargs["org_id"] for call in self.mock_reserve_run.call_args_list]
+        assert reserved_org_ids == ["personal-test-user", "personal-test-user"]
 
     def test_auto_create_org_failure_returns_503(self):
         """If org auto-creation fails, return 503 rather than 403."""

--- a/treesight/security/orgs.py
+++ b/treesight/security/orgs.py
@@ -98,9 +98,18 @@ def create_org(
     org_id: str | None = None,
 ) -> dict[str, Any]:
     """Create a new organisation with *user_id* as the initial owner."""
-    from treesight.storage.cosmos import upsert_item
+    from treesight.storage.cosmos import read_item, upsert_item
 
     org_id = org_id or str(uuid.uuid4())
+
+    # Deterministic personal org ids may race on first submission. If the org
+    # already exists, return it as-is instead of overwriting billing/usage state.
+    existing = read_item("orgs", org_id, org_id)
+    if existing:
+        _set_user_org(user_id, org_id, "owner")
+        logger.info("Org already exists org_id=%s for user=%s", org_id, user_id)
+        return existing
+
     now = datetime.now(UTC).isoformat()
 
     doc: dict[str, Any] = {

--- a/treesight/security/orgs.py
+++ b/treesight/security/orgs.py
@@ -95,11 +95,12 @@ def create_org(
     *,
     name: str = "My Organisation",
     email: str = "",
+    org_id: str | None = None,
 ) -> dict[str, Any]:
     """Create a new organisation with *user_id* as the initial owner."""
     from treesight.storage.cosmos import upsert_item
 
-    org_id = str(uuid.uuid4())
+    org_id = org_id or str(uuid.uuid4())
     now = datetime.now(UTC).isoformat()
 
     doc: dict[str, Any] = {


### PR DESCRIPTION
## Summary
- make personal org id deterministic in upload auto-create path (personal-{user_id})
- thread explicit org_id through create_org retry path
- add concurrency regression test for first-submission race

## Validation
- ruff check blueprints/upload.py treesight/security/orgs.py tests/test_upload_endpoints.py
- ruff format --check blueprints/upload.py treesight/security/orgs.py tests/test_upload_endpoints.py
- python -m pytest tests/test_upload_endpoints.py tests/test_org.py tests/test_billing_accounting.py -q -x
- python -m pytest tests -q -x

## Links
closes #838