### PR TITLE
feat: add backlog autopilot + PR watchdog automation

### DIFF
--- a/.github/workflows/backlog-autopilot.yml
+++ b/.github/workflows/backlog-autopilot.yml
@@ -43,10 +43,11 @@ jobs:
       - name: Run backlog autopilot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+          INPUT_DRY_RUN: ${{ github.event.inputs.dry_run || '' }}
           INPUT_MONTHLY_BUDGET_USD: ${{ github.event.inputs.monthly_budget_usd || '' }}
           INPUT_MONTH_SPEND_USED_USD: ${{ github.event.inputs.month_spend_used_usd || '' }}
           INPUT_MAX_NEW_ASSIGNMENTS: ${{ github.event.inputs.max_new_assignments || '' }}
+          VAR_DRY_RUN: ${{ vars.AUTOPILOT_DRY_RUN || 'true' }}
           VAR_MONTHLY_BUDGET_USD: ${{ vars.AUTOPILOT_MONTHLY_BUDGET_USD || '200' }}
           VAR_MONTH_SPEND_USED_USD: ${{ vars.AUTOPILOT_MONTH_SPEND_USED_USD || '0' }}
           VAR_MAX_NEW_ASSIGNMENTS: ${{ vars.AUTOPILOT_MAX_NEW_ASSIGNMENTS || '2' }}
@@ -55,7 +56,7 @@ jobs:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           REPOSITORY_NAME: ${{ github.event.repository.name }}
         run: |
-          DRY_RUN="${INPUT_DRY_RUN:-true}"
+          DRY_RUN="${INPUT_DRY_RUN:-$VAR_DRY_RUN}"
           MONTHLY_BUDGET_USD="${INPUT_MONTHLY_BUDGET_USD:-$VAR_MONTHLY_BUDGET_USD}"
           MONTH_SPEND_USED_USD="${INPUT_MONTH_SPEND_USED_USD:-$VAR_MONTH_SPEND_USED_USD}"
           MAX_NEW_ASSIGNMENTS="${INPUT_MAX_NEW_ASSIGNMENTS:-$VAR_MAX_NEW_ASSIGNMENTS}"

--- a/.github/workflows/backlog-autopilot.yml
+++ b/.github/workflows/backlog-autopilot.yml
@@ -1,0 +1,68 @@
+name: Backlog Autopilot
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run only (no assignments)"
+        required: false
+        default: "true"
+      monthly_budget_usd:
+        description: "Monthly budget for agent automation (USD)"
+        required: false
+        default: "200"
+      month_spend_used_usd:
+        description: "Month-to-date spend used for this automation (USD)"
+        required: false
+        default: "0"
+      max_new_assignments:
+        description: "Max new assignments per run"
+        required: false
+        default: "2"
+  schedule:
+    - cron: "15 */8 * * *"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  dispatch:
+    name: Budget-Paced Dispatch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Python
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
+        with:
+          python-version: "3.12"
+
+      - name: Run backlog autopilot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DRY_RUN="${{ github.event.inputs.dry_run || 'true' }}"
+          MONTHLY_BUDGET_USD="${{ github.event.inputs.monthly_budget_usd || vars.AUTOPILOT_MONTHLY_BUDGET_USD || '200' }}"
+          MONTH_SPEND_USED_USD="${{ github.event.inputs.month_spend_used_usd || vars.AUTOPILOT_MONTH_SPEND_USED_USD || '0' }}"
+          MAX_NEW_ASSIGNMENTS="${{ github.event.inputs.max_new_assignments || vars.AUTOPILOT_MAX_NEW_ASSIGNMENTS || '2' }}"
+          RESERVE_RATIO="${{ vars.AUTOPILOT_RESERVE_RATIO || '0.25' }}"
+          MAX_OPEN_AUTOPILOT_PRS="${{ vars.AUTOPILOT_MAX_OPEN_AUTOPILOT_PRS || '8' }}"
+
+          ARGS=(
+            --owner "${{ github.repository_owner }}"
+            --repo "${{ github.event.repository.name }}"
+            --monthly-budget-usd "$MONTHLY_BUDGET_USD"
+            --month-spend-used-usd "$MONTH_SPEND_USED_USD"
+            --reserve-ratio "$RESERVE_RATIO"
+            --max-new-assignments "$MAX_NEW_ASSIGNMENTS"
+            --max-open-autopilot-prs "$MAX_OPEN_AUTOPILOT_PRS"
+          )
+
+          if [ "$DRY_RUN" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+
+          python scripts/backlog_autopilot.py "${ARGS[@]}"

--- a/.github/workflows/backlog-autopilot.yml
+++ b/.github/workflows/backlog-autopilot.yml
@@ -43,17 +43,28 @@ jobs:
       - name: Run backlog autopilot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+          INPUT_MONTHLY_BUDGET_USD: ${{ github.event.inputs.monthly_budget_usd || '' }}
+          INPUT_MONTH_SPEND_USED_USD: ${{ github.event.inputs.month_spend_used_usd || '' }}
+          INPUT_MAX_NEW_ASSIGNMENTS: ${{ github.event.inputs.max_new_assignments || '' }}
+          VAR_MONTHLY_BUDGET_USD: ${{ vars.AUTOPILOT_MONTHLY_BUDGET_USD || '200' }}
+          VAR_MONTH_SPEND_USED_USD: ${{ vars.AUTOPILOT_MONTH_SPEND_USED_USD || '0' }}
+          VAR_MAX_NEW_ASSIGNMENTS: ${{ vars.AUTOPILOT_MAX_NEW_ASSIGNMENTS || '2' }}
+          VAR_RESERVE_RATIO: ${{ vars.AUTOPILOT_RESERVE_RATIO || '0.25' }}
+          VAR_MAX_OPEN_AUTOPILOT_PRS: ${{ vars.AUTOPILOT_MAX_OPEN_AUTOPILOT_PRS || '8' }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
         run: |
-          DRY_RUN="${{ github.event.inputs.dry_run || 'true' }}"
-          MONTHLY_BUDGET_USD="${{ github.event.inputs.monthly_budget_usd || vars.AUTOPILOT_MONTHLY_BUDGET_USD || '200' }}"
-          MONTH_SPEND_USED_USD="${{ github.event.inputs.month_spend_used_usd || vars.AUTOPILOT_MONTH_SPEND_USED_USD || '0' }}"
-          MAX_NEW_ASSIGNMENTS="${{ github.event.inputs.max_new_assignments || vars.AUTOPILOT_MAX_NEW_ASSIGNMENTS || '2' }}"
-          RESERVE_RATIO="${{ vars.AUTOPILOT_RESERVE_RATIO || '0.25' }}"
-          MAX_OPEN_AUTOPILOT_PRS="${{ vars.AUTOPILOT_MAX_OPEN_AUTOPILOT_PRS || '8' }}"
+          DRY_RUN="${INPUT_DRY_RUN:-true}"
+          MONTHLY_BUDGET_USD="${INPUT_MONTHLY_BUDGET_USD:-$VAR_MONTHLY_BUDGET_USD}"
+          MONTH_SPEND_USED_USD="${INPUT_MONTH_SPEND_USED_USD:-$VAR_MONTH_SPEND_USED_USD}"
+          MAX_NEW_ASSIGNMENTS="${INPUT_MAX_NEW_ASSIGNMENTS:-$VAR_MAX_NEW_ASSIGNMENTS}"
+          RESERVE_RATIO="$VAR_RESERVE_RATIO"
+          MAX_OPEN_AUTOPILOT_PRS="$VAR_MAX_OPEN_AUTOPILOT_PRS"
 
           ARGS=(
-            --owner "${{ github.repository_owner }}"
-            --repo "${{ github.event.repository.name }}"
+            --owner "$REPOSITORY_OWNER"
+            --repo "$REPOSITORY_NAME"
             --monthly-budget-usd "$MONTHLY_BUDGET_USD"
             --month-spend-used-usd "$MONTH_SPEND_USED_USD"
             --reserve-ratio "$RESERVE_RATIO"

--- a/.github/workflows/pr-watchdog.yml
+++ b/.github/workflows/pr-watchdog.yml
@@ -15,6 +15,7 @@ on:
     - cron: "45 */6 * * *"
 
 permissions:
+  checks: read
   contents: read
   pull-requests: read
   issues: write
@@ -35,13 +36,14 @@ jobs:
       - name: Run watchdog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+          INPUT_DRY_RUN: ${{ github.event.inputs.dry_run || '' }}
           INPUT_MAX_PRS: ${{ github.event.inputs.max_prs || '' }}
+          VAR_DRY_RUN: ${{ vars.AUTOPILOT_WATCHDOG_DRY_RUN || 'true' }}
           VAR_MAX_PRS: ${{ vars.AUTOPILOT_WATCHDOG_MAX_PRS || '20' }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           REPOSITORY_NAME: ${{ github.event.repository.name }}
         run: |
-          DRY_RUN="${INPUT_DRY_RUN:-true}"
+          DRY_RUN="${INPUT_DRY_RUN:-$VAR_DRY_RUN}"
           MAX_PRS="${INPUT_MAX_PRS:-$VAR_MAX_PRS}"
 
           ARGS=(

--- a/.github/workflows/pr-watchdog.yml
+++ b/.github/workflows/pr-watchdog.yml
@@ -35,13 +35,18 @@ jobs:
       - name: Run watchdog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+          INPUT_MAX_PRS: ${{ github.event.inputs.max_prs || '' }}
+          VAR_MAX_PRS: ${{ vars.AUTOPILOT_WATCHDOG_MAX_PRS || '20' }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
         run: |
-          DRY_RUN="${{ github.event.inputs.dry_run || 'true' }}"
-          MAX_PRS="${{ github.event.inputs.max_prs || vars.AUTOPILOT_WATCHDOG_MAX_PRS || '20' }}"
+          DRY_RUN="${INPUT_DRY_RUN:-true}"
+          MAX_PRS="${INPUT_MAX_PRS:-$VAR_MAX_PRS}"
 
           ARGS=(
-            --owner "${{ github.repository_owner }}"
-            --repo "${{ github.event.repository.name }}"
+            --owner "$REPOSITORY_OWNER"
+            --repo "$REPOSITORY_NAME"
             --max-prs "$MAX_PRS"
           )
 

--- a/.github/workflows/pr-watchdog.yml
+++ b/.github/workflows/pr-watchdog.yml
@@ -1,0 +1,52 @@
+name: PR Watchdog
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run only (no PR comment updates)"
+        required: false
+        default: "true"
+      max_prs:
+        description: "Maximum open autopilot PRs to scan"
+        required: false
+        default: "20"
+  schedule:
+    - cron: "45 */6 * * *"
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  watchdog:
+    name: Track PR Blockers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Python
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
+        with:
+          python-version: "3.12"
+
+      - name: Run watchdog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DRY_RUN="${{ github.event.inputs.dry_run || 'true' }}"
+          MAX_PRS="${{ github.event.inputs.max_prs || vars.AUTOPILOT_WATCHDOG_MAX_PRS || '20' }}"
+
+          ARGS=(
+            --owner "${{ github.repository_owner }}"
+            --repo "${{ github.event.repository.name }}"
+            --max-prs "$MAX_PRS"
+          )
+
+          if [ "$DRY_RUN" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+
+          python scripts/pr_watchdog.py "${ARGS[@]}"

--- a/scripts/backlog_autopilot.py
+++ b/scripts/backlog_autopilot.py
@@ -62,10 +62,11 @@ def compute_budget_status(
     automation_budget = monthly_budget_usd * max(0.0, 1.0 - reserve_ratio)
     month_days = _days_in_month(today)
     allowed_today = automation_budget * (today.day / month_days)
+    allowed_today_rounded = round(allowed_today, 2)
     return BudgetStatus(
-        allowed_today=round(allowed_today, 2),
+        allowed_today=allowed_today_rounded,
         spent=month_spend_used_usd,
-        can_spend=month_spend_used_usd < allowed_today,
+        can_spend=month_spend_used_usd < allowed_today_rounded,
     )
 
 

--- a/scripts/backlog_autopilot.py
+++ b/scripts/backlog_autopilot.py
@@ -1,0 +1,303 @@
+"""Budget-paced GitHub issue autopilot dispatcher.
+
+This script selects a bounded number of open issues and (optionally) assigns
+Copilot to them, while respecting pacing and quality guardrails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from typing import Any
+from urllib import error, request
+
+
+@dataclass(frozen=True)
+class BudgetStatus:
+    allowed_today: float
+    spent: float
+    can_spend: bool
+
+
+@dataclass(frozen=True)
+class IssueCandidate:
+    number: int
+    title: str
+    labels: set[str]
+    assignees: set[str]
+    url: str
+
+
+@dataclass(frozen=True)
+class Config:
+    owner: str
+    repo: str
+    token: str
+    dry_run: bool
+    monthly_budget_usd: float
+    month_spend_used_usd: float
+    reserve_ratio: float
+    max_new_assignments: int
+    max_open_autopilot_prs: int
+
+
+def _days_in_month(today: date) -> int:
+    if today.month == 12:
+        next_month = date(today.year + 1, 1, 1)
+    else:
+        next_month = date(today.year, today.month + 1, 1)
+    return (next_month - date(today.year, today.month, 1)).days
+
+
+def compute_budget_status(
+    *,
+    today: date,
+    monthly_budget_usd: float,
+    month_spend_used_usd: float,
+    reserve_ratio: float,
+) -> BudgetStatus:
+    automation_budget = monthly_budget_usd * max(0.0, 1.0 - reserve_ratio)
+    month_days = _days_in_month(today)
+    allowed_today = automation_budget * (today.day / month_days)
+    return BudgetStatus(
+        allowed_today=round(allowed_today, 2),
+        spent=month_spend_used_usd,
+        can_spend=month_spend_used_usd < allowed_today,
+    )
+
+
+def issue_priority_score(labels: set[str]) -> int:
+    score = 0
+    if "security" in labels:
+        score += 1000
+    if "priority:now" in labels:
+        score += 600
+    if "priority:next" in labels:
+        score += 400
+    if "discovered" in labels:
+        score += 250
+    if "priority:backlog" in labels:
+        score += 100
+    return score
+
+
+def select_issues(
+    issues: list[IssueCandidate],
+    *,
+    max_new_assignments: int,
+) -> list[IssueCandidate]:
+    eligible = [
+        issue for issue in issues if issue_priority_score(issue.labels) > 0 and not issue.assignees
+    ]
+    ordered = sorted(
+        eligible,
+        key=lambda issue: (issue_priority_score(issue.labels), issue.number),
+        reverse=True,
+    )
+    return ordered[:max_new_assignments]
+
+
+def _github_api(
+    *,
+    token: str,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None = None,
+) -> Any:
+    url = f"https://api.github.com{path}"
+    payload = None
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if body is not None:
+        payload = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    req = request.Request(url=url, data=payload, method=method, headers=headers)
+    try:
+        with request.urlopen(req, timeout=30) as resp:
+            data = resp.read()
+            return json.loads(data.decode("utf-8")) if data else None
+    except error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="ignore")
+        raise RuntimeError(f"GitHub API error {exc.code} on {method} {path}: {detail}") from exc
+
+
+def _fetch_paginated(token: str, path: str) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        separator = "&" if "?" in path else "?"
+        page_path = f"{path}{separator}per_page=100&page={page}"
+        batch = _github_api(token=token, method="GET", path=page_path)
+        if not isinstance(batch, list) or not batch:
+            break
+        results.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return results
+
+
+def load_open_issues(*, token: str, owner: str, repo: str) -> list[IssueCandidate]:
+    raw_issues = _fetch_paginated(token, f"/repos/{owner}/{repo}/issues?state=open")
+    out: list[IssueCandidate] = []
+    for issue in raw_issues:
+        # GitHub issues endpoint includes pull requests.
+        if "pull_request" in issue:
+            continue
+        labels = {
+            label.get("name", "") for label in issue.get("labels", []) if isinstance(label, dict)
+        }
+        assignees = {
+            assignee.get("login", "")
+            for assignee in issue.get("assignees", [])
+            if isinstance(assignee, dict)
+        }
+        out.append(
+            IssueCandidate(
+                number=int(issue["number"]),
+                title=str(issue.get("title", "")),
+                labels=labels,
+                assignees=assignees,
+                url=str(issue.get("html_url", "")),
+            )
+        )
+    return out
+
+
+def count_open_copilot_prs(*, token: str, owner: str, repo: str) -> int:
+    pulls = _fetch_paginated(token, f"/repos/{owner}/{repo}/pulls?state=open")
+    count = 0
+    for pr in pulls:
+        user = pr.get("user")
+        login = user.get("login", "") if isinstance(user, dict) else ""
+        title = str(pr.get("title", ""))
+        if login == "Copilot" or title.startswith("[WIP]"):
+            count += 1
+    return count
+
+
+def assign_issue_to_copilot(*, token: str, owner: str, repo: str, issue_number: int) -> None:
+    _github_api(
+        token=token,
+        method="POST",
+        path=f"/repos/{owner}/{repo}/issues/{issue_number}/assignees",
+        body={"assignees": ["Copilot"]},
+    )
+
+
+def post_issue_comment(
+    *,
+    token: str,
+    owner: str,
+    repo: str,
+    issue_number: int,
+    body: str,
+) -> None:
+    _github_api(
+        token=token,
+        method="POST",
+        path=f"/repos/{owner}/{repo}/issues/{issue_number}/comments",
+        body={"body": body},
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--owner", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--monthly-budget-usd", type=float, required=True)
+    parser.add_argument("--month-spend-used-usd", type=float, required=True)
+    parser.add_argument("--reserve-ratio", type=float, default=0.25)
+    parser.add_argument("--max-new-assignments", type=int, default=2)
+    parser.add_argument("--max-open-autopilot-prs", type=int, default=8)
+    parser.add_argument("--today", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    token = os.getenv("GITHUB_TOKEN", "").strip()
+    if not token:
+        raise ValueError("GITHUB_TOKEN is required")
+
+    today = date.fromisoformat(args.today) if args.today else datetime.now(UTC).date()
+    cfg = Config(
+        owner=args.owner,
+        repo=args.repo,
+        token=token,
+        dry_run=bool(args.dry_run),
+        monthly_budget_usd=float(args.monthly_budget_usd),
+        month_spend_used_usd=float(args.month_spend_used_usd),
+        reserve_ratio=float(args.reserve_ratio),
+        max_new_assignments=int(args.max_new_assignments),
+        max_open_autopilot_prs=int(args.max_open_autopilot_prs),
+    )
+
+    budget = compute_budget_status(
+        today=today,
+        monthly_budget_usd=cfg.monthly_budget_usd,
+        month_spend_used_usd=cfg.month_spend_used_usd,
+        reserve_ratio=cfg.reserve_ratio,
+    )
+    if not budget.can_spend:
+        print(
+            f"budget_throttle: spent={budget.spent:.2f} allowed_today={budget.allowed_today:.2f}; "
+            "no new assignments"
+        )
+        return 0
+
+    open_autopilot_prs = count_open_copilot_prs(token=cfg.token, owner=cfg.owner, repo=cfg.repo)
+    if open_autopilot_prs >= cfg.max_open_autopilot_prs:
+        print(
+            f"queue_throttle: open_autopilot_prs={open_autopilot_prs} "
+            f">= max_open_autopilot_prs={cfg.max_open_autopilot_prs}; no new assignments"
+        )
+        return 0
+
+    issues = load_open_issues(token=cfg.token, owner=cfg.owner, repo=cfg.repo)
+    targets = select_issues(issues, max_new_assignments=cfg.max_new_assignments)
+
+    if not targets:
+        print("no eligible issues found")
+        return 0
+
+    print("selected issues:")
+    for target in targets:
+        print(f"- #{target.number} {target.title} ({target.url})")
+
+    if cfg.dry_run:
+        print("dry-run enabled; no assignment actions were performed")
+        return 0
+
+    for target in targets:
+        assign_issue_to_copilot(
+            token=cfg.token,
+            owner=cfg.owner,
+            repo=cfg.repo,
+            issue_number=target.number,
+        )
+        post_issue_comment(
+            token=cfg.token,
+            owner=cfg.owner,
+            repo=cfg.repo,
+            issue_number=target.number,
+            body=(
+                "Autopilot dispatcher assigned Copilot under monthly pacing policy "
+                f"(budget spent {budget.spent:.2f} / allowed today {budget.allowed_today:.2f})."
+            ),
+        )
+
+    print(f"assigned {len(targets)} issue(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pr_watchdog.py
+++ b/scripts/pr_watchdog.py
@@ -1,0 +1,377 @@
+"""PR watchdog that tracks blockers and opinion-needed items on active autopilot PRs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass
+from typing import Any
+from urllib import error, request
+
+CHECK_FAILURE_CONCLUSIONS = {
+    "failure",
+    "timed_out",
+    "cancelled",
+    "action_required",
+    "startup_failure",
+    "stale",
+}
+
+COMMENT_MARKER = "<!-- pr-watchdog -->"
+
+
+@dataclass(frozen=True)
+class ReviewThread:
+    author: str
+    path: str
+    url: str
+    body: str
+
+
+@dataclass(frozen=True)
+class PRSummary:
+    number: int
+    url: str
+    title: str
+    failing_checks: tuple[str, ...]
+    pending_checks: tuple[str, ...]
+    unresolved_threads: tuple[ReviewThread, ...]
+
+    @property
+    def has_blockers(self) -> bool:
+        return bool(self.failing_checks or self.unresolved_threads)
+
+
+def _github_rest(
+    *,
+    token: str,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None = None,
+) -> Any:
+    url = f"https://api.github.com{path}"
+    payload = None
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if body is not None:
+        payload = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    req = request.Request(url=url, data=payload, method=method, headers=headers)
+    try:
+        with request.urlopen(req, timeout=30) as resp:
+            data = resp.read()
+            return json.loads(data.decode("utf-8")) if data else None
+    except error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="ignore")
+        raise RuntimeError(f"GitHub REST error {exc.code} on {method} {path}: {detail}") from exc
+
+
+def _github_graphql(*, token: str, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+    payload = {"query": query, "variables": variables}
+    result = _github_rest(token=token, method="POST", path="/graphql", body=payload)
+    if not isinstance(result, dict):
+        raise RuntimeError("GraphQL returned non-object response")
+    if result.get("errors"):
+        raise RuntimeError(f"GraphQL errors: {result['errors']}")
+    return result
+
+
+def _fetch_paginated(token: str, path: str) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        separator = "&" if "?" in path else "?"
+        page_path = f"{path}{separator}per_page=100&page={page}"
+        batch = _github_rest(token=token, method="GET", path=page_path)
+        if not isinstance(batch, list) or not batch:
+            break
+        results.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return results
+
+
+def list_active_autopilot_prs(
+    *, token: str, owner: str, repo: str, max_prs: int
+) -> list[dict[str, Any]]:
+    pulls = _fetch_paginated(token, f"/repos/{owner}/{repo}/pulls?state=open")
+    active: list[dict[str, Any]] = []
+    for pr in pulls:
+        title = str(pr.get("title", ""))
+        user = pr.get("user")
+        login = user.get("login", "") if isinstance(user, dict) else ""
+        if login == "Copilot" or title.startswith("[WIP]"):
+            active.append(pr)
+        if len(active) >= max_prs:
+            break
+    return active
+
+
+def collect_check_status(
+    *,
+    token: str,
+    owner: str,
+    repo: str,
+    head_sha: str,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    data = _github_rest(
+        token=token,
+        method="GET",
+        path=f"/repos/{owner}/{repo}/commits/{head_sha}/check-runs?per_page=100",
+    )
+    checks = data.get("check_runs", []) if isinstance(data, dict) else []
+
+    failing: list[str] = []
+    pending: list[str] = []
+    for check in checks:
+        if not isinstance(check, dict):
+            continue
+        name = str(check.get("name", "unknown"))
+        status = str(check.get("status", ""))
+        conclusion = str(check.get("conclusion", ""))
+        if status != "completed":
+            pending.append(name)
+            continue
+        if conclusion in CHECK_FAILURE_CONCLUSIONS:
+            failing.append(name)
+
+    return tuple(sorted(set(failing))), tuple(sorted(set(pending)))
+
+
+def collect_unresolved_threads(
+    *,
+    token: str,
+    owner: str,
+    repo: str,
+    pr_number: int,
+) -> tuple[ReviewThread, ...]:
+    query = """
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100) {
+            nodes {
+              isResolved
+              comments(first: 1) {
+                nodes {
+                  body
+                  path
+                  url
+                  author { login }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    result = _github_graphql(
+        token=token,
+        query=query,
+        variables={"owner": owner, "repo": repo, "number": pr_number},
+    )
+    repo_data = (result.get("data") or {}).get("repository") or {}
+    pr_data = repo_data.get("pullRequest") or {}
+    nodes = (pr_data.get("reviewThreads") or {}).get("nodes") or []
+
+    unresolved: list[ReviewThread] = []
+    for node in nodes:
+        if not isinstance(node, dict) or node.get("isResolved") is True:
+            continue
+        comments = (node.get("comments") or {}).get("nodes") or []
+        first = comments[0] if comments else {}
+        if not isinstance(first, dict):
+            continue
+        unresolved.append(
+            ReviewThread(
+                author=str((first.get("author") or {}).get("login", "unknown")),
+                path=str(first.get("path") or ""),
+                url=str(first.get("url") or ""),
+                body=str(first.get("body") or ""),
+            )
+        )
+
+    return tuple(unresolved)
+
+
+def render_comment(summary: PRSummary) -> str:
+    lines = [
+        COMMENT_MARKER,
+        "## PR Watchdog",
+        "",
+        f"PR: #{summary.number} — {summary.title}",
+        f"Link: {summary.url}",
+        "",
+        "### Blockers",
+    ]
+    if summary.failing_checks:
+        lines.append("- Failing checks:")
+        for check in summary.failing_checks:
+            lines.append(f"  - {check}")
+    else:
+        lines.append("- Failing checks: none")
+
+    if summary.unresolved_threads:
+        lines.append("- Unresolved review threads:")
+        for thread in summary.unresolved_threads:
+            lines.append(f"  - {thread.author} on {thread.path or 'unknown path'}: {thread.url}")
+    else:
+        lines.append("- Unresolved review threads: none")
+
+    lines.append("")
+    lines.append("### Needs Opinion")
+    if summary.unresolved_threads:
+        lines.append(
+            "- Yes. There are unresolved review threads requiring maintainer judgment or approval."
+        )
+    else:
+        lines.append("- No explicit opinion-needed threads currently open.")
+
+    lines.append("")
+    lines.append("### Check Progress")
+    if summary.pending_checks:
+        lines.append("- Pending checks:")
+        for check in summary.pending_checks:
+            lines.append(f"  - {check}")
+    else:
+        lines.append("- Pending checks: none")
+
+    lines.append("")
+    if summary.has_blockers:
+        lines.append("Status: BLOCKED")
+    elif summary.pending_checks:
+        lines.append("Status: WAITING_ON_CI")
+    else:
+        lines.append("Status: READY_FOR_MAINTAINER_REVIEW")
+
+    return "\n".join(lines)
+
+
+def _find_existing_watchdog_comment(
+    *,
+    token: str,
+    owner: str,
+    repo: str,
+    pr_number: int,
+) -> int | None:
+    comments = _fetch_paginated(
+        token, f"/repos/{owner}/{repo}/issues/{pr_number}/comments?sort=created"
+    )
+    for comment in comments:
+        if not isinstance(comment, dict):
+            continue
+        body = str(comment.get("body", ""))
+        if COMMENT_MARKER in body:
+            return int(comment["id"])
+    return None
+
+
+def upsert_watchdog_comment(
+    *,
+    token: str,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    body: str,
+) -> None:
+    existing_id = _find_existing_watchdog_comment(
+        token=token,
+        owner=owner,
+        repo=repo,
+        pr_number=pr_number,
+    )
+    if existing_id is None:
+        _github_rest(
+            token=token,
+            method="POST",
+            path=f"/repos/{owner}/{repo}/issues/{pr_number}/comments",
+            body={"body": body},
+        )
+        return
+
+    _github_rest(
+        token=token,
+        method="PATCH",
+        path=f"/repos/{owner}/{repo}/issues/comments/{existing_id}",
+        body={"body": body},
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--owner", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--max-prs", type=int, default=20)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    token = os.getenv("GITHUB_TOKEN", "").strip()
+    if not token:
+        raise ValueError("GITHUB_TOKEN is required")
+
+    pulls = list_active_autopilot_prs(
+        token=token,
+        owner=args.owner,
+        repo=args.repo,
+        max_prs=args.max_prs,
+    )
+    if not pulls:
+        print("no active autopilot PRs found")
+        return 0
+
+    for pr in pulls:
+        number = int(pr["number"])
+        head = pr.get("head") or {}
+        head_sha = str(head.get("sha", ""))
+        failing, pending = collect_check_status(
+            token=token,
+            owner=args.owner,
+            repo=args.repo,
+            head_sha=head_sha,
+        )
+        unresolved = collect_unresolved_threads(
+            token=token,
+            owner=args.owner,
+            repo=args.repo,
+            pr_number=number,
+        )
+        summary = PRSummary(
+            number=number,
+            url=str(pr.get("html_url", "")),
+            title=str(pr.get("title", "")),
+            failing_checks=failing,
+            pending_checks=pending,
+            unresolved_threads=unresolved,
+        )
+        comment = render_comment(summary)
+
+        print(
+            f"#{summary.number} blockers={summary.has_blockers} pending={len(summary.pending_checks)}"
+        )
+        if args.dry_run:
+            continue
+        upsert_watchdog_comment(
+            token=token,
+            owner=args.owner,
+            repo=args.repo,
+            pr_number=summary.number,
+            body=comment,
+        )
+
+    if args.dry_run:
+        print("dry-run enabled; no comments were created or updated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_backlog_autopilot.py
+++ b/tests/test_backlog_autopilot.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from datetime import date
+
+from scripts.backlog_autopilot import (
+    IssueCandidate,
+    compute_budget_status,
+    select_issues,
+)
+
+
+def _issue(number: int, labels: set[str], assignees: set[str] | None = None) -> IssueCandidate:
+    return IssueCandidate(
+        number=number,
+        title=f"Issue {number}",
+        labels=labels,
+        assignees=assignees or set(),
+        url=f"https://example.invalid/{number}",
+    )
+
+
+def test_budget_status_allows_when_spend_below_pacing_target() -> None:
+    status = compute_budget_status(
+        today=date(2026, 6, 15),
+        monthly_budget_usd=300.0,
+        month_spend_used_usd=50.0,
+        reserve_ratio=0.25,
+    )
+    assert status.allowed_today > 50.0
+    assert status.can_spend is True
+
+
+def test_budget_status_blocks_when_spend_above_pacing_target() -> None:
+    status = compute_budget_status(
+        today=date(2026, 6, 5),
+        monthly_budget_usd=300.0,
+        month_spend_used_usd=120.0,
+        reserve_ratio=0.25,
+    )
+    assert status.can_spend is False
+
+
+def test_select_issues_prioritizes_security_and_now() -> None:
+    issues = [
+        _issue(1, {"priority:next"}),
+        _issue(2, {"security"}),
+        _issue(3, {"priority:now"}),
+        _issue(4, {"discovered", "priority:backlog"}),
+    ]
+    selected = select_issues(issues, max_new_assignments=2)
+    assert [issue.number for issue in selected] == [2, 3]
+
+
+def test_select_issues_skips_assigned_issues() -> None:
+    issues = [
+        _issue(10, {"security"}, {"someone"}),
+        _issue(11, {"priority:now"}),
+    ]
+    selected = select_issues(issues, max_new_assignments=2)
+    assert [issue.number for issue in selected] == [11]

--- a/tests/test_pr_watchdog.py
+++ b/tests/test_pr_watchdog.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from scripts.pr_watchdog import PRSummary, ReviewThread, render_comment
+
+
+def test_render_comment_marks_blocked_when_failing_checks_present() -> None:
+    summary = PRSummary(
+        number=1,
+        url="https://example.invalid/pr/1",
+        title="Example",
+        failing_checks=("CI/Test",),
+        pending_checks=(),
+        unresolved_threads=(),
+    )
+    body = render_comment(summary)
+    assert "Status: BLOCKED" in body
+    assert "CI/Test" in body
+
+
+def test_render_comment_marks_needs_opinion_when_unresolved_threads_present() -> None:
+    summary = PRSummary(
+        number=2,
+        url="https://example.invalid/pr/2",
+        title="Example",
+        failing_checks=(),
+        pending_checks=(),
+        unresolved_threads=(
+            ReviewThread(
+                author="copilot-pull-request-reviewer",
+                path="treesight/security/quota.py",
+                url="https://example.invalid/thread/1",
+                body="Needs fix",
+            ),
+        ),
+    )
+    body = render_comment(summary)
+    assert "Needs Opinion" in body
+    assert "Yes." in body
+    assert "Status: BLOCKED" in body
+
+
+def test_render_comment_marks_ready_when_no_blockers_or_pending() -> None:
+    summary = PRSummary(
+        number=3,
+        url="https://example.invalid/pr/3",
+        title="Example",
+        failing_checks=(),
+        pending_checks=(),
+        unresolved_threads=(),
+    )
+    body = render_comment(summary)
+    assert "Status: READY_FOR_MAINTAINER_REVIEW" in body


### PR DESCRIPTION
## What
- Add budget-paced issue dispatcher script and workflow (dry-run by default)
- Add PR watchdog script and workflow to track blockers and opinion-needed items on active autopilot PRs
- Add focused tests for both scripts

## Why
- Keep backlog moving within monthly budget pacing
- Surface blockers and maintainer-opinion needs directly on the real PRs you oversee

## Validation
- ruff check scripts/backlog_autopilot.py scripts/pr_watchdog.py tests/test_backlog_autopilot.py tests/test_pr_watchdog.py
- pytest tests/test_backlog_autopilot.py tests/test_pr_watchdog.py
- Local dry-run against live repo data for both scripts