### PR TITLE
fix(autopilot): reliable Copilot assignment + watchdog write perms

### DIFF
--- a/.github/workflows/pr-watchdog.yml
+++ b/.github/workflows/pr-watchdog.yml
@@ -17,7 +17,7 @@ on:
 permissions:
   checks: read
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 jobs:

--- a/scripts/backlog_autopilot.py
+++ b/scripts/backlog_autopilot.py
@@ -17,6 +17,10 @@ from urllib import error, request
 COPILOT_ACTOR_ID = "BOT_kgDOC9w8XQ"
 
 
+def _copilot_actor_id() -> str:
+    return os.getenv("AUTOPILOT_COPILOT_ACTOR_ID", COPILOT_ACTOR_ID).strip() or COPILOT_ACTOR_ID
+
+
 @dataclass(frozen=True)
 class BudgetStatus:
     allowed_today: float
@@ -150,9 +154,10 @@ def _fetch_paginated(token: str, path: str) -> list[dict[str, Any]]:
 def _github_graphql(*, token: str, query: str, variables: dict[str, Any]) -> dict[str, Any]:
     payload = json.dumps({"query": query, "variables": variables}).encode("utf-8")
     headers = {
-        "Accept": "application/json",
+        "Accept": "application/vnd.github+json",
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
     }
     req = request.Request(
         url="https://api.github.com/graphql",
@@ -244,7 +249,9 @@ def assign_issue_to_copilot(*, token: str, owner: str, repo: str, issue_number: 
     assignees_obj = issue.get("assignees")
     nodes = assignees_obj.get("nodes", []) if isinstance(assignees_obj, dict) else []
     existing_actor_ids: list[str] = []
+    existing_actor_id_set: set[str] = set()
     existing_logins: set[str] = set()
+    copilot_actor_id = _copilot_actor_id()
     for node in nodes:
         if not isinstance(node, dict):
             continue
@@ -252,13 +259,14 @@ def assign_issue_to_copilot(*, token: str, owner: str, repo: str, issue_number: 
         login = node.get("login")
         if isinstance(actor_id, str) and actor_id:
             existing_actor_ids.append(actor_id)
+            existing_actor_id_set.add(actor_id)
         if isinstance(login, str) and login:
             existing_logins.add(login)
 
-    if "Copilot" in existing_logins:
+    if "Copilot" in existing_logins or copilot_actor_id in existing_actor_id_set:
         return
 
-    actor_ids = [*existing_actor_ids, COPILOT_ACTOR_ID]
+    actor_ids = list(dict.fromkeys([*existing_actor_ids, copilot_actor_id]))
     _github_graphql(
         token=token,
         query=(

--- a/scripts/backlog_autopilot.py
+++ b/scripts/backlog_autopilot.py
@@ -14,6 +14,8 @@ from datetime import UTC, date, datetime
 from typing import Any
 from urllib import error, request
 
+COPILOT_ACTOR_ID = "BOT_kgDOC9w8XQ"
+
 
 @dataclass(frozen=True)
 class BudgetStatus:
@@ -145,6 +147,37 @@ def _fetch_paginated(token: str, path: str) -> list[dict[str, Any]]:
     return results
 
 
+def _github_graphql(*, token: str, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+    payload = json.dumps({"query": query, "variables": variables}).encode("utf-8")
+    headers = {
+        "Accept": "application/json",
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    req = request.Request(
+        url="https://api.github.com/graphql",
+        data=payload,
+        method="POST",
+        headers=headers,
+    )
+    try:
+        with request.urlopen(req, timeout=30) as resp:
+            data = resp.read()
+            parsed = json.loads(data.decode("utf-8")) if data else {}
+    except error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="ignore")
+        raise RuntimeError(f"GitHub GraphQL error {exc.code}: {detail}") from exc
+
+    errors = parsed.get("errors")
+    if errors:
+        raise RuntimeError(f"GitHub GraphQL returned errors: {errors}")
+
+    result = parsed.get("data")
+    if not isinstance(result, dict):
+        raise RuntimeError("GitHub GraphQL response missing 'data' object")
+    return result
+
+
 def load_open_issues(*, token: str, owner: str, repo: str) -> list[IssueCandidate]:
     raw_issues = _fetch_paginated(token, f"/repos/{owner}/{repo}/issues?state=open")
     out: list[IssueCandidate] = []
@@ -185,11 +218,55 @@ def count_open_copilot_prs(*, token: str, owner: str, repo: str) -> int:
 
 
 def assign_issue_to_copilot(*, token: str, owner: str, repo: str, issue_number: int) -> None:
-    _github_api(
+    issue_data = _github_graphql(
         token=token,
-        method="POST",
-        path=f"/repos/{owner}/{repo}/issues/{issue_number}/assignees",
-        body={"assignees": ["Copilot"]},
+        query=(
+            "query AssignableIssue($owner: String!, $repo: String!, $number: Int!) {"
+            " repository(owner: $owner, name: $repo) {"
+            "   issue(number: $number) {"
+            "     id"
+            "     assignees(first: 100) { nodes { id login } }"
+            "   }"
+            " }"
+            "}"
+        ),
+        variables={"owner": owner, "repo": repo, "number": issue_number},
+    )
+    repository = issue_data.get("repository")
+    issue = repository.get("issue") if isinstance(repository, dict) else None
+    if not isinstance(issue, dict):
+        raise RuntimeError(f"Issue #{issue_number} not found for {owner}/{repo}")
+
+    assignable_id = issue.get("id")
+    if not isinstance(assignable_id, str) or not assignable_id:
+        raise RuntimeError(f"Issue #{issue_number} missing assignable id")
+
+    assignees_obj = issue.get("assignees")
+    nodes = assignees_obj.get("nodes", []) if isinstance(assignees_obj, dict) else []
+    existing_actor_ids: list[str] = []
+    existing_logins: set[str] = set()
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        actor_id = node.get("id")
+        login = node.get("login")
+        if isinstance(actor_id, str) and actor_id:
+            existing_actor_ids.append(actor_id)
+        if isinstance(login, str) and login:
+            existing_logins.add(login)
+
+    if "Copilot" in existing_logins:
+        return
+
+    actor_ids = [*existing_actor_ids, COPILOT_ACTOR_ID]
+    _github_graphql(
+        token=token,
+        query=(
+            "mutation ReplaceActorsForAssignable($input: ReplaceActorsForAssignableInput!) {"
+            "  replaceActorsForAssignable(input: $input) { __typename }"
+            "}"
+        ),
+        variables={"input": {"assignableId": assignable_id, "actorIds": actor_ids}},
     )
 
 

--- a/tests/test_backlog_autopilot.py
+++ b/tests/test_backlog_autopilot.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from datetime import date
 
 from scripts.backlog_autopilot import (
+    COPILOT_ACTOR_ID,
     IssueCandidate,
+    assign_issue_to_copilot,
     compute_budget_status,
     select_issues,
 )
@@ -58,3 +60,52 @@ def test_select_issues_skips_assigned_issues() -> None:
     ]
     selected = select_issues(issues, max_new_assignments=2)
     assert [issue.number for issue in selected] == [11]
+
+
+def test_assign_issue_to_copilot_adds_actor_id(monkeypatch) -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_graphql(*, token: str, query: str, variables: dict[str, object]) -> dict[str, object]:
+        calls.append((query, variables))
+        if "query AssignableIssue" in query:
+            return {
+                "repository": {
+                    "issue": {
+                        "id": "I_123",
+                        "assignees": {"nodes": [{"id": "U_1", "login": "Hardcoreprawn"}]},
+                    }
+                }
+            }
+        return {"replaceActorsForAssignable": {"__typename": "ReplaceActorsForAssignablePayload"}}
+
+    monkeypatch.setattr("scripts.backlog_autopilot._github_graphql", fake_graphql)
+
+    assign_issue_to_copilot(token="t", owner="o", repo="r", issue_number=850)
+
+    assert len(calls) == 2
+    mutation_variables = calls[1][1]
+    assert mutation_variables["input"] == {
+        "assignableId": "I_123",
+        "actorIds": ["U_1", COPILOT_ACTOR_ID],
+    }
+
+
+def test_assign_issue_to_copilot_noop_when_already_assigned(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def fake_graphql(*, token: str, query: str, variables: dict[str, object]) -> dict[str, object]:
+        calls.append(query)
+        return {
+            "repository": {
+                "issue": {
+                    "id": "I_123",
+                    "assignees": {"nodes": [{"id": COPILOT_ACTOR_ID, "login": "Copilot"}]},
+                }
+            }
+        }
+
+    monkeypatch.setattr("scripts.backlog_autopilot._github_graphql", fake_graphql)
+
+    assign_issue_to_copilot(token="t", owner="o", repo="r", issue_number=850)
+
+    assert len(calls) == 1


### PR DESCRIPTION
## What
- Replace REST assignee call in `scripts/backlog_autopilot.py` with GraphQL `replaceActorsForAssignable` flow that mirrors `gh issue edit --add-assignee @copilot` behavior
- Preserve existing assignees and add Copilot actor id (`BOT_kgDOC9w8XQ`)
- Add tests for GraphQL assignment flow and no-op when Copilot is already assigned
- Update `.github/workflows/pr-watchdog.yml` permissions to `pull-requests: write` so watchdog can post PR comments

## Validation
- `ruff check scripts/backlog_autopilot.py tests/test_backlog_autopilot.py`
- `pytest -q tests/test_backlog_autopilot.py`
- Live run: fixed script assigned issue #804 with Copilot assignee present
- Live run: watchdog failure reproduced as 403 before permission fix

closes #912